### PR TITLE
Cherry-pick unique changes from closed PRs #175 and #176

### DIFF
--- a/api/configuration.mdx
+++ b/api/configuration.mdx
@@ -27,7 +27,7 @@ Configuration is read from `.env` file or `process.env`.
 </ParamField>
 
 <ParamField path="CONTAINER_MAX_OUTPUT_SIZE" type="number" default="10485760">
-  Maximum container output size in bytes (default: 10MB).
+  Maximum container output size in bytes (default: 10MB). Stdout beyond this limit is truncated.
 </ParamField>
 
 <ParamField path="IDLE_TIMEOUT" type="number" default="1800000">

--- a/changelog/docs-updates.mdx
+++ b/changelog/docs-updates.mdx
@@ -5,6 +5,19 @@ icon: "file-pen"
 rss: true
 ---
 
+<Update label="v1.2.46–v1.2.47 sync: store mount, reply context, requiresTrigger" description="2026-04-04" tags={["Updated"]}>
+  Triaged 3 automated Mintlify PRs (#175–#177). Merged #177 (most comprehensive), closed #175 and #176 (superseded). Cherry-picked unique content from closed PRs.
+
+  ## Updated
+  - **Store mount (rw)**: Documented `store/` read-write mount for main agent across containers, container-runtime, security, security-model, groups, customization pages
+  - **`requiresTrigger` parameter**: Added to `register_group` MCP tool description in containers and messaging pages
+  - **Reply context**: Updated architecture database section with `reply_to_message_id`, `reply_to_message_content`, `reply_to_sender_name` columns
+  - **`isMain` preservation**: Updated register_group handler snippet in messaging page
+  - **`CONTAINER_MAX_OUTPUT_SIZE`**: Added truncation behavior note to configuration reference
+  - **Token count**: Updated from 43.3k to 43.4k in introduction and skills-system pages
+  - **Changelog**: Added v1.2.46 and v1.2.47 product release entries
+</Update>
+
 <Update label="Breaking change detection docs" description="2026-04-03" tags={["Updated"]}>
   - **`quickstart`**: Added breaking change changelog scan to `/update-nanoclaw` step list
   - **`integrations/skills-system`**: Added "Breaking change detection" subsection documenting the `[BREAKING]` entry scan and migration skill prompts

--- a/features/customization.mdx
+++ b/features/customization.mdx
@@ -305,6 +305,14 @@ if (isMain) {
     containerPath: '/workspace/project',
     readonly: true,
   });
+
+  // Store mounted read-write so the main agent can
+  // query and write to the SQLite database directly
+  mounts.push({
+    hostPath: path.join(projectRoot, 'store'),
+    containerPath: '/workspace/project/store',
+    readonly: false,
+  });
   
   mounts.push({
     hostPath: groupDir,

--- a/features/messaging.mdx
+++ b/features/messaging.mdx
@@ -294,7 +294,9 @@ case 'register_group':
     break;
   }
   if (data.jid && data.name && data.folder && data.trigger) {
-    // Defense in depth: isMain is never set via IPC
+    // Defense in depth: isMain preserved from existing registration,
+    // never set via IPC
+    const existingGroup = registeredGroups[data.jid];
     deps.registerGroup(data.jid, {
       name: data.name,
       folder: data.folder,
@@ -302,6 +304,7 @@ case 'register_group':
       added_at: new Date().toISOString(),
       containerConfig: data.containerConfig,
       requiresTrigger: data.requiresTrigger,
+      isMain: existingGroup?.isMain,
     });
   }
 ```

--- a/integrations/skills-system.mdx
+++ b/integrations/skills-system.mdx
@@ -15,7 +15,7 @@ From the NanoClaw README:
 
 This approach means:
 
-- The base NanoClaw codebase stays small (~43.3k tokens)
+- The base NanoClaw codebase stays small (~43.4k tokens)
 - Each installation is customized to your exact needs
 - No configuration sprawl or unused features
 - The code remains understandable and modifiable


### PR DESCRIPTION
## Summary
- Preserves unique content from PRs #175 and #176, which were closed as superseded by #177
- All overlapping store mount / requiresTrigger changes were already merged via #177

## Cherry-picked changes
- **`api/configuration.mdx`**: Added truncation behavior note to `CONTAINER_MAX_OUTPUT_SIZE` (from #176)
- **`integrations/skills-system.mdx`**: Token count 43.3k → 43.4k (from #176)
- **`features/customization.mdx`**: Store mount in main channel code snippet (from #175)
- **`features/messaging.mdx`**: `isMain` preservation in `register_group` handler (from #175)
- **`changelog/docs-updates.mdx`**: Docs changelog entry for the full v1.2.46–v1.2.47 triage

## Verified against upstream
- `CONTAINER_MAX_OUTPUT_SIZE` truncation: confirmed in `src/container-runner.ts`
- Store mount in `src/container-runner.ts:92-99`
- `isMain: existingGroup?.isMain` in `src/ipc.ts`
- `mint validate` passes

## Test plan
- [x] `mint validate` passes
- [ ] Verify pages render correctly after merge

Closes #175
Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)