### PR TITLE
Fix stale docs: credential proxy, DB path, mount allowlist, task lifecycle

### DIFF
--- a/advanced/security-model.mdx
+++ b/advanced/security-model.mdx
@@ -138,27 +138,30 @@ if (
 
 ### Credential handling
 
-**Mounted credentials:**
-- Claude auth tokens (filtered from `.env`, read-only)
+**Credential proxy** (`src/credential-proxy.ts`):
+- Runs on the host as an HTTP proxy (default port 3001)
+- Containers send API requests to the proxy with a placeholder token
+- Proxy injects real credentials (API key or OAuth token) on every outbound request
+- Supports hot-swapping between API key and OAuth modes (reads `.env` per request)
+- For OAuth, auto-refreshes tokens from `~/.claude/.credentials.json`
 
 **NOT mounted:**
 - Channel sessions (e.g., `store/auth/` for WhatsApp) - host only
 - Mount allowlist - external, never mounted
+- Real API keys or OAuth tokens - injected by proxy, never in containers
 - Any credentials matching blocked patterns
 
-**Credential filtering:**
-
-Only these environment variables are exposed to containers (from `src/container-runner.ts:206`):
+**Container environment** (from `src/container-runner.ts`):
 
 ```typescript
-function readSecrets(): Record<string, string> {
-  return readEnvFile(['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_API_KEY']);
-}
+// Containers get a placeholder token and proxy URL — never real credentials
+ANTHROPIC_BASE_URL=http://${CONTAINER_HOST_GATEWAY}:${CREDENTIAL_PROXY_PORT}
+CLAUDE_CODE_OAUTH_TOKEN=placeholder
 ```
 
-<Warning>
-Anthropic credentials are mounted so that Claude Code can authenticate when the agent runs. However, this means the agent itself can discover these credentials via Bash or file operations. Ideally, Claude Code would authenticate without exposing credentials to the agent's execution environment.
-</Warning>
+<Note>
+Containers cannot extract real credentials. The credential proxy intercepts all API requests and replaces the placeholder token with real authentication before forwarding to `api.anthropic.com`.
+</Note>
 
 ## Privilege comparison
 

--- a/advanced/troubleshooting.mdx
+++ b/advanced/troubleshooting.mdx
@@ -262,14 +262,15 @@ sqlite3 store/messages.db "SELECT name, container_config FROM registered_groups;
   
   ```json
   {
-    "allowedPaths": [
+    "allowedRoots": [
       {
-        "hostPath": "/Users/you/Documents/project",
-        "containerPath": "/workspace/extra/project",
-        "readonly": false,
-        "nonMainReadOnly": true
+        "path": "/Users/you/Documents/project",
+        "allowReadWrite": true,
+        "description": "Project files"
       }
-    ]
+    ],
+    "blockedPatterns": [".ssh", ".gnupg", ".aws", ".env", "credentials"],
+    "nonMainReadOnly": true
   }
   ```
   

--- a/api/skills/examples.mdx
+++ b/api/skills/examples.mdx
@@ -379,17 +379,16 @@ The `/add-parallel` skill adds an MCP integration with non-blocking async operat
 <Tab title="Environment passing">
 
 ```markdown
-### 3. Update Container Runner
+### 3. Configure Environment
 
-Add `PARALLEL_API_KEY` to allowed environment variables:
+Add `PARALLEL_API_KEY` to `.env` so the credential proxy and MCP env resolution can access it:
 
-```typescript
-const allowedVars = [
-  'CLAUDE_CODE_OAUTH_TOKEN', 
-  'ANTHROPIC_API_KEY', 
-  'PARALLEL_API_KEY'
-];
+```bash
+# .env
+PARALLEL_API_KEY=your-api-key-here
 ```
+
+The `readMcpEnvVars()` function in `container-runner.ts` automatically extracts `${VAR}` references from `.mcp.json` and resolves them from `.env`.
 ```
 
 </Tab>

--- a/concepts/architecture.mdx
+++ b/concepts/architecture.mdx
@@ -141,7 +141,7 @@ The IPC watcher (`src/ipc.ts`) enables container-to-host communication:
 
 ### Database
 
-SQLite database (`data/nanoclaw.db`) stores:
+SQLite database (`store/messages.db`) stores:
 
 - **messages**: All messages with timestamps
 - **chats**: Chat metadata (name, last activity, is_group)

--- a/concepts/security.mdx
+++ b/concepts/security.mdx
@@ -184,25 +184,20 @@ IPC operations from non-main groups are silently rejected if unauthorized. This 
 - Mount allowlist - external, never mounted
 - Any credentials matching blocked patterns
 
-#### Credential filtering
+#### Credential proxy
 
-Only these environment variables are exposed to containers:
-
-```typescript
-const allowedVars = ['CLAUDE_CODE_OAUTH_TOKEN', 'ANTHROPIC_API_KEY'];
-```
-
-Credentials are passed via stdin JSON (never written to disk or mounted as files):
+Containers never see real credentials. A credential proxy (`src/credential-proxy.ts`) runs on the host and injects authentication on every outbound API request:
 
 ```typescript
-// Secrets passed on container startup, then deleted
-container.stdin.write(JSON.stringify({ ...input, secrets }));
-container.stdin.end();
-delete input.secrets; // Remove from memory immediately
+// Container has a placeholder token — real credentials injected by proxy
+ANTHROPIC_BASE_URL=http://host.docker.internal:3001  // → proxy
+CLAUDE_CODE_OAUTH_TOKEN=placeholder                   // → replaced by proxy
 ```
+
+The proxy reads credentials from `.env` on each request (supports hot-swapping between API key and OAuth modes without restart). For OAuth, it auto-refreshes tokens from `~/.claude/.credentials.json`.
 
 <Warning>
-Anthropic credentials are mounted so that Claude Code can authenticate when the agent runs. However, this means the agent itself can discover these credentials via Bash or file operations. Ideally, Claude Code would authenticate without exposing credentials to the agent's execution environment.
+The credential proxy prevents credential exposure to containers. However, the proxy URL is accessible from within the container's network. The container cannot extract the real credentials, but it can make authenticated API requests through the proxy.
 </Warning>
 
 ## Privilege comparison

--- a/features/scheduled-tasks.mdx
+++ b/features/scheduled-tasks.mdx
@@ -54,7 +54,7 @@ NanoClaw supports three types of scheduled tasks:
     schedule_value: '2026-03-01T10:00:00Z'
     ```
 
-    One-time tasks are automatically removed after execution.
+    One-time tasks are set to `completed` status after execution and remain in the database for reference.
   </Tab>
 </Tabs>
 


### PR DESCRIPTION
## Summary

Audit of docs portal against upstream code (`qwibitai/nanoclaw@main`) revealed 6 stale references. All fixes verified against upstream source.

- **`concepts/security.mdx`** — Replace old `readSecrets()`/`allowedVars` pattern with credential proxy description (removed in v1.2.12)
- **`concepts/architecture.mdx`** — Fix DB path from `data/nanoclaw.db` to `store/messages.db` (matches `STORE_DIR` in `config.ts`)
- **`advanced/security-model.mdx`** — Replace `readSecrets()` code block with credential proxy architecture
- **`advanced/troubleshooting.mdx`** — Fix mount allowlist schema from `allowedPaths` to `allowedRoots` (matches `mount-security.ts` validation)
- **`features/scheduled-tasks.mdx`** — One-time tasks are set to `completed` status, not removed (matches `updateTaskAfterRun` in `db.ts`)
- **`api/skills/examples.mdx`** — Update env passing example from `allowedVars` to `.env` + `readMcpEnvVars` pattern

## Verification

Each change was cross-referenced against:
1. `git show upstream/main:<file>` on the upstream NanoClaw repo
2. The Mintlify docs portal MCP (live search)
3. Local running instance behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)