### PR TITLE
Fix 3 doc errors found in evening maintainer sweep

### DIFF
--- a/advanced/troubleshooting.mdx
+++ b/advanced/troubleshooting.mdx
@@ -226,14 +226,21 @@ ls -la store/auth/
 Re-authenticate with WhatsApp:
 
 ```bash
-npm run auth
+claude
+/add-whatsapp
 ```
 
 Scan the QR code with your phone, then restart the service:
 
-```bash
+<CodeGroup>
+```bash macOS
 launchctl kickstart -k gui/$(id -u)/com.nanoclaw
 ```
+
+```bash Linux
+systemctl --user restart nanoclaw
+```
+</CodeGroup>
 
 ## Container mount issues
 

--- a/integrations/gmail.mdx
+++ b/integrations/gmail.mdx
@@ -422,64 +422,44 @@ Ask your agent:
 
 ## Removing Gmail
 
-### Tool-only mode
+To remove the Gmail skill and revert to a Gmail-free setup:
 
 <Steps>
-  <Step title="Remove mount">
-    Delete the `~/.gmail-mcp` mount from `src/container-runner.ts`
-  </Step>
-  
-  <Step title="Remove MCP server">
-    Delete `gmail` from MCP servers and `mcp__gmail__*` from allowed tools in `container/agent-runner/src/index.ts`
-  </Step>
-  
-  <Step title="Clear agent runners">
+  <Step title="Find the merge commit">
     ```bash
-    rm -r data/sessions/*/agent-runner-src 2>/dev/null || true
+    git log --merges --oneline | grep gmail
     ```
+
+    Look for a commit like `abc1234 Merge remote-tracking branch 'upstream/skill/gmail'`.
   </Step>
 
-  <Step title="Rebuild">
+  <Step title="Revert the merge">
     ```bash
-    cd container && ./build.sh && cd ..
+    git revert -m 1 <merge-commit>
+    ```
+
+    This creates a new commit that undoes all of Gmail's code changes.
+  </Step>
+
+  <Step title="Rebuild and restart">
+    ```bash
+    npm install
     npm run build
+    ```
+
+    <CodeGroup>
+    ```bash macOS
     launchctl kickstart -k gui/$(id -u)/com.nanoclaw
     ```
+
+    ```bash Linux
+    systemctl --user restart nanoclaw
+    ```
+    </CodeGroup>
   </Step>
 </Steps>
 
-### Channel mode
-
-<Steps>
-  <Step title="Delete channel files">
-    ```bash
-    rm src/channels/gmail.ts
-    rm src/channels/gmail.test.ts
-    ```
-  </Step>
-
-  <Step title="Revert code changes">
-    - Remove `GmailChannel` import and creation from `src/index.ts`
-    - Remove mount from `src/container-runner.ts`
-    - Remove MCP server from `container/agent-runner/src/index.ts`
-    - Remove Gmail JID tests from `src/routing.test.ts`
-  </Step>
-
-  <Step title="Uninstall dependency">
-    ```bash
-    npm uninstall googleapis
-    ```
-  </Step>
-
-  <Step title="Clear and rebuild">
-    ```bash
-    rm -r data/sessions/*/agent-runner-src 2>/dev/null || true
-    cd container && ./build.sh && cd ..
-    npm run build
-    launchctl kickstart -k gui/$(id -u)/com.nanoclaw
-    ```
-  </Step>
-</Steps>
+See [removing a skill](/integrations/skills-system#removing-a-skill) for details.
 
 ## Next steps
 

--- a/integrations/skills-system.mdx
+++ b/integrations/skills-system.mdx
@@ -142,7 +142,7 @@ Dependencies are implicit in git history — no separate dependency file is need
 | Discord | `/add-discord` | discord.js |
 | Telegram | `/add-telegram` | grammy |
 | Slack | `/add-slack` | @slack/bolt (Socket Mode) |
-| WhatsApp | `/add-whatsapp` | whatsapp-web.js |
+| WhatsApp | `/add-whatsapp` | @whiskeysockets/baileys |
 
 ### Services
 


### PR DESCRIPTION
## Summary
- **skills-system.mdx**: WhatsApp library listed as `whatsapp-web.js`, corrected to `@whiskeysockets/baileys` (matches all other references in the docs)
- **troubleshooting.mdx**: WhatsApp re-auth command was `npm run auth`, corrected to `claude` + `/add-whatsapp`; added missing Linux `systemctl` restart command
- **gmail.mdx**: Removal instructions used manual file surgery (`rm`, `npm uninstall`, editing imports) — replaced with `git revert -m 1` pattern consistent with all other channel integrations

Closes #14

## Test plan
- [x] `mint validate` passes
- [x] Verify WhatsApp library name matches upstream `package.json`
- [x] Confirm `/add-whatsapp` is the current re-auth flow
- [x] Visual check of Gmail removal section renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)