### PR TITLE
Fix rendering issues and WhatsApp-as-default framing

### DIFF
--- a/advanced/security-model.mdx
+++ b/advanced/security-model.mdx
@@ -10,7 +10,7 @@ NanoClaw's security model is built on OS-level isolation rather than application
 NanoClaw operates with different trust levels for different entities:
 
 | Entity | Trust Level | Rationale |
-|--------|-------------|-----------||
+|--------|-------------|-----------|
 | Main group | Trusted | Private self-chat, admin control |
 | Non-main groups | Untrusted | Other users may be malicious |
 | Container agents | Sandboxed | Isolated execution environment |

--- a/concepts/architecture.mdx
+++ b/concepts/architecture.mdx
@@ -30,9 +30,9 @@ graph TB
     DB[(SQLite Database)] --> Router
     DB --> Scheduler
 
-    style Container fill:#ccfbf1
-    style Agent fill:#99f6e4
-    style CF fill:#f0fdfa
+    style Container fill:#6ee7b7,color:#1e1e1e
+    style Agent fill:#34d399,color:#1e1e1e
+    style CF fill:#a7f3d0,color:#1e1e1e
 ```
 
 ## Core components
@@ -205,7 +205,7 @@ sequenceDiagram
 
 ## File system layout
 
-```
+```text
 nanoclaw/
 ├── src/                    # Host process source code
 ├── container/
@@ -218,7 +218,6 @@ nanoclaw/
 │   │   └── logs/           # Container logs
 │   └── {group-name}/       # Other registered groups
 ├── data/
-│   ├── nanoclaw.db         # SQLite database
 │   ├── sessions/
 │   │   └── {group}/
 │   │       ├── .claude/    # Claude session data
@@ -229,6 +228,7 @@ nanoclaw/
 │           ├── tasks/      # Task operation queue
 │           └── input/      # Container input (follow-ups)
 └── store/
+    ├── messages.db         # SQLite database
     └── auth/               # Channel sessions (not mounted)
 ```
 

--- a/concepts/security.mdx
+++ b/concepts/security.mdx
@@ -9,7 +9,7 @@ NanoClaw's security model is built on **true isolation** at the OS level rather 
 ## Trust model
 
 | Entity | Trust Level | Rationale |
-|--------|-------------|-----------||
+|--------|-------------|-----------|
 | Main group | Trusted | Private self-chat, admin control |
 | Non-main groups | Untrusted | Other users may be malicious |
 | Container agents | Sandboxed | Isolated execution environment |
@@ -59,10 +59,10 @@ graph TB
     AG --> BA
     AG --> FO
 
-    style MSG fill:#ffe6e6
-    style AG fill:#ccfbf1
-    style BA fill:#ccfbf1
-    style FO fill:#ccfbf1
+    style MSG fill:#fca5a5,color:#1e1e1e
+    style AG fill:#6ee7b7,color:#1e1e1e
+    style BA fill:#6ee7b7,color:#1e1e1e
+    style FO fill:#6ee7b7,color:#1e1e1e
 ```
 
 <Note>

--- a/installation.mdx
+++ b/installation.mdx
@@ -303,7 +303,7 @@ This creates the `nanoclaw-agent` image.
 
 After installation, NanoClaw creates:
 
-```
+```text
 NanoClaw/
 ├── src/                    # Source code
 ├── dist/                   # Compiled JavaScript
@@ -312,10 +312,10 @@ NanoClaw/
 │   └── main/              # Main channel
 │       ├── CLAUDE.md      # Group memory
 │       └── logs/          # Container logs
-├── store/                  # Channel sessions
-│   └── auth/              # Authentication data
-├── data/                   # SQLite database
-│   ├── nanoclaw.db        # Messages, groups, tasks
+├── store/                  # Persistent data
+│   ├── messages.db        # SQLite database (messages, groups, tasks)
+│   └── auth/              # Channel authentication data
+├── data/                   # Runtime data
 │   └── sessions/          # Claude sessions per group
 ├── logs/                   # Application logs
 │   ├── nanoclaw.log       # Main log

--- a/integrations/whatsapp.mdx
+++ b/integrations/whatsapp.mdx
@@ -75,14 +75,14 @@ WhatsApp (Baileys) → SQLite → Polling loop → Container (Claude Agent SDK) 
 
 ## Setup
 
-WhatsApp setup is handled by the `/setup` skill when you first install NanoClaw:
+WhatsApp is not bundled with NanoClaw's core install. Add it using the `/add-whatsapp` skill:
 
 ```bash
 claude
-/setup
+/add-whatsapp
 ```
 
-The setup process will:
+This merges the `skill/whatsapp` branch into your fork, adding the WhatsApp channel code and its dependencies (including `@whiskeysockets/baileys`). The skill will then:
 
 1. Generate a QR code for WhatsApp Web authentication
 2. Wait for you to scan it with your phone
@@ -90,7 +90,7 @@ The setup process will:
 4. Connect to WhatsApp and verify the connection
 
 <Note>
-  If authentication fails or expires, run `/setup` again to re-authenticate.
+  If authentication fails or expires, run `/add-whatsapp` again to re-authenticate.
 </Note>
 
 ## Configuration
@@ -275,25 +275,25 @@ Ensure `ASSISTANT_HAS_OWN_NUMBER` is set correctly in `src/config.ts`:
 - If sharing a number, set to `false` (bot messages will have the name prefix)
 - If using a dedicated number, set to `true` (bot messages are identified by `fromMe`)
 
-## Switching to another channel
+## Using other channels
 
-You can add other channels alongside WhatsApp or replace it entirely:
+NanoClaw supports multiple messaging channels as equal options. You can run WhatsApp alongside other channels or use a different channel entirely.
 
-### Add alongside WhatsApp
-
-```bash
-/add-telegram  # Keeps WhatsApp, adds Telegram
-```
-
-### Replace WhatsApp
-
-When adding a new channel, choose "Replace WhatsApp" and set the appropriate flag:
+### Add another channel
 
 ```bash
-TELEGRAM_ONLY=true  # in .env
+/add-telegram  # Adds Telegram alongside WhatsApp
 ```
 
-This disables WhatsApp channel creation while keeping the implementation available.
+### Remove WhatsApp
+
+To remove the WhatsApp skill and revert to a channel-free core:
+
+```bash
+git revert -m 1 <whatsapp-merge-commit>
+```
+
+See [removing a skill](/integrations/skills-system#removing-a-skill) for details.
 
 ## Implementation details
 
@@ -329,11 +329,15 @@ async setTyping(jid: string, isTyping: boolean): Promise<void> {
 
 ## Source code reference
 
-The WhatsApp implementation is fully contained in:
+After installing the WhatsApp skill, the implementation lives in:
 
-- **`src/channels/whatsapp.ts`** - Main WhatsAppChannel class (379 lines)
-- **`src/config.ts`** - Configuration constants
+- **`src/channels/whatsapp.ts`** - Main WhatsAppChannel class
+- **`src/config.ts`** - Configuration constants (extended by the skill)
 - **`src/index.ts`** - Channel initialization and routing
+
+<Note>
+These files are added by the `skill/whatsapp` branch merge. They do not exist in NanoClaw's core install.
+</Note>
 
 ## Next steps
 


### PR DESCRIPTION
## Summary

- Fix double-pipe (`||`) table syntax in trust model tables (`security.mdx`, `security-model.mdx`)
- Increase Mermaid diagram contrast with darker fills and explicit text color (`security.mdx`, `architecture.mdx`)
- Add `text` language tags to directory tree code blocks (`installation.mdx`, `architecture.mdx`)
- Correct stale database path `data/nanoclaw.db` → `store/messages.db` in file trees
- Reframe WhatsApp page: installed via `/add-whatsapp`, not bundled in core
- Clarify source code files only exist after skill branch merge

Closes #14, #15, #16, #17, #18

## Test plan

- [x] `mint validate` passes
- [x] Verify trust model tables render correctly
- [x] Verify Mermaid diagrams have readable contrast
- [x] Verify WhatsApp page no longer implies it's the default channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)