### PR TITLE
Switch theme from aspen to mint

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://mintlify.com/docs.json",
   "name": "NanoClaw",
-  "theme": "aspen",
+  "theme": "mint",
   "logo": {
     "light": "/images/nanoclaw-logotype-dark.svg",
     "dark": "/images/nanoclaw-logotype-dark.svg",


### PR DESCRIPTION
## Summary

- Switch Mintlify theme from `aspen` to `mint` for better sidebar category typography (14px vs 12px headings)
- Remove unnecessary h5 CSS override from `callout-overrides.css`

## Test plan

- [ ] Verify sidebar category names render at same size as glifo.cat docs
- [ ] Confirm all other styling (teal colors, dark mode, callouts) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)