### PR TITLE
Fix navigation: rename duplicate titles and reorder pages logically

### DIFF
--- a/advanced/security-model.mdx
+++ b/advanced/security-model.mdx
@@ -1,5 +1,5 @@
 ---
-title: Security model
+title: Security deep dive
 description: Deep dive into NanoClaw's security architecture and trust boundaries
 ---
 

--- a/concepts/security.mdx
+++ b/concepts/security.mdx
@@ -1,5 +1,5 @@
 ---
-title: Security model
+title: Security overview
 description: Understanding NanoClaw's security boundaries and trust model
 ---
 

--- a/concepts/tasks.mdx
+++ b/concepts/tasks.mdx
@@ -1,5 +1,5 @@
 ---
-title: Scheduled tasks
+title: Task scheduling concepts
 description: How NanoClaw's task scheduler works and how tasks are executed
 ---
 

--- a/docs.json
+++ b/docs.json
@@ -36,9 +36,9 @@
             "pages": [
               "concepts/architecture",
               "concepts/security",
+              "concepts/containers",
               "concepts/groups",
-              "concepts/tasks",
-              "concepts/containers"
+              "concepts/tasks"
             ]
           },
           {
@@ -67,9 +67,9 @@
             "group": "Advanced",
             "pages": [
               "advanced/security-model",
-              "advanced/ipc-system",
               "advanced/container-runtime",
               "advanced/docker-sandboxes",
+              "advanced/ipc-system",
               "advanced/remote-control",
               "advanced/troubleshooting",
               "advanced/contributing"

--- a/features/scheduled-tasks.mdx
+++ b/features/scheduled-tasks.mdx
@@ -1,5 +1,5 @@
 ---
-title: Scheduled tasks
+title: Setting up scheduled tasks
 description: Set up recurring and one-time tasks with cron expressions, intervals, or specific timestamps
 ---
 


### PR DESCRIPTION
## Summary
- Rename duplicate page titles to avoid navigation confusion: "Security model" becomes "Security overview" (concepts) and "Security deep dive" (advanced); "Scheduled tasks" becomes "Task scheduling concepts" (concepts) and "Setting up scheduled tasks" (features)
- Reorder concepts group to place `containers` before `groups` and `tasks`, reflecting its foundational role
- Regroup advanced topics to cluster security and container pages together

## Test plan
- [ ] Verify the Mintlify docs site builds without errors
- [ ] Confirm sidebar navigation displays the updated titles correctly
- [ ] Check that all page links resolve properly (no broken references)