### PR TITLE
Fix outdated WhatsApp-as-default references

### DIFF
--- a/advanced/contributing.mdx
+++ b/advanced/contributing.mdx
@@ -111,7 +111,7 @@ Skills should be self-contained directories under `.claude/skills/{skill-name}/`
     ## Design decisions
     
     - Use polling instead of webhooks for simplicity
-    - Store Telegram credentials in the same `.env` file as WhatsApp
+    - Store Telegram credentials in the `.env` file
     - Reuse the existing message queue system
     ```
   </Step>

--- a/advanced/docker-sandboxes.mdx
+++ b/advanced/docker-sandboxes.mdx
@@ -28,7 +28,7 @@ graph TB
 
 - **Docker Desktop v4.40+** with sandbox capabilities enabled
 - **Anthropic API key**
-- **Platform credentials** for your messaging channels (Telegram bot token, WhatsApp-enabled phone number, etc.)
+- **Platform credentials** for your messaging channels (e.g., Telegram bot token, WhatsApp phone number, Discord bot token, Slack app token)
 
 ## Setup
 

--- a/advanced/ipc-system.mdx
+++ b/advanced/ipc-system.mdx
@@ -16,7 +16,7 @@ The IPC system is built on three core components:
 ```
 data/ipc/
 ├── main/                    # Main group IPC namespace
-│   ├── messages/            # Outbound messages to WhatsApp
+│   ├── messages/            # Outbound messages to channels
 │   ├── tasks/               # Task management operations
 │   └── input/               # Inbound messages from host
 ├── family-chat/             # Non-main group namespace
@@ -79,6 +79,10 @@ export function startIpcWatcher(deps: IpcDeps): void {
       "text": "Hello from the agent!"
     }
     ```
+
+    <Note>
+    The `chatJid` format varies by channel: `1234567890@s.whatsapp.net` for WhatsApp, `tg:12345` for Telegram, `discord:12345` for Discord, etc.
+    </Note>
   </Step>
   
   <Step title="Host polls IPC directory">
@@ -119,7 +123,7 @@ export function startIpcWatcher(deps: IpcDeps): void {
 
 ### Send message
 
-Allows agents to send messages to WhatsApp chats.
+Allows agents to send messages to chats.
 
 **File location:** `data/ipc/{group}/messages/message-{timestamp}.json`
 
@@ -215,7 +219,7 @@ Deletes a task permanently.
 
 ### Refresh groups
 
-Forces a refresh of WhatsApp group metadata. **Main group only.**
+Forces a refresh of group metadata. **Main group only.**
 
 **Format:**
 ```json
@@ -246,7 +250,7 @@ case 'refresh_groups':
 
 ### Register group
 
-Registers a new WhatsApp group for agent access. **Main group only.**
+Registers a new group for agent access. **Main group only.**
 
 **Format:**
 ```json

--- a/advanced/security-model.mdx
+++ b/advanced/security-model.mdx
@@ -14,7 +14,7 @@ NanoClaw operates with different trust levels for different entities:
 | Main group | Trusted | Private self-chat, admin control |
 | Non-main groups | Untrusted | Other users may be malicious |
 | Container agents | Sandboxed | Isolated execution environment |
-| WhatsApp messages | User input | Potential prompt injection |
+| Incoming messages | User input | Potential prompt injection |
 
 ## Security boundaries
 
@@ -142,7 +142,7 @@ if (
 - Claude auth tokens (filtered from `.env`, read-only)
 
 **NOT mounted:**
-- WhatsApp session (`store/auth/`) - host only
+- Channel sessions (e.g., `store/auth/` for WhatsApp) - host only
 - Mount allowlist - external, never mounted
 - Any credentials matching blocked patterns
 
@@ -176,7 +176,7 @@ Anthropic credentials are mounted so that Claude Code can authenticate when the 
 ```
 ┌──────────────────────────────────────────────────────────────────┐
 │                        UNTRUSTED ZONE                             │
-│  WhatsApp Messages (potentially malicious)                        │
+│  Incoming Messages (potentially malicious)                         │
 └────────────────────────────────┬─────────────────────────────────┘
                                  │
                                  ▼ Trigger check, input escaping

--- a/advanced/troubleshooting.mdx
+++ b/advanced/troubleshooting.mdx
@@ -23,8 +23,8 @@ docker ps -a --format '{{.Names}} {{.Status}}' 2>/dev/null | grep nanoclaw
 # 4. Recent errors in service log?
 grep -E 'ERROR|WARN' logs/nanoclaw.log | tail -20
 
-# 5. Is WhatsApp connected? (look for last connection event)
-grep -E 'Connected to WhatsApp|Connection closed|connection.*close' logs/nanoclaw.log | tail -5
+# 5. Are channels connected? (look for last connection event)
+grep -E 'Connected|Connection closed|connection.*close' logs/nanoclaw.log | tail -5
 
 # 6. Are groups loaded?
 grep 'groupCount' logs/nanoclaw.log | tail -3
@@ -43,7 +43,7 @@ Messages sent to the agent receive no response.
     grep 'New messages' logs/nanoclaw.log | tail -10
     ```
     
-    If no messages appear, the issue is with WhatsApp connectivity.
+    If no messages appear, the issue is with channel connectivity.
   </Step>
   
   <Step title="Check if containers are being spawned">
@@ -305,7 +305,7 @@ sqlite3 store/messages.db "SELECT name, container_config FROM registered_groups;
 ## IPC issues
 
 ### Symptoms
-- Messages sent via IPC don't appear in WhatsApp
+- Messages sent via IPC don't appear in the chat
 - Tasks don't get scheduled
 - IPC files accumulate in `data/ipc/{group}/`
 

--- a/api/configuration.mdx
+++ b/api/configuration.mdx
@@ -14,7 +14,7 @@ Configuration is read from `.env` file or `process.env`.
 </ParamField>
 
 <ParamField path="ASSISTANT_HAS_OWN_NUMBER" type="boolean" default="false">
-  Whether the assistant has its own WhatsApp number. Set to `"true"` to enable.
+  Whether the assistant has its own phone number or dedicated account. Set to `"true"` to enable.
 </ParamField>
 
 <ParamField path="CONTAINER_IMAGE" type="string" default="nanoclaw-agent:latest">

--- a/api/overview.mdx
+++ b/api/overview.mdx
@@ -3,7 +3,7 @@ title: API overview
 description: Core API reference for NanoClaw architecture and data flow
 ---
 
-NanoClaw is a single Node.js process that connects to messaging channels (WhatsApp, etc.) and routes messages to Claude Agent SDK instances running in isolated containers. Each group has its own filesystem and memory.
+NanoClaw is a single Node.js process that connects to messaging channels (WhatsApp, Telegram, Discord, Slack, Gmail) and routes messages to Claude Agent SDK instances running in isolated containers. Each group has its own filesystem and memory.
 
 ## Architecture
 
@@ -14,7 +14,7 @@ NanoClaw is a single Node.js process that connects to messaging channels (WhatsA
 - **Container Runner** (`src/container-runner.ts`) - Spawns agent containers with mounts
 - **Task Scheduler** (`src/task-scheduler.ts`) - Runs scheduled tasks
 - **Database** (`src/db.ts`) - SQLite operations for messages, groups, and tasks
-- **Channels** (`src/channels/whatsapp.ts`) - Channel connections and message delivery
+- **Channels** (`src/channels/`) - Channel connections and message delivery
 
 ### Key concepts
 

--- a/concepts/architecture.mdx
+++ b/concepts/architecture.mdx
@@ -142,7 +142,7 @@ The IPC watcher (`src/ipc.ts`) enables container-to-host communication:
 
 SQLite database (`data/nanoclaw.db`) stores:
 
-- **messages**: All WhatsApp messages with timestamps
+- **messages**: All messages with timestamps
 - **chats**: Chat metadata (name, last activity, is_group)
 - **sessions**: Claude session IDs per group folder
 - **registered_groups**: Active groups configuration
@@ -228,7 +228,7 @@ nanoclaw/
 │           ├── tasks/      # Task operation queue
 │           └── input/      # Container input (follow-ups)
 └── store/
-    └── auth/               # WhatsApp session (not mounted)
+    └── auth/               # Channel sessions (not mounted)
 ```
 
 ## Container image
@@ -286,7 +286,7 @@ The agent runner is the TypeScript code that wraps Claude Agent SDK. It handles 
 1. **Container system check**: Ensure Docker is running, clean up orphaned containers
 2. **Database initialization**: Create tables if needed, load schema
 3. **State loading**: Restore message cursors, sessions, registered groups
-4. **Channel connection**: Connect to WhatsApp, authenticate if needed
+4. **Channel connection**: Connect to messaging channels, authenticate if needed
 5. **Subsystem startup**: 
    - Task scheduler loop (60s interval)
    - IPC watcher (1s poll interval)
@@ -304,7 +304,7 @@ On `SIGTERM` or `SIGINT`:
 4. Process exits with code 0
 
 <Warning>
-Containers are intentionally not killed during shutdown to prevent data loss from WhatsApp reconnection restarts. They'll finish on their own via idle timeout or container timeout.
+Containers are intentionally not killed during shutdown to prevent data loss from channel reconnection restarts. They'll finish on their own via idle timeout or container timeout.
 </Warning>
 
 ## Related topics

--- a/concepts/security.mdx
+++ b/concepts/security.mdx
@@ -12,10 +12,10 @@ NanoClaw's security model is built on **true isolation** at the OS level rather 
 | Main group | Trusted | Private self-chat, admin control |
 | Non-main groups | Untrusted | Other users may be malicious |
 | Container agents | Sandboxed | Isolated execution environment |
-| WhatsApp messages | User input | Potential prompt injection |
+| Incoming messages | User input | Potential prompt injection |
 
 <Info>
-The main group is typically your WhatsApp self-chat. It has full administrative privileges and can manage all other groups.
+The main group is typically your private self-chat. It has full administrative privileges and can manage all other groups.
 </Info>
 
 ## Security boundaries
@@ -34,31 +34,31 @@ This is the primary security boundary. Rather than relying on application-level 
 ```mermaid
 graph TB
     subgraph "Untrusted Zone"
-        WA[WhatsApp Messages]
+        MSG[Incoming Messages]
     end
-    
+
     subgraph "Host Process (Trusted)"
         RT[Message Router]
         IPC[IPC Authorization]
         MV[Mount Validation]
         CF[Credential Filtering]
     end
-    
+
     subgraph "Container (Isolated/Sandboxed)"
         AG[Agent Execution]
         BA[Bash Commands]
         FO[File Operations]
     end
-    
-    WA -->|Trigger check, escaping| RT
+
+    MSG -->|Trigger check, escaping| RT
     RT -->|Explicit mounts only| MV
     MV --> AG
     AG -.->|IPC operations| IPC
     IPC -.->|Validated| RT
     AG --> BA
     AG --> FO
-    
-    style WA fill:#ffe6e6
+
+    style MSG fill:#ffe6e6
     style AG fill:#e1f5ff
     style BA fill:#e1f5ff
     style FO fill:#e1f5ff
@@ -179,7 +179,7 @@ IPC operations from non-main groups are silently rejected if unauthorized. This 
 
 #### NOT mounted
 
-- WhatsApp session (`store/auth/`) - host only
+- Channel sessions (e.g., `store/auth/` for WhatsApp) - host only
 - Mount allowlist - external, never mounted
 - Any credentials matching blocked patterns
 
@@ -228,7 +228,7 @@ The main group (typically your self-chat) is **trusted** because:
 
 Non-main groups are **untrusted** because:
 
-1. Other WhatsApp users may attempt prompt injection
+1. Other users may attempt prompt injection
 2. Malicious users could try to escalate privileges
 3. Groups should only affect their own context, not others
 4. Defense in depth: even if prompt injection succeeds, damage is limited
@@ -242,7 +242,7 @@ Even with restrictions, non-main groups have full agent capabilities (MCP tools,
 ```
 ┌──────────────────────────────────────────────────────────────────┐
 │                        UNTRUSTED ZONE                             │
-│  WhatsApp Messages (potentially malicious)                        │
+│  Incoming Messages (potentially malicious)                         │
 └────────────────────────────────┬─────────────────────────────────┘
                                  │
                                  ▼ Trigger check, input escaping
@@ -275,7 +275,7 @@ Even with restrictions, non-main groups have full agent capabilities (MCP tools,
 **Mitigation**:
 - Agent only has access to its own group's session
 - Cannot send messages to other groups (IPC authorization)
-- Cannot access WhatsApp credentials (not mounted)
+- Cannot access channel credentials (not mounted)
 - Cannot modify mount allowlist (external, never mounted)
 
 **Worst case**: Agent sends its own group's messages to attacker (group context is compromised, but other groups remain isolated)

--- a/features/scheduled-tasks.mdx
+++ b/features/scheduled-tasks.mdx
@@ -229,7 +229,7 @@ Tasks are managed through IPC messages written to `data/ipc/{group}/tasks/`:
   "schedule_type": "cron",
   "schedule_value": "0 9 * * *",
   "context_mode": "isolated",
-  "targetJid": "user@s.whatsapp.net"
+  "targetJid": "user@s.whatsapp.net or tg:12345 or similar"
 }
 ```
 


### PR DESCRIPTION
## Summary
- Replace WhatsApp-specific language with channel-agnostic terminology across 10 documentation pages
- Affected areas: trust model tables, security diagrams, IPC docs, architecture, troubleshooting, API reference
- Integration-specific pages (whatsapp.mdx, telegram.mdx, etc.) intentionally left unchanged

## Context
The docs were based on an older version of the codebase where WhatsApp was the only/default channel. NanoClaw now supports WhatsApp, Telegram, Discord, Slack, and Gmail as equal channels.

## Test plan
- [x] `mint validate` passes
- [ ] Visual review of changed pages on preview deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)