### PR TITLE
Add weekly docs audit and skill branch documentation workflows

### DIFF
--- a/.mintlify/workflows/new-skill-docs.md
+++ b/.mintlify/workflows/new-skill-docs.md
@@ -1,0 +1,54 @@
+---
+name: Document new skill branches
+on:
+  push:
+    - repo: qwibitai/nanoclaw
+      branch: skill/*
+context:
+  - repo: qwibitai/nanoclaw
+automerge: false
+---
+
+A new skill branch was pushed or updated on the upstream NanoClaw repository. Review the skill and create or update its documentation page.
+
+## Instructions
+
+### 1. Identify the skill
+
+Determine which `skill/*` branch was pushed. Check its contents:
+- New source files added (e.g., `src/channels/telegram.ts`)
+- Modified files (e.g., `src/index.ts`, `src/config.ts`, `package.json`)
+- `.env.example` additions (new environment variables)
+- Any SKILL.md file in the branch
+
+### 2. Check if documentation already exists
+
+Look in `integrations/` for an existing page for this skill. If it exists, update it. If not, create a new one.
+
+### 3. Create or update the integration page
+
+Follow the pattern of existing integration pages (e.g., `integrations/discord.mdx`, `integrations/telegram.mdx`). Each integration page should include:
+
+- **Title and description** in frontmatter
+- **Overview** — what the integration does and which library it uses
+- **Installation** — `git fetch upstream skill/{name}` and `git merge upstream/skill/{name}`
+- **Setup** — environment variables, authentication steps, platform-specific configuration
+- **Registration** — how to register groups with the correct JID format
+- **Features** — what capabilities the integration supports
+- **Removing** — how to revert the merge and clean up registrations
+- **Troubleshooting** — common issues (bot not responding, auth errors, missing tokens)
+
+### 4. Update the integrations overview
+
+If this is a new integration, add it to `integrations/overview.mdx` in the channel list.
+
+### 5. Update navigation
+
+If this is a new page, add it to the navigation in `docs.json` under the Integrations group.
+
+### 6. Style guidelines
+
+- Match the existing tone and structure of other integration pages
+- Use Mintlify components (Tabs, Accordions, CodeGroups) where appropriate
+- Include the JID format for group registration
+- Always include a "Removing" section with `git revert` instructions

--- a/.mintlify/workflows/weekly-docs-audit.md
+++ b/.mintlify/workflows/weekly-docs-audit.md
@@ -1,0 +1,43 @@
+---
+name: Weekly docs health audit
+on:
+  cron: "0 9 * * 1"
+context:
+  - repo: qwibitai/nanoclaw
+automerge: false
+---
+
+Run a weekly health check on the documentation, comparing it against the current upstream codebase.
+
+## Instructions
+
+### 1. Check for broken internal links
+
+Scan all `.mdx` files for internal links (e.g., `[text](/path/to/page)`, `[text](./relative.mdx)`) and verify the target pages exist. Report any broken links.
+
+### 2. Check for stale code references
+
+Compare code snippets and function references in the docs against the actual upstream source code in the `qwibitai/nanoclaw` context repo. Flag any that no longer match, specifically:
+
+- Function names that no longer exist (e.g., `readSecrets()` was removed)
+- Database paths or table names that changed
+- Configuration option names or defaults that changed
+- File paths referenced in docs that no longer exist
+- Import paths or module structures that changed
+
+### 3. Check for missing documentation
+
+Review recent upstream changes (last 7 days of commits on `qwibitai/nanoclaw`) and identify any new features, configuration options, or behavioral changes that aren't documented yet.
+
+### 4. Check frontmatter quality
+
+Verify all `.mdx` files have:
+- A `title` field
+- A `description` field with at least 50 characters
+
+### 5. Report and fix
+
+- For broken links and stale references: fix them directly
+- For missing documentation: add stub sections with TODO markers
+- For frontmatter issues: add missing fields
+- If everything is healthy, do not open a PR


### PR DESCRIPTION
## Summary

Two new Mintlify Agent workflows:

- **Weekly docs health audit** (cron, Mondays 9am UTC) — scans for broken internal links, stale code references vs upstream, missing documentation for recent changes, and incomplete frontmatter. Only opens a PR if issues are found.

- **New skill branch docs** (push trigger on `skill/*` branches) — when a new skill branch is pushed to `qwibitai/nanoclaw`, auto-generates an integration page following the pattern of existing pages (Discord, Telegram, etc.) with setup, features, removal, and troubleshooting sections.

## Test plan

- [ ] Merge and verify workflows appear in Mintlify dashboard
- [ ] Weekly audit: wait for Monday run, or trigger manually from dashboard
- [ ] Skill docs: wait for next `skill/*` branch push to upstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)