### PR TITLE
Rename repo to nanoclaw-docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,10 @@
-# Mintlify Starter Kit
+# NanoClaw Docs
 
-Use the starter kit to get your docs deployed and ready to customize.
-
-Click the green **Use this template** button at the top of this repo to copy the Mintlify starter kit. The starter kit contains examples with
-
-- Guide pages
-- Navigation
-- Customizations
-- API reference pages
-- Use of popular components
-
-**[Follow the full quickstart guide](https://starter.mintlify.com/quickstart)**
-
-## AI-assisted writing
-
-Set up your AI coding tool to work with Mintlify:
-
-```bash
-npx skills add https://mintlify.com/docs
-```
-
-This command installs Mintlify's documentation skill for your configured AI tools like Claude Code, Cursor, Windsurf, and others. The skill includes component reference, writing standards, and workflow guidance.
-
-See the [AI tools guides](/ai-tools) for tool-specific setup.
+Documentation for [NanoClaw](https://github.com/qwibitai/nanoclaw), built with [Mintlify](https://mintlify.com).
 
 ## Development
 
-Install the [Mintlify CLI](https://www.npmjs.com/package/mint) to preview your documentation changes locally. To install, use the following command:
+Install the [Mintlify CLI](https://www.npmjs.com/package/mint) to preview documentation changes locally:
 
 ```
 npm i -g mint
@@ -40,16 +18,22 @@ mint dev
 
 View your local preview at `http://localhost:3000`.
 
+## AI-assisted writing
+
+Set up your AI coding tool to work with Mintlify:
+
+```bash
+npx skills add https://mintlify.com/docs
+```
+
+This command installs Mintlify's documentation skill for your configured AI tools like Claude Code, Cursor, Windsurf, and others.
+
 ## Publishing changes
 
-Install our GitHub app from your [dashboard](https://dashboard.mintlify.com/settings/organization/github-app) to propagate changes from your repo to your deployment. Changes are deployed to production automatically after pushing to the default branch.
+Install the GitHub app from your [dashboard](https://dashboard.mintlify.com/settings/organization/github-app) to propagate changes from your repo to your deployment. Changes are deployed to production automatically after pushing to the default branch.
 
-## Need help?
-
-### Troubleshooting
+## Troubleshooting
 
 - If your dev environment isn't running: Run `mint update` to ensure you have the most recent version of the CLI.
 - If a page loads as a 404: Make sure you are running in a folder with a valid `docs.json`.
-
-### Resources
 - [Mintlify documentation](https://mintlify.com/docs)


### PR DESCRIPTION
Update README to reflect NanoClaw project identity instead of generic Mintlify starter kit template. Update git remote URL.

https://claude.ai/code/session_01Y1mLETiUogSH5tQkFvX1c5