### PR TITLE
docs: v2.0.0 launch readiness — front-door rewrites (Phase A)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,7 +159,7 @@ To PR changes to `qwibitai/nanoclaw` from Ethan's fork (`glifocat/nanoclaw-glifo
 
 ## Token Count
 
-Source of truth: `repo-tokens/badge.svg` in upstream (auto-generated). Currently ~43.7k tokens. Update `introduction.mdx` and `integrations/skills-system.mdx` if the badge value changes significantly.
+Source of truth: `repo-tokens/badge.svg` in upstream (auto-generated). Currently ~127k tokens (~64% of Claude's context window — jumped from 43.7k at v1.2.53 to 127k at v2.0.0 due to the ground-up rewrite). Update `introduction.mdx` and `integrations/skills-system.mdx` if the badge value changes significantly.
 
 ## Writing Standards
 

--- a/changelog/docs-updates.mdx
+++ b/changelog/docs-updates.mdx
@@ -5,6 +5,26 @@ icon: "file-pen"
 rss: true
 ---
 
+<Update label="v2.0.0 launch readiness: front-door rewrites" description="2026-04-22" tags={["Updated"]}>
+  Phase A of the v2 documentation sprint — bringing the pages every new user lands on into alignment with the v2 rewrite. All claims verified directly against upstream source (`src/db/schema.ts`, `src/types.ts`, `src/config.ts`, `container/Dockerfile`, `src/delivery.ts`) rather than upstream `docs/` (which includes a stale `architecture.md` draft and a `db-session.md` that omits the `container_state` table).
+
+  ## Rewritten
+  - **`introduction.mdx`**: v2 positioning — two-DB session IO, entity model, Node + Bun runtime split, OneCLI-only credentials. Token count updated to ~127k (~64% of context window). Source file table aligned with `src/` as of v2.0.1.
+  - **`quickstart.mdx`**: one-command `bash nanoclaw.sh` flow replaces the v1 fork-and-clone + Claude Code + `/setup` dance. Documents the three-level setup log contract (terminal, `logs/setup.log`, per-step raw logs) and the Anthropic OAuth exception.
+  - **`installation.mdx`**: simplified to system requirements + platform prerequisites + `bash nanoclaw.sh`. Service management retained (launchd / systemd / WSL wrapper). File-structure tree updated for `data/v2-sessions/`, `store/v2.db`, and the per-session `inbound.db` + `outbound.db` layout.
+  - **`integrations/overview.mdx`**: reframed around channels (13+) and providers (4), both living on dedicated branches (`channels`, `providers`). Expanded channel list to cover Teams, iMessage, Matrix, Google Chat, Webex, Linear, GitHub, WeChat, Resend, and the local `/claw` CLI.
+  - **`features/customization.mdx`**: full v2 rewrite — verified trigger pattern code against `src/config.ts`, replaced nonexistent `POLL_INTERVAL` / `SCHEDULER_POLL_INTERVAL` with actual `ACTIVE_POLL_MS` / `SWEEP_POLL_MS` from `src/delivery.ts`, documented per-wiring engage config (`engage_mode`, `sender_scope`, `ignored_message_policy`, `session_mode`), kept OneCLI / legacy credential proxy as version tabs.
+
+  ## v2 update banners
+  Added `<Warning>` banners to pages pending a v2 rewrite (channel adapters moved to a single `channels` branch in v2, not per-channel `skill/*` branches):
+  - `integrations/whatsapp.mdx`, `telegram.mdx`, `discord.mdx`, `slack.mdx`, `gmail.mdx`, `x-twitter.mdx`, `skills-system.mdx`
+  - `integrations/ollama.mdx` (Ollama now lives on the `providers` branch — `/add-ollama-provider` or `/add-ollama-tool`)
+
+  ## Token count sync
+  - `integrations/skills-system.mdx`: 43.8k → 127k
+  - `CLAUDE.md`: maintenance note updated to reflect the v1.2.53 → v2.0.0 jump
+</Update>
+
 <Update label="v2.0.0: architectural rewrite docs" description="2026-04-22" tags={["Updated"]}>
   Merged PR #187 — comprehensive rewrite of concepts, advanced, api, and features pages for the v2.0.0 ground-up architectural rewrite ([qwibitai/nanoclaw#1919](https://github.com/qwibitai/nanoclaw/pull/1919)). Closed PRs #184, #185, #186 as superseded.
 

--- a/docs.json
+++ b/docs.json
@@ -128,7 +128,6 @@
               "integrations/telegram",
               "integrations/discord",
               "integrations/slack",
-              "integrations/gmail",
               "integrations/ollama",
               "integrations/x-twitter",
               "integrations/parallel-ai"

--- a/docs.json
+++ b/docs.json
@@ -34,7 +34,7 @@
     "eyebrows": "breadcrumbs"
   },
   "banner": {
-    "content": "**These docs are being updated for NanoClaw v2.** Hit something that looks outdated? [Ping us on Discord](https://discord.gg/VDdww8qS42).",
+    "content": "**Docs are catching up to v2.** [Join the Discord community](https://discord.gg/VDdww8qS42) — get help, share what you're building, or just say hi.",
     "dismissible": true
   },
   "navbar": {

--- a/docs.json
+++ b/docs.json
@@ -33,6 +33,10 @@
   "styling": {
     "eyebrows": "breadcrumbs"
   },
+  "banner": {
+    "content": "**These docs are being updated for NanoClaw v2.** Hit something that looks outdated? [Ping us on Discord](https://discord.gg/VDdww8qS42).",
+    "dismissible": true
+  },
   "navbar": {
     "primary": {
       "type": "github",

--- a/features/customization.mdx
+++ b/features/customization.mdx
@@ -1,195 +1,145 @@
 ---
 title: Customize NanoClaw
-description: Learn how to modify NanoClaw's behavior by changing code, not configuration files
+description: Change behavior by editing code, wiring agent groups, and installing skills — no config-file sprawl.
 tag: "UPDATED"
+keywords: ["customize", "config", "trigger", "engage mode", "mount allowlist", "env vars", "buildTriggerPattern"]
 ---
 
-## Philosophy
+NanoClaw doesn't rely on large configuration files. Instead, customizations fall into four lanes:
 
-NanoClaw doesn't use configuration files. Instead, it's designed to be customized by modifying the code directly. The codebase is small enough (a few thousand lines) that you can safely make changes.
+1. **Code changes** — for behavior baked into the orchestrator (trigger pattern, polling, timeouts)
+2. **Wiring settings** — per-messaging-group config stored in the central DB (engage mode, sender scope, session mode)
+3. **Skills** — for features and integrations (install via `/add-<name>`, uninstall via `git revert`)
+4. **Mount allowlist** — for which host directories an agent can see
+
+## Philosophy
 
 <Note>
 **From the README:**
 
-"NanoClaw doesn't use configuration files. To make changes, just tell Claude Code what you want... The codebase is small enough that Claude can safely modify it."
+> NanoClaw doesn't use configuration files. To make changes, just tell Claude Code what you want... The codebase is small enough that Claude can safely modify it.
 </Note>
 
-## Why no config files?
+The result: your fork does exactly what you asked for, and nothing else. No generic system to learn — just the code you want, readable by you and by Claude Code.
 
-Configuration files lead to sprawl - dozens of options, complex validation, and bloat. NanoClaw takes a different approach:
+## Change the trigger word
 
-- **Small codebase**: ~5,000 lines across a handful of files
-- **AI-native**: Claude Code understands and modifies the code for you
-- **Bespoke**: Your fork does exactly what you need, not what a generic system supports
-- **No feature bloat**: Customizations are skills, not core features
-
-## Common customizations
-
-Here are the most common ways to customize NanoClaw:
-
-### Change the trigger word
-
-The default trigger is `@Andy`. To change it:
-
-```
-Change the trigger word to @Bob
-```
-
-Claude Code will update:
-- `ASSISTANT_NAME` in `src/config.ts`
-- The `.env` file
-- Trigger pattern regex in `src/config.ts`
-
-### Adjust response style
-
-To change how the agent responds:
-
-```
-Remember in the future to make responses shorter and more direct
-```
-
-This updates the agent's memory (stored in `groups/main/CLAUDE.md`).
-
-### Add a custom greeting
-
-```
-Add a custom greeting when I say good morning
-```
-
-Claude Code will modify the message processing logic to detect "good morning" and respond appropriately.
-
-### Change polling intervals
-
-Adjust how often NanoClaw checks for messages or due tasks:
+The default is `@Andy`, derived from `ASSISTANT_NAME` in `src/config.ts`:
 
 ```typescript
-// src/config.ts
-export const POLL_INTERVAL = 2000; // Message polling (2 seconds)
-export const SCHEDULER_POLL_INTERVAL = 60000; // Task polling (60 seconds)
+// src/config.ts (verified v2)
+export const ASSISTANT_NAME = process.env.ASSISTANT_NAME || envConfig.ASSISTANT_NAME || 'Andy';
+
+export function buildTriggerPattern(trigger: string): RegExp {
+  return new RegExp(`^${escapeRegex(trigger.trim())}\\b`, 'i');
+}
+
+export const DEFAULT_TRIGGER = `@${ASSISTANT_NAME}`;
+export const TRIGGER_PATTERN = buildTriggerPattern(DEFAULT_TRIGGER);
 ```
 
-To change:
-
-```
-Reduce the message polling interval to 1 second for faster responses
-```
-
-### Modify container limits
-
-Control how many agent containers can run simultaneously:
-
-```typescript
-// src/config.ts
-export const MAX_CONCURRENT_CONTAINERS = Math.max(
-  1,
-  parseInt(process.env.MAX_CONCURRENT_CONTAINERS || '5', 10) || 5,
-);
-```
-
-To change:
-
-```
-Increase the max concurrent containers to 10
-```
-
-Or set the environment variable:
+To change it, update `.env`:
 
 ```bash
-export MAX_CONCURRENT_CONTAINERS=10
+ASSISTANT_NAME=Bob
 ```
 
-### Adjust idle timeout
-
-Change how long containers stay alive after the last response:
-
-```typescript
-// src/config.ts
-export const IDLE_TIMEOUT = parseInt(process.env.IDLE_TIMEOUT || '1800000', 10); // 30 minutes
-```
-
-To change:
+Or ask Claude Code:
 
 ```
-Set the idle timeout to 10 minutes
+@Andy change the trigger word to @Bob
 ```
 
-Or:
+Claude updates `.env`, restarts the service, and verifies the new pattern matches.
+
+## Environment variables
+
+`src/config.ts` reads `ASSISTANT_NAME`, `ASSISTANT_HAS_OWN_NUMBER`, `ONECLI_URL`, `ONECLI_API_KEY`, and `TZ` from `.env` (with `process.env` taking precedence). Everything else is `process.env` only.
+
+<Tabs>
+  <Tab title="OneCLI Agent Vault (default)">
+    ```bash
+    # .env
+    ASSISTANT_NAME=Andy
+    ASSISTANT_HAS_OWN_NUMBER=false
+    ONECLI_URL=http://127.0.0.1:10254
+    # ONECLI_API_KEY=...  # only if your OneCLI instance requires auth
+    TZ=America/Los_Angeles
+    ```
+
+    Credentials are managed by the OneCLI Agent Vault. No API keys live in `.env`.
+  </Tab>
+
+  <Tab title="Legacy credential proxy (opt-in)">
+    ```bash
+    # .env
+    ASSISTANT_NAME=Andy
+    ASSISTANT_HAS_OWN_NUMBER=false
+    ANTHROPIC_API_KEY=sk-ant-...
+    ```
+
+    Requires the `/use-native-credential-proxy` skill (lives at `skill/native-credential-proxy` on upstream). The skill restores the v1-style credential proxy — the host reads `ANTHROPIC_API_KEY` from `.env` and injects it into container traffic via a local proxy on port 3001. Containers never see the raw key.
+  </Tab>
+</Tabs>
+
+### Runtime-tunable settings (process.env only)
+
+| Variable | Default | What it controls |
+|---|---|---|
+| `CONTAINER_IMAGE` | `nanoclaw-agent:latest` | Which image to spawn |
+| `CONTAINER_TIMEOUT` | `1800000` (30 min) | Hard upper bound on a single container run |
+| `CONTAINER_MAX_OUTPUT_SIZE` | `10485760` (10 MB) | Truncation threshold for container stdout |
+| `MAX_MESSAGES_PER_PROMPT` | `10` | How many queued inbound messages join one Claude turn |
+| `IDLE_TIMEOUT` | `1800000` (30 min) | How long a container stays alive after the last response |
+| `MAX_CONCURRENT_CONTAINERS` | `5` | Global cap on active containers |
+
+Bump them like:
 
 ```bash
-export IDLE_TIMEOUT=600000  # 10 minutes in milliseconds
+MAX_CONCURRENT_CONTAINERS=10 systemctl --user restart nanoclaw
 ```
 
-## Configuration via environment
+Or persist in your systemd / launchd service definition.
 
-While NanoClaw avoids config files, it does support a minimal `.env` file for secrets and deployment settings:
+## Per-wiring behavior (engage mode, sender scope, session mode)
 
-```bash
-# .env
-ASSISTANT_NAME=Andy
-ASSISTANT_HAS_OWN_NUMBER=false
-ANTHROPIC_API_KEY=sk-ant-...
-MAX_CONCURRENT_CONTAINERS=5
-IDLE_TIMEOUT=1800000
-CONTAINER_TIMEOUT=1800000
-```
+Every messaging group × agent group wiring (stored in `messaging_group_agents`) has orthogonal settings:
 
-### Environment variable precedence
+| Setting | Values | Meaning |
+|---|---|---|
+| `engage_mode` | `mention` (default) \| `pattern` \| `mention-sticky` | When the agent reacts: trigger-only, regex match, or trigger-and-then-sticky |
+| `engage_pattern` | regex string | Used when `engage_mode='pattern'`. Sentinel `.` means "match every message" |
+| `sender_scope` | `all` (default) \| `known` | Respond to anyone vs. only users in the agent group's member list |
+| `ignored_message_policy` | `drop` (default) \| `accumulate` | What happens to messages that didn't trigger — forgotten, or carried into the next prompt |
+| `session_mode` | `shared` (default) \| `per-thread` \| `agent-shared` | How sessions are carved: one per messaging group, one per thread, or one across multiple messaging groups |
+
+Change them with the `/manage-channels` skill — it reads/writes the wiring directly without requiring SQL.
+
+## Polling and delivery loops (source-verified)
+
+If you need to tune the delivery cadence, the constants live in `src/delivery.ts` and `src/host-sweep.ts`:
 
 ```typescript
-// From src/config.ts
-export const ASSISTANT_NAME =
-  process.env.ASSISTANT_NAME || envConfig.ASSISTANT_NAME || 'Andy';
-export const ASSISTANT_HAS_OWN_NUMBER =
-  (process.env.ASSISTANT_HAS_OWN_NUMBER ||
-    envConfig.ASSISTANT_HAS_OWN_NUMBER) === 'true';
+// src/delivery.ts
+const ACTIVE_POLL_MS = 1000;    // running sessions checked every 1s
+const SWEEP_POLL_MS = 60_000;   // liveness/recovery sweep every 60s
+
+// src/host-sweep.ts
+const SWEEP_INTERVAL_MS = 60_000;
+export const CLAIM_STUCK_MS = 60 * 1000;
+export const ABSOLUTE_CEILING_MS = 30 * 60 * 1000;
 ```
 
-1. `process.env` (runtime environment variables)
-2. `.env` file values
-3. Hardcoded defaults
+Most users never change these. If you do, remember: tighter active-poll = more CPU for idle-but-active sessions; looser sweep = slower stuck-detection.
 
-## Key configuration files
+## Memory and per-agent-group prompts
 
-### src/config.ts
-
-The main configuration file:
-
-```typescript
-// Trigger pattern
-export const ASSISTANT_NAME = 'Andy';
-export const TRIGGER_PATTERN = new RegExp(
-  `^@${escapeRegex(ASSISTANT_NAME)}\\b`,
-  'i',
-);
-
-// Polling intervals
-export const POLL_INTERVAL = 2000;
-export const SCHEDULER_POLL_INTERVAL = 60000;
-
-// Container settings
-export const CONTAINER_IMAGE = 'nanoclaw-agent:latest';
-export const CONTAINER_TIMEOUT = 1800000;
-export const IDLE_TIMEOUT = 1800000;
-export const MAX_CONCURRENT_CONTAINERS = 5;
-
-// Paths
-export const GROUPS_DIR = path.resolve(PROJECT_ROOT, 'groups');
-export const DATA_DIR = path.resolve(PROJECT_ROOT, 'data');
-
-// Timezone (validated IANA identifier; falls back to UTC)
-export const TIMEZONE = resolveConfigTimezone();
-```
-
-See the full file at `src/config.ts`.
-
-### groups/main/CLAUDE.md
-
-Memory for the main channel (your private self-chat). Edit this to change the agent's behavior:
+Agent-group memory lives in `groups/<folder>/CLAUDE.md`. Edit it to change the agent's persona, style, or pinned context:
 
 ```markdown
 # NanoClaw Assistant
 
-You are Andy, a helpful AI assistant...
+You are Andy, a helpful AI assistant.
 
 ## Preferences
 
@@ -198,156 +148,11 @@ You are Andy, a helpful AI assistant...
 - Always confirm before making changes
 ```
 
-### .claude/settings.json
+`CLAUDE.md` is composed at session start — a shared base plus the per-group fragment. Per-group changes don't affect other agent groups.
 
-Per-group Claude Code settings (auto-generated):
+## Mount allowlist
 
-```json
-{
-  "env": {
-    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
-    "CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD": "1",
-    "CLAUDE_CODE_DISABLE_AUTO_MEMORY": "0"
-  }
-}
-```
-
-Generated in `src/container-runner.ts` during the `buildVolumeMounts` function.
-
-## Customization workflow
-
-<Steps>
-  <Step title="Identify what to change">
-    Describe what you want in natural language:
-    
-    ```
-    I want the agent to respond faster
-    ```
-  </Step>
-  
-  <Step title="Ask Claude Code">
-    Either:
-    - Tell Claude directly: `"Reduce the polling interval to 1 second"`
-    - Use guided mode: `/customize`
-  </Step>
-  
-  <Step title="Review changes">
-    Claude shows you the diff before applying:
-    
-    ```diff
-    - export const POLL_INTERVAL = 2000;
-    + export const POLL_INTERVAL = 1000;
-    ```
-  </Step>
-  
-  <Step title="Test and iterate">
-    Run NanoClaw and verify the change works as expected
-  </Step>
-</Steps>
-
-## The /customize skill
-
-Run `/customize` for guided customization:
-
-```
-/customize
-```
-
-Claude will ask:
-- What channel you want to add (WhatsApp, Telegram, Discord, etc.)
-- What integrations you need (Gmail, Calendar, etc.)
-- How you want to change behavior
-- What features to modify
-
-## Adding channels
-
-Channels are added via skills, not by modifying core code:
-
-```
-/add-telegram
-/add-slack
-/add-discord
-```
-
-Each skill teaches Claude how to transform your NanoClaw installation to support that channel.
-
-<Warning>
-**Don't add features via PRs.**
-
-Contribute skills instead. This keeps the base system minimal and lets users customize cleanly.
-</Warning>
-
-## Adding integrations
-
-Same pattern - use skills:
-
-```
-/add-gmail
-/add-calendar
-/add-notion
-```
-
-The skill modifies your codebase to add the integration.
-
-## Mount configuration
-
-Control what directories agents can access:
-
-### Main channel
-
-Gets read-only access to the project root:
-
-```typescript
-// From src/container-runner.ts — main group mounts
-if (isMain) {
-  mounts.push({
-    hostPath: projectRoot,
-    containerPath: '/workspace/project',
-    readonly: true,
-  });
-
-  // Store mounted read-write so the main agent can
-  // query and write to the SQLite database directly
-  mounts.push({
-    hostPath: path.join(projectRoot, 'store'),
-    containerPath: '/workspace/project/store',
-    readonly: false,
-  });
-  
-  mounts.push({
-    hostPath: groupDir,
-    containerPath: '/workspace/group',
-    readonly: false,
-  });
-}
-```
-
-### Other channels
-
-Only get their own group folder:
-
-```typescript
-// From src/container-runner.ts — non-main group mounts
-mounts.push({
-  hostPath: groupDir,
-  containerPath: '/workspace/group',
-  readonly: false,
-});
-```
-
-### Mount allowlist
-
-Groups can request additional mounts via `containerConfig.additionalMounts` in their registration:
-
-```typescript
-containerConfig: {
-  additionalMounts: [
-    { hostPath: '/Users/you/Documents/vault', readonly: true }
-  ]
-}
-```
-
-Requests are validated against `~/.config/nanoclaw/mount-allowlist.json`:
+Agents only see what you mount. The allowlist lives at `~/.config/nanoclaw/mount-allowlist.json` (outside the project root, never mounted into containers):
 
 ```json
 {
@@ -368,84 +173,68 @@ Requests are validated against `~/.config/nanoclaw/mount-allowlist.json`:
 }
 ```
 
-See `src/mount-security.ts` for validation logic.
+Per-agent-group mount requests live in `groups/<folder>/container.json`. The host validates each request against the allowlist before mounting. See [Security model](/advanced/security-model) for the full picture.
+
+## The `/customize` skill
+
+For guided changes without memorizing file paths:
+
+```
+/customize
+```
+
+Claude Code asks what you want to change — trigger, behavior, integrations, mounts — and applies the diff after showing it to you.
+
+## Adding channels, providers, and features
+
+Channels and AI providers are skills, not core features. Install from the `channels` or `providers` branch:
+
+```
+/add-telegram       # channel
+/add-codex          # alternate provider (OpenAI)
+/add-ollama-provider  # alternate provider (local models)
+```
+
+See [Integrations overview](/integrations/overview) for the full list.
+
+To remove a channel or provider, `git revert` the skill's commit — restores the previous state cleanly.
+
+## Customization workflow
+
+<Steps>
+  <Step title="Describe what you want">
+    Natural language — `@Andy I want the agent to respond to every message, not just mentions` — works fine.
+  </Step>
+
+  <Step title="Claude suggests the change">
+    For wiring changes: `/manage-channels` + update `engage_mode`. For code changes: a diff against `src/config.ts` or elsewhere.
+  </Step>
+
+  <Step title="Review the diff">
+    Claude shows the exact lines before applying.
+  </Step>
+
+  <Step title="Test">
+    Run NanoClaw, verify the change works. If not: `/debug`.
+  </Step>
+</Steps>
 
 ## Debugging customizations
 
-If a customization doesn't work:
-
-### Check logs
-
 ```bash
-tail -f groups/main/logs/agent.log
+tail -f logs/nanoclaw.log
 ```
 
-### Ask Claude Code
+Or ask the agent itself:
 
 ```
-Why isn't the polling interval change working?
-Show me the current value of POLL_INTERVAL
+@Andy why did my engage mode change not take effect?
+@Andy /debug
 ```
 
-### Use the /debug skill
+## Related
 
-```
-/debug
-```
-
-Claude will:
-- Check recent logs
-- Verify configuration values
-- Identify common issues
-- Suggest fixes
-
-## Contributing customizations
-
-If your customization would benefit others, contribute it as a skill:
-
-- **Feature skills** (code changes): Branch from `main`, make your code changes, and submit a PR. Maintainers will create a `skill/<name>` branch and add the SKILL.md to the marketplace.
-- **Utility skills** (standalone tools): Create `.claude/skills/{name}/` with a SKILL.md and code files, then submit a PR to `main`.
-- **Operational skills** (workflows, guides): Create `.claude/skills/{name}/SKILL.md` and submit a PR to `main`.
-- **Container skills** (agent runtime): Create `container/skills/{name}/SKILL.md` and submit a PR to `main`.
-
-**Don't submit PRs that add features to the core codebase.** Only bug fixes, security fixes, and clear improvements are accepted.
-
-## Advanced: Direct code modification
-
-For complex customizations, you can modify the code directly:
-
-### Example: Custom message filtering
-
-Add logic to filter messages before processing:
-
-```typescript
-// src/index.ts (in processGroupMessages)
-const missedMessages = getMessagesSince(
-  chatJid,
-  sinceTimestamp,
-  ASSISTANT_NAME,
-).filter(m => {
-  // Custom filter: ignore messages from specific users
-  return !m.sender_name.includes('spam');
-});
-```
-
-### Example: Custom IPC handlers
-
-Add new IPC message types:
-
-```typescript
-// src/ipc.ts (in processTaskIpc)
-case 'custom_action':
-  if (data.customData) {
-    // Your custom logic here
-    logger.info({ data }, 'Custom action received');
-  }
-  break;
-```
-
-## Related documentation
-
-- [Messaging](/features/messaging) - Customize trigger patterns
-- [Scheduled tasks](/features/scheduled-tasks) - Customize task behavior
-- [Agent Swarms](/features/agent-swarms) - Adjust container limits for swarms
+- [Messaging](/features/messaging) — inbound routing and engage evaluation
+- [Scheduled tasks](/features/scheduled-tasks) — task model and cron
+- [Security](/concepts/security) — sender policies, user roles
+- [Architecture](/concepts/architecture) — two-DB session model

--- a/features/messaging.mdx
+++ b/features/messaging.mdx
@@ -1,12 +1,18 @@
 ---
 title: Message handling and routing
-description: Learn how NanoClaw processes messages, triggers agent responses, and routes communication across channels
+description: Every message is a row in an inbox, every response a row in an outbox — the pattern that drives channels, scheduling, and agent-to-agent routing.
 tag: "UPDATED"
+keywords: ["messaging", "inbox", "outbox", "routing", "engage modes", "session db"]
 ---
 
-## Overview
+## The inbox/outbox model
 
-In v2, NanoClaw processes messages through an event-driven adapter architecture. Channel adapters receive messages and route them through a centralized inbound router that evaluates engage modes, resolves senders, and fans out to wired agents. Responses flow back through a delivery system that polls session databases.
+Every agent session has two SQLite files:
+
+- **`inbound.db`** — anything the agent needs to see. User messages, webhooks, scheduled tasks when they come due, agent-to-agent requests. The host writes; the container reads.
+- **`outbound.db`** — anything the agent wants to do. Replies, tool calls, schedule requests, sub-agent spawns. The container writes; the host reads.
+
+One writer per file means no SQLite cross-mount contention, no stdin piping, no IPC coordination layer. Every inbound source uses the same `messages_in` table; every outbound action uses the same `messages_out` table. Scheduling, channels, and agent-to-agent routing are the same pattern with different metadata.
 
 ## Message flow
 
@@ -113,18 +119,12 @@ Container concurrency is managed globally:
 
 ## Channel routing
 
-NanoClaw supports multiple messaging channels through a unified adapter interface. Each adapter registers `onInbound`, `onInboundEvent`, `onMetadata`, and `onAction` callbacks.
+Every channel is a thin adapter over [Vercel's Chat SDK](https://chat-sdk.dev/docs/adapters). Adapters implement the same four callbacks (`onInbound`, `onInboundEvent`, `onMetadata`, `onAction`), so routing, fan-out, and delivery don't know or care which platform a message came from.
 
-### Supported channels
-
-- WhatsApp (via `/add-whatsapp` skill)
-- Telegram (via `/add-telegram` skill)
-- Discord (via `/add-discord` skill)
-- Slack (via `/add-slack` skill)
-- Gmail (via `/add-gmail` skill)
+15+ adapters live on the `channels` branch (Discord, Slack, Telegram, Teams, Google Chat, WhatsApp, Matrix, iMessage, GitHub, Linear, and more). Install one per fork with `/add-<name>`. See the [integrations overview](/integrations/overview) for the full list.
 
 <Warning>
-Channels are added via skills, not configuration files. Use `/add-telegram` or similar skills to add new channels. See the [integrations overview](/integrations/overview).
+Channels are installed as skills, not configured through env vars or files. Use `/add-telegram`, `/add-discord`, etc. to copy an adapter module into your fork.
 </Warning>
 
 ## Delivery system
@@ -156,6 +156,6 @@ When a message arrives on an unwired channel (no agent wirings exist):
 
 ## Related documentation
 
-- [Scheduled tasks](/features/scheduled-tasks) — automate recurring agent tasks
-- [Agent Swarms](/features/agent-swarms) — multi-agent collaboration
-- [Customization](/features/customization) — modify trigger patterns and behavior
+- [Scheduled tasks](/features/scheduled-tasks) — a scheduled task is a message row with a timestamp
+- [Integrations overview](/integrations/overview) — channels and providers available as skills
+- [Customization](/features/customization) — modify trigger patterns, engage modes, and delivery polling

--- a/features/scheduled-tasks.mdx
+++ b/features/scheduled-tasks.mdx
@@ -1,12 +1,15 @@
 ---
 title: Setting up scheduled tasks
-description: Set up recurring and one-time tasks with cron expressions or specific timestamps
+description: A scheduled task is a message with a timestamp — same inbox, same flow, same tools as any other message.
 tag: "UPDATED"
+keywords: ["scheduled tasks", "cron", "recurring", "process_after", "series_id", "scripts"]
 ---
 
 ## Overview
 
-NanoClaw's task scheduler runs agents on a schedule, allowing you to automate recurring tasks like daily reports, weekly summaries, or periodic checks. In v2, tasks are stored as messages in the session database and managed through MCP tools.
+v2 has no separate task scheduler. A scheduled task is a row in `messages_in` with a `process_after` timestamp (and optionally a `recurrence` cron expression). The host sweep runs every 60 seconds, finds rows whose time has come, wakes the session's container, and the agent picks it up like any other inbound message.
+
+That means everything scheduled — daily briefings, weekly reports, per-hour polls, one-time reminders — goes through the same pipeline as a user message. You only learn one model.
 
 ## Task types
 
@@ -198,6 +201,5 @@ If a task fails:
 
 ## Related documentation
 
-- [Messaging](/features/messaging) — how messages trigger agent responses
-- [Agent Swarms](/features/agent-swarms) — use multiple agents in scheduled tasks
-- [Customization](/features/customization) — modify task behavior
+- [Messaging](/features/messaging) — the inbox/outbox pattern that scheduling rides on
+- [Customization](/features/customization) — sweep interval, timezone, and concurrency

--- a/installation.mdx
+++ b/installation.mdx
@@ -1,674 +1,331 @@
 ---
 title: Installation
-description: Detailed installation requirements and setup for macOS, Linux, and Windows (WSL)
+description: Requirements and platform-specific setup for macOS, Linux, and Windows (WSL2).
 icon: "download"
-keywords: ["requirements", "docker", "node", "apple container", "windows", "wsl", "onecli"]
+tag: "UPDATED"
+keywords: ["requirements", "docker", "node", "apple container", "wsl", "onecli", "bun", "nanoclaw.sh"]
 ---
 
-# Installation
-
-Complete installation guide for NanoClaw on macOS, Linux, and Windows (WSL).
+Everything you need to know before running `bash nanoclaw.sh`. For the one-command install flow itself, see [Quick start](/quickstart).
 
 ## System requirements
 
-### Operating system
-
 <Tabs>
   <Tab title="macOS">
-    - macOS 11 (Big Sur) or later
-    - Intel or Apple Silicon (M1/M2/M3)
-    - 4GB RAM minimum, 8GB recommended
-    - 2GB free disk space
+    - macOS 12 (Monterey) or later
+    - Intel or Apple Silicon (M1/M2/M3/M4)
+    - 4 GB RAM minimum, 8 GB recommended
+    - 4 GB free disk space (container image + node_modules)
   </Tab>
 
   <Tab title="Linux">
-    - Ubuntu 20.04+, Debian 11+, or equivalent
-    - x86_64 architecture
-    - 2GB RAM minimum, 4GB recommended
-    - 2GB free disk space
-    - systemd (for service management)
+    - Ubuntu 22.04+, Debian 12+, or equivalent
+    - x86_64 or aarch64
+    - 2 GB RAM minimum, 4 GB recommended
+    - 4 GB free disk space
+    - systemd (for the user service)
   </Tab>
 
-  <Tab title="Windows (WSL)">
-    - Windows 10 version 2004+ or Windows 11
-    - WSL 2 with Ubuntu 20.04+ (recommended)
-    - 4GB RAM minimum, 8GB recommended
-    - 2GB free disk space (inside WSL filesystem)
+  <Tab title="Windows (WSL2)">
+    - Windows 10 2004+ or Windows 11
+    - WSL 2 with Ubuntu 22.04+
+    - 4 GB RAM minimum, 8 GB recommended
+    - 4 GB free disk space (inside the WSL filesystem)
     - Docker Desktop with WSL 2 backend enabled
 
     <Note>
-    NanoClaw runs inside WSL, not natively on Windows. All commands should be run in a WSL terminal.
+    NanoClaw runs inside WSL, not natively on Windows. All commands go in a WSL terminal.
     </Note>
   </Tab>
 </Tabs>
 
-## Prerequisites
+## What the installer needs
 
-### 1. Node.js 20 or later
+`nanoclaw.sh` installs most things for you. This list exists so you know the dependency surface before running it.
 
-NanoClaw requires Node.js 20 or later.
+| Dependency | Scope | Installer handles it? |
+|---|---|---|
+| Node 22 | Host (orchestrator) | Yes — via nvm if missing |
+| pnpm 10 | Host (package manager) | Yes — via `corepack enable` |
+| Docker (or Apple Container) | Host (container runtime) | Partial — prompts you to install if absent |
+| Build tools (gcc, python3) | Host (for `better-sqlite3` native compile) | No — install beforehand |
+| OneCLI Agent Vault | Host (credential injection) | Yes — via `/init-onecli` step |
+| Bun 1.3.12 | Container (agent-runner runtime) | Yes — baked into the agent container image |
 
-<Tabs>
-  <Tab title="macOS">
-    **Using Homebrew** (recommended):
-    ```bash
-    brew install node@22
-    ```
+### Build tools
 
-    **Using nvm**:
-    ```bash
-    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
-    nvm install 22
-    nvm use 22
-    ```
-
-    Verify installation:
-    ```bash
-    node --version  # Should show v20.x or higher
-    ```
-  </Tab>
-  
-  <Tab title="Linux">
-    **Using NodeSource**:
-    ```bash
-    curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
-    sudo apt-get install -y nodejs
-    ```
-
-    **Using nvm**:
-    ```bash
-    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
-    nvm install 22
-    nvm use 22
-    ```
-
-    Verify installation:
-    ```bash
-    node --version  # Should show v20.x or higher
-    ```
-  </Tab>
-
-  <Tab title="Windows (WSL)">
-    Inside your WSL terminal, use **nvm** (recommended):
-    ```bash
-    curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | bash
-    source ~/.bashrc
-    nvm install 22
-    nvm use 22
-    ```
-
-    Verify installation:
-    ```bash
-    node --version  # Should show v20.x or higher
-    ```
-  </Tab>
-</Tabs>
-
-### 2. Claude Code
-
-Claude Code is required to run the `/setup` command and customize NanoClaw.
-
-Download from: [claude.ai/download](https://claude.ai/download)
+`better-sqlite3` is the only host dependency that needs native compilation. Install the platform toolchain before running `nanoclaw.sh`:
 
 <Tabs>
   <Tab title="macOS">
-    1. Download Claude Code for macOS
-    2. Open the DMG file
-    3. Drag Claude Code to Applications
-    4. Launch Claude Code
-    5. Sign in with your Anthropic account
-
-    Verify installation:
-    ```bash
-    claude --version
-    ```
-  </Tab>
-  
-  <Tab title="Linux">
-    1. Download Claude Code for Linux (.deb or .AppImage)
-    2. Install the package:
-       ```bash
-       sudo dpkg -i claude-code_*.deb
-       # or run the AppImage directly
-       ```
-    3. Launch Claude Code
-    4. Sign in with your Anthropic account
-
-    Verify installation:
-    ```bash
-    claude --version
-    ```
-  </Tab>
-
-  <Tab title="Windows (WSL)">
-    Install Claude Code inside WSL using npm:
-    ```bash
-    npm install -g @anthropic-ai/claude-code
-    ```
-
-    Verify installation:
-    ```bash
-    claude --version
-    ```
-  </Tab>
-</Tabs>
-
-<Info>
-You need a Claude Pro or Claude Team subscription, or an Anthropic API key.
-</Info>
-
-### 3. Container runtime
-
-Agents run in isolated containers. You need either Apple Container (macOS only) or Docker.
-
-<Tabs>
-  <Tab title="Apple Container (macOS)">
-    Apple Container is a lightweight, native macOS container runtime.
-
-    **Installation**:
-    ```bash
-    brew install container
-    ```
-
-    **Verify**:
-    ```bash
-    container --version
-    ```
-
-    **Benefits**:
-    - Native macOS integration
-    - Lighter resource usage than Docker
-    - Faster startup times
-
-    <Note>
-    Apple Container is macOS-only. During setup, you can choose between Apple Container and Docker. Docker is the default and works on macOS, Linux, and Windows (via WSL2).
-    </Note>
-  </Tab>
-  
-  <Tab title="Docker">
-    Docker is the default container runtime and works on macOS, Linux, and Windows (via WSL2).
-
-    **macOS**:
-    ```bash
-    # Using Homebrew
-    brew install --cask docker
-
-    # Start Docker Desktop
-    open -a Docker
-    ```
-
-    **Linux**:
-    ```bash
-    # Install Docker
-    curl -fsSL https://get.docker.com | sh
-
-    # Add your user to the docker group
-    sudo usermod -aG docker $USER
-
-    # Start Docker service
-    sudo systemctl start docker
-    sudo systemctl enable docker
-
-    # Log out and back in for group changes to take effect
-    ```
-
-    **Verify**:
-    ```bash
-    docker --version
-    docker info
-    ```
-
-    <Warning>
-    On Linux, after adding yourself to the docker group, you must log out and back in for the changes to take effect.
-    </Warning>
-  </Tab>
-
-  <Tab title="Windows (WSL) — Docker Desktop">
-    WSL uses Docker Desktop's WSL 2 backend.
-
-    1. Install [Docker Desktop for Windows](https://docs.docker.com/desktop/install/windows-install/)
-    2. Open Docker Desktop Settings > Resources > WSL Integration
-    3. Enable integration with your WSL distro (e.g., Ubuntu)
-    4. Verify from inside WSL:
-       ```bash
-       docker --version
-       docker info
-       ```
-
-    <Warning>
-    Do not install Docker Engine inside WSL directly — use Docker Desktop's WSL 2 backend. Installing both causes conflicts.
-    </Warning>
-  </Tab>
-</Tabs>
-
-### 4. Build tools (for native modules)
-
-NanoClaw uses `better-sqlite3`, which requires native compilation.
-
-<Tabs>
-  <Tab title="macOS">
-    Install Xcode Command Line Tools:
     ```bash
     xcode-select --install
     ```
-
-    Verify:
-    ```bash
-    gcc --version
-    ```
   </Tab>
-  
+
   <Tab title="Linux">
-    Install build essentials:
     ```bash
     sudo apt-get update
     sudo apt-get install -y build-essential python3
-    ```
-
-    Verify:
-    ```bash
-    gcc --version
-    python3 --version
     ```
   </Tab>
 
-  <Tab title="Windows (WSL)">
-    Same as Linux — run inside your WSL terminal:
+  <Tab title="Windows (WSL2)">
+    Same as Linux, inside your WSL terminal:
     ```bash
     sudo apt-get update
     sudo apt-get install -y build-essential python3
-    ```
-
-    Verify:
-    ```bash
-    gcc --version
-    python3 --version
     ```
   </Tab>
 </Tabs>
 
-### 5. OneCLI (v1.2.35+)
+### Container runtime
 
-Starting in v1.2.35, NanoClaw uses OneCLI Agent Vault for credential management. OneCLI is a local vault that injects API keys into container traffic without exposing secrets.
-
-```bash
-curl -fsSL onecli.sh/install | sh
-curl -fsSL onecli.sh/cli/install | sh
-```
-
-Verify installation:
-```bash
-onecli version
-```
-
-Run `onecli --help` to see all available commands for managing secrets and vault configuration.
-
-<Info>
-OneCLI is also installed automatically by the `/setup` skill if not already present. It's listed here so you know about the dependency upfront.
-</Info>
-
-<Note>
-**What `/setup` handles for you:** OneCLI installation, npm dependencies, container image build, channel configuration, and service setup. **What you need beforehand:** Node.js, Claude Code, a container runtime, and build tools.
-</Note>
-
-## Installation steps
-
-Once all prerequisites are installed:
-
-<Steps>
-  <Step title="Fork and clone the repository">
-    Fork [qwibitai/nanoclaw](https://github.com/qwibitai/nanoclaw) on GitHub, then clone your fork:
-
-    ```bash
-    git clone https://github.com/<you>/nanoclaw.git
-    cd nanoclaw
-    ```
-
-    <Info>
-    Forking gives you a remote to push your customizations to. A plain `git clone` works for trying things out — you can migrate to a fork later.
-    </Info>
-
-    <Warning>
-    **WSL users**: Clone into the Linux filesystem (`~/nanoclaw`), not the Windows mount (`/mnt/c/...`). File operations on `/mnt/c/` are significantly slower due to the 9P filesystem bridge.
-    </Warning>
-  </Step>
-
-  <Step title="Launch Claude Code">
-    ```bash
-    claude
-    ```
-  </Step>
-
-  <Step title="Run setup">
-    In Claude Code:
-    ```
-    /setup
-    ```
-
-    Claude will handle dependencies, container setup, marketplace plugin installation, and channel configuration automatically.
-
-    At the end of setup, you'll be asked about **opt-in diagnostics**. NanoClaw can send anonymized system info (version, OS, architecture, node version, channels selected) to help improve the project. You can choose **Yes**, **No**, or **Never ask again**. No personally identifiable information is collected.
-  </Step>
-</Steps>
-
-See the [Quick start guide](/quickstart) for detailed setup instructions.
-
-## Docker sandbox one-liner
-
-If you just want NanoClaw's Docker sandboxes without the full setup:
+Docker is the default and works on all three platforms. Apple Container is an opt-in alternative on macOS 15+.
 
 <Tabs>
-  <Tab title="macOS / Linux">
+  <Tab title="Docker (default)">
+    **macOS:**
     ```bash
-    curl -fsSL https://nanoclaw.dev/install-docker-sandboxes.sh | bash
+    brew install --cask docker
+    open -a Docker
     ```
+
+    **Linux:**
+    ```bash
+    curl -fsSL https://get.docker.com | sh
+    sudo usermod -aG docker $USER
+    sudo systemctl enable --now docker
+    # Log out and back in for group membership to take effect
+    ```
+
+    **Windows (WSL2):** Install [Docker Desktop](https://docs.docker.com/desktop/install/windows-install/), then enable WSL integration in Settings → Resources → WSL Integration for your distro.
+
+    <Warning>
+    WSL users: do not install Docker Engine inside WSL directly. Use Docker Desktop's WSL 2 backend. Installing both causes conflicts.
+    </Warning>
   </Tab>
 
-  <Tab title="Windows (WSL)">
+  <Tab title="Apple Container (macOS 15+)">
+    Lightweight native macOS runtime. Opt-in after setup via `/convert-to-apple-container`.
+
     ```bash
-    curl -fsSL https://nanoclaw.dev/install-docker-sandboxes-windows.sh | bash
+    brew install container
+    container --version
     ```
+
+    <Note>
+    The default installer picks Docker. To switch, run `/convert-to-apple-container` after NanoClaw is running. The skill modifies `src/container-runtime.ts`, adjusts mount syntax and stop commands, and handles credential proxy networking if you're using the legacy proxy skill.
+    </Note>
   </Tab>
 </Tabs>
 
-## Package dependencies
+## Run the installer
 
-NanoClaw uses these core dependencies (from `package.json`):
-
-```json
-{
-  "dependencies": {
-    "@onecli-sh/sdk": "^0.2.0",    // OneCLI Agent Vault integration (v1.2.35+)
-    "better-sqlite3": "11.10.0",   // SQLite database
-    "cron-parser": "5.5.0"         // Task scheduling
-  }
-}
-```
-
-<Note>
-Channel-specific dependencies (e.g., `@whiskeysockets/baileys` for WhatsApp, `grammy` for Telegram) are added when you install a channel skill. Only core dependencies ship on `main`.
-</Note>
-
-<Info>
-All dependencies are installed automatically by `/setup` via `npm install`.
-</Info>
-
-## Container image
-
-The agent container includes:
-
-- **Base**: Node.js 22 (Debian slim)
-- **Browser**: Chromium with CJK and emoji font support
-- **Claude Agent SDK**: `@anthropic-ai/claude-code` (pre-installed)
-- **Tools**: `agent-browser`, bash, git, curl
-- **User**: Non-root `node` user (uid 1000)
-
-The container is built during setup:
+Once the system dependencies above are in place:
 
 ```bash
-./container/build.sh
+git clone https://github.com/qwibitai/nanoclaw.git
+cd nanoclaw
+bash nanoclaw.sh
 ```
 
-This creates the `nanoclaw-agent` image.
+The installer walks through bootstrap, container build, OneCLI credential registration, channel pairing, and service installation. Progress streams to your terminal; full per-step logs land in `logs/setup.log` and `logs/setup-steps/`.
 
-## File structure
+For the step-by-step breakdown of what each phase does, see [Quick start](/quickstart).
 
-After installation, NanoClaw creates:
+## File structure after install
 
 <Tree>
-  <Tree.Folder name="NanoClaw" defaultOpen>
-    <Tree.Folder name="src" />
-    <Tree.Folder name="dist" />
-    <Tree.Folder name="container" />
+  <Tree.Folder name="nanoclaw" defaultOpen>
+    <Tree.Folder name="src">
+      <Tree.File name="index.ts" />
+      <Tree.File name="session-manager.ts" />
+      <Tree.File name="container-runner.ts" />
+      <Tree.Folder name="db" />
+      <Tree.Folder name="channels" />
+    </Tree.Folder>
+    <Tree.Folder name="container">
+      <Tree.File name="Dockerfile" />
+      <Tree.File name="entrypoint.sh" />
+      <Tree.Folder name="agent-runner" />
+    </Tree.Folder>
     <Tree.Folder name="groups" defaultOpen>
       <Tree.Folder name="main" defaultOpen>
         <Tree.File name="CLAUDE.md" />
-        <Tree.Folder name="logs" />
+        <Tree.File name="container.json" />
       </Tree.Folder>
     </Tree.Folder>
-    <Tree.Folder name="store" defaultOpen>
-      <Tree.File name="messages.db" />
-      <Tree.Folder name="auth" />
+    <Tree.Folder name="store">
+      <Tree.File name="v2.db" />
     </Tree.Folder>
     <Tree.Folder name="data" defaultOpen>
-      <Tree.Folder name="sessions" />
+      <Tree.Folder name="v2-sessions" defaultOpen>
+        <Tree.Folder name="{agent_group_id}" defaultOpen>
+          <Tree.Folder name="{session_id}" defaultOpen>
+            <Tree.File name="inbound.db" />
+            <Tree.File name="outbound.db" />
+            <Tree.File name=".heartbeat" />
+          </Tree.Folder>
+        </Tree.Folder>
+      </Tree.Folder>
     </Tree.Folder>
-    <Tree.Folder name="logs" defaultOpen>
+    <Tree.Folder name="logs">
       <Tree.File name="nanoclaw.log" />
-      <Tree.File name="nanoclaw.error.log" />
+      <Tree.File name="setup.log" />
+      <Tree.Folder name="setup-steps" />
     </Tree.Folder>
     <Tree.File name=".env" />
+    <Tree.File name="nanoclaw.sh" />
     <Tree.File name="package.json" />
   </Tree.Folder>
 </Tree>
 
-**External files**:
-- `~/.config/nanoclaw/mount-allowlist.json` - Mount permissions
-- `~/.config/nanoclaw/sender-allowlist.json` - Sender access control (optional)
-- `~/Library/LaunchAgents/com.nanoclaw.plist` (macOS) - Service config
-- `~/.config/systemd/user/nanoclaw.service` (Linux/WSL with systemd) - Service config
+**External files** (outside the project directory):
+
+| Path | Purpose |
+|------|---------|
+| `~/.config/nanoclaw/mount-allowlist.json` | Which host directories agents can mount |
+| `~/.config/nanoclaw/sender-allowlist.json` | Optional per-channel sender access control |
+| `~/Library/LaunchAgents/com.nanoclaw.plist` (macOS) | launchd service definition |
+| `~/.config/systemd/user/nanoclaw.service` (Linux) | systemd user-service definition |
+
+## Container image contents
+
+The agent container (`nanoclaw-agent:latest`) is built from `container/Dockerfile`:
+
+- **Base**: `node:22-slim`
+- **tini** as PID 1 — reaps Chromium zombies, forwards signals so `outbound.db` writes finalize on SIGTERM
+- **Bun 1.3.12** runs the agent-runner TypeScript directly (no `tsc` build step)
+- **Chromium** for browser automation via `agent-browser`
+- **Global Node CLIs (pnpm)**: `@anthropic-ai/claude-code`, `agent-browser`, `vercel`
+- **Non-root `node` user**, `/workspace/group` as working directory
+- **Source is never baked in** — `/app/src` is a read-only bind mount from the host, so code changes take effect without rebuilding
+
+Optional: `INSTALL_CJK_FONTS=true` in `.env` adds Chinese/Japanese/Korean font support (~200 MB).
 
 ## Service management
 
-NanoClaw runs as a background service:
+NanoClaw runs as a background service so the host stays responsive to channel events between your messages.
 
 <Tabs>
   <Tab title="macOS (launchd)">
     ```bash
-    # Start service
+    # Start / stop
     launchctl load ~/Library/LaunchAgents/com.nanoclaw.plist
-
-    # Stop service
     launchctl unload ~/Library/LaunchAgents/com.nanoclaw.plist
 
-    # Restart service
+    # Restart
     launchctl kickstart -k gui/$(id -u)/com.nanoclaw
 
-    # Check status
+    # Status
     launchctl list | grep nanoclaw
 
-    # View logs
-    tail -f ~/workspace/NanoClaw/logs/nanoclaw.log
+    # Logs
+    tail -f logs/nanoclaw.log
     ```
   </Tab>
-  
+
   <Tab title="Linux (systemd)">
     ```bash
-    # Start service
     systemctl --user start nanoclaw
-
-    # Stop service
     systemctl --user stop nanoclaw
-
-    # Restart service
     systemctl --user restart nanoclaw
-
-    # Check status
     systemctl --user status nanoclaw
 
     # Enable on boot
     systemctl --user enable nanoclaw
 
-    # View logs
+    # Logs
     journalctl --user -u nanoclaw -f
     ```
 
     <Note>
-      **VM / SSH users:** The setup script automatically runs `loginctl enable-linger` for non-root users so the service keeps running after you disconnect from SSH. If linger is not enabled, systemd terminates all user processes when the last session closes. You can verify with `loginctl show-user $USER | grep Linger`.
+    **VM / SSH users:** the installer runs `loginctl enable-linger` so the service survives SSH logout. Verify with `loginctl show-user $USER | grep Linger`.
     </Note>
   </Tab>
-  
+
   <Tab title="WSL (without systemd)">
-    If your WSL doesn't have systemd enabled:
+    If WSL doesn't have systemd enabled, the installer drops a wrapper script:
 
     ```bash
-    # Start service
     bash start-nanoclaw.sh
-
-    # Stop service
-    pkill -f "node dist/index.js"
-
-    # View logs
-    tail -f logs/nanoclaw.log
+    pkill -f "bun.*src/index.ts"     # stop
+    tail -f logs/nanoclaw.log        # logs
     ```
 
-    To enable systemd in WSL:
+    To enable systemd in WSL (recommended):
     ```bash
     echo -e "[boot]\nsystemd=true" | sudo tee /etc/wsl.conf
-    # Restart WSL
+    # Restart WSL from PowerShell: wsl --shutdown
     ```
   </Tab>
 </Tabs>
 
-## Verification
-
-Verify your installation:
-
-```bash
-# Check service is running
-# macOS
-launchctl list | grep nanoclaw
-
-# Linux
-systemctl --user status nanoclaw
-
-# Check logs
-tail -f logs/nanoclaw.log
-
-# Test database
-node -e "const db=require('./dist/db.js');console.log(db.getAllRegisteredGroups())"
-```
-
-Or ask Claude Code:
-```
-/debug
-```
-
 ## Troubleshooting
 
-### Node.js native module errors
+### `better-sqlite3` build errors
 
 ```bash
-# Rebuild native modules
-npm rebuild
-
-# Or reinstall dependencies
-rm -rf node_modules package-lock.json
-npm install
+pnpm rebuild better-sqlite3
+# or
+rm -rf node_modules pnpm-lock.yaml && pnpm install
 ```
+
+If the error mentions Python: `sudo apt-get install python3` (Linux/WSL) or `xcode-select --install` (macOS).
 
 ### Container build fails
 
 ```bash
-# Clear build cache
 # Docker
 docker builder prune -f
+./container/build.sh
 
 # Apple Container
-container builder stop
-container builder rm
-container builder start
-
-# Rebuild
+container builder stop && container builder rm && container builder start
 ./container/build.sh
 ```
 
 ### Service won't start
 
-<Tabs>
-  <Tab title="macOS">
-    ```bash
-    # Check error logs
-    cat logs/nanoclaw.error.log
+Check the error log and the setup progression log:
 
-    # Verify Node.js path
-    which node
-
-    # Ensure .env exists
-    ls -la .env
-
-    # Rebuild and restart
-    npm run build
-    launchctl kickstart -k gui/$(id -u)/com.nanoclaw
-    ```
-  </Tab>
-  
-  <Tab title="Linux">
-    ```bash
-    # Check service status
-    systemctl --user status nanoclaw
-
-    # View logs
-    journalctl --user -u nanoclaw -n 50
-
-    # Verify Docker access
-    docker ps
-
-    # Rebuild and restart
-    npm run build
-    systemctl --user restart nanoclaw
-    ```
-  </Tab>
-</Tabs>
-
-### WSL-specific issues
-
-**Docker not found in WSL:**
-
-Ensure Docker Desktop's WSL integration is enabled (Settings > Resources > WSL Integration). Verify with:
 ```bash
-docker --version
+cat logs/nanoclaw.error.log
+cat logs/setup.log
 ```
 
-If Docker Desktop is running but WSL can't find it, restart WSL:
+Ask the agent itself for a diagnostic once it's up:
+
+```
+@Andy /debug
+```
+
+### WSL: Docker integration
+
+If `docker` commands aren't found in WSL, enable WSL integration in Docker Desktop (Settings → Resources → WSL Integration → toggle your distro). Restart WSL from PowerShell if needed:
+
 ```powershell
-# In PowerShell (not WSL)
 wsl --shutdown
 ```
 
-**Slow file operations:**
+### WSL: slow builds
 
-If builds or installs are slow, you may have cloned into `/mnt/c/`. Move to the Linux filesystem:
-```bash
-mv /mnt/c/Users/you/nanoclaw ~/nanoclaw
-cd ~/nanoclaw
-```
-
-**`getuid` warnings:**
-
-On native Windows (without WSL), `process.getuid()` is unavailable. The container runner handles this gracefully — the warning is informational and can be ignored. Inside WSL, `getuid` works normally.
-
-### Docker group permission issues (Linux)
-
-If you see "permission denied" errors:
-
-```bash
-# Immediate fix
-sudo setfacl -m u:$USER:rw /var/run/docker.sock
-
-# Persistent fix
-sudo mkdir -p /etc/systemd/system/docker.service.d
-sudo tee /etc/systemd/system/docker.service.d/socket-acl.conf << EOF
-[Service]
-ExecStartPost=/usr/bin/setfacl -m u:$USER:rw /var/run/docker.sock
-EOF
-sudo systemctl daemon-reload
-sudo systemctl restart docker
-```
+Clone into the Linux filesystem (`~/nanoclaw`), not `/mnt/c/`. The 9P bridge to Windows drives is 10-100× slower than native Linux FS operations.
 
 ## Next steps
 
 <CardGroup cols={2}>
   <Card title="Quick start" icon="rocket" href="/quickstart">
-    Complete the setup process
+    Run `bash nanoclaw.sh` and send your first message
   </Card>
-  <Card title="Security" icon="shield" href="/concepts/security">
-    Learn about container isolation
+  <Card title="Architecture" icon="diagram-project" href="/concepts/architecture">
+    How the two-DB session model works
   </Card>
-  <Card title="Customizing" icon="wrench" href="/features/customization">
-    Modify NanoClaw for your needs
+  <Card title="Integrations" icon="plug" href="/integrations/overview">
+    Add channels: Telegram, Slack, Discord, and more
   </Card>
-  <Card title="Troubleshooting" icon="life-ring" href="/advanced/troubleshooting">
-    Fix common issues
+  <Card title="Customization" icon="wrench" href="/features/customization">
+    Change the trigger word, adjust timeouts, tune engage modes
   </Card>
 </CardGroup>

--- a/integrations/discord.mdx
+++ b/integrations/discord.mdx
@@ -5,6 +5,10 @@ description: Add Discord as a messaging channel for NanoClaw using the /add-disc
 
 import RestartService from "/snippets/restart-service.mdx";
 
+<Warning>
+This page is pending a v2 rewrite. The `/add-discord` skill flow still works, but some mechanics described below reflect v1 architecture — in v2, channel adapters live on a single `channels` branch. See [Integrations overview](/integrations/overview) for current context.
+</Warning>
+
 Add Discord as a messaging channel for NanoClaw. Perfect for team collaboration and community management.
 
 ## Overview

--- a/integrations/gmail.mdx
+++ b/integrations/gmail.mdx
@@ -1,10 +1,17 @@
 ---
-title: Gmail integration
-description: Add Gmail as a tool or full channel using the /add-gmail skill for email reading, sending, and monitoring
+title: Gmail integration (v1 only)
+description: The /add-gmail skill shipped on v1. v2 does not include a Gmail adapter — use /add-resend for outbound email.
+hidden: true
 ---
 
 <Warning>
-This page is pending a v2 rewrite. The `/add-gmail` skill flow still works, but some mechanics described below reflect v1 architecture — in v2, channel adapters live on a single `channels` branch. See [Integrations overview](/integrations/overview) for current context.
+**Gmail is not a v2 channel.** v2 ships with no `src/channels/gmail.ts` and no `/add-gmail` skill on the `channels` branch. This page describes the v1 integration for users still running v1.
+
+For v2:
+- **Outbound email** — `/add-resend` (transactional sends via Resend)
+- **Google Chat** — `/add-gchat`
+
+See the [integrations overview](/integrations/overview) for the current v2 channel list.
 </Warning>
 
 Add Gmail to NanoClaw as a tool (read, send, search, draft) or as a full channel that monitors your inbox and triggers the agent on new emails.

--- a/integrations/gmail.mdx
+++ b/integrations/gmail.mdx
@@ -3,6 +3,10 @@ title: Gmail integration
 description: Add Gmail as a tool or full channel using the /add-gmail skill for email reading, sending, and monitoring
 ---
 
+<Warning>
+This page is pending a v2 rewrite. The `/add-gmail` skill flow still works, but some mechanics described below reflect v1 architecture — in v2, channel adapters live on a single `channels` branch. See [Integrations overview](/integrations/overview) for current context.
+</Warning>
+
 Add Gmail to NanoClaw as a tool (read, send, search, draft) or as a full channel that monitors your inbox and triggers the agent on new emails.
 
 ## Overview

--- a/integrations/ollama.mdx
+++ b/integrations/ollama.mdx
@@ -5,6 +5,10 @@ tag: "UPDATED"
 keywords: ["ollama", "local models", "llm", "mcp", "self-hosted"]
 ---
 
+<Warning>
+In v2, Ollama moved from a core integration to a skill on the `providers` branch. Install via `/add-ollama-provider` (run Ollama as a full provider for an agent group) or `/add-ollama-tool` (keep Claude as the agent, expose Ollama as a tool). The MCP setup described below reflects v1 mechanics; a v2 rewrite is pending. See [Integrations overview](/integrations/overview#providers) for the v2 provider model.
+</Warning>
+
 NanoClaw can delegate tasks to local models running on [Ollama](https://ollama.com), while Claude remains the orchestrator. This lets you offload cheaper tasks (summarization, translation, general queries) to local models and reduce API costs.
 
 ## How it works

--- a/integrations/overview.mdx
+++ b/integrations/overview.mdx
@@ -11,7 +11,7 @@ NanoClaw trunk ships the registry and infrastructure. Channel adapters and alter
 
 <CardGroup cols={2}>
   <Card title="Channels" icon="plug" href="#channels">
-    Where messages come from: WhatsApp, Telegram, Discord, Slack, email, the terminal — 13+ adapters live on the `channels` branch
+    Where messages come from: WhatsApp, Telegram, Discord, Slack, Teams, email, the terminal — 15+ adapters live on the `channels` branch
   </Card>
   <Card title="Providers" icon="robot" href="#providers">
     Which AI runs the agent: Claude (default), OpenAI Codex, OpenCode (OpenRouter/Google/DeepSeek), Ollama (local). Configurable per agent group.
@@ -40,10 +40,6 @@ Install with a skill invocation in Claude Code. The skill copies the adapter fro
   <Card title="Slack" icon="hashtag" href="/integrations/slack">
     `/add-slack` — Socket Mode (no public URL required)
   </Card>
-
-  <Card title="Gmail" icon="envelope" href="/integrations/gmail">
-    `/add-gmail` — OAuth for reading and sending
-  </Card>
 </CardGroup>
 
 ### Also available on the `channels` branch
@@ -58,6 +54,7 @@ Install with a skill invocation in Claude Code. The skill copies the adapter fro
 | `/add-linear` | Linear | Issue comments, triage workflows |
 | `/add-github` | GitHub | PR comments, issue reactions, webhooks |
 | `/add-wechat` | WeChat | WeChat Work API |
+| `/add-emacs` | Emacs | Talk to your agent from inside your editor |
 | `/add-resend` | Email (outbound) | Transactional sends via Resend |
 | `/claw` | Local terminal | Talk to your agent from a CLI — no platform account required |
 

--- a/integrations/overview.mdx
+++ b/integrations/overview.mdx
@@ -1,94 +1,124 @@
 ---
 title: Integrations overview
-description: Connect NanoClaw to your favorite messaging platforms and services
-keywords: ["integrations", "whatsapp", "telegram", "discord", "slack"]
+description: Channels and providers as skills — add only what you need.
+tag: "UPDATED"
+keywords: ["integrations", "channels", "providers", "skills", "add-telegram", "add-whatsapp", "add-codex", "add-opencode"]
 ---
 
-NanoClaw supports multiple communication channels and integrations, allowing you to interact with your AI assistant wherever you work.
+NanoClaw trunk ships the registry and infrastructure. Channel adapters and alternative AI providers live on long-lived skill branches — you install them on demand with `/add-<name>` skills. This keeps your fork lean and your code legible: nothing you didn't ask for.
 
-## Available channels
-
-All channels are installed via the [skills system](/integrations/skills-system). During `/setup`, you choose which platforms to connect — pick one or many:
+## Two kinds of integration
 
 <CardGroup cols={2}>
-  <Card title="WhatsApp" icon="message" href="/integrations/whatsapp">
-    Add WhatsApp with `/add-whatsapp`. Uses the Baileys library for WhatsApp Web API.
+  <Card title="Channels" icon="plug" href="#channels">
+    Where messages come from: WhatsApp, Telegram, Discord, Slack, email, the terminal — 13+ adapters live on the `channels` branch
   </Card>
-
-  <Card title="Telegram" icon="paper-plane" href="/integrations/telegram">
-    Add Telegram with `/add-telegram`. Uses the grammy framework.
-  </Card>
-
-  <Card title="Discord" icon="comments" href="/integrations/discord">
-    Add Discord with `/add-discord`. Perfect for team collaboration and community management.
-  </Card>
-
-  <Card title="Slack" icon="hashtag" href="/integrations/slack">
-    Connect to Slack workspaces with `/add-slack`. Uses Socket Mode — no public URL needed.
-  </Card>
-
-  <Card title="Gmail" icon="envelope" href="/integrations/gmail">
-    Add Gmail with `/add-gmail`. Use as a tool or full channel for email monitoring.
+  <Card title="Providers" icon="robot" href="#providers">
+    Which AI runs the agent: Claude (default), OpenAI Codex, OpenCode (OpenRouter/Google/DeepSeek), Ollama (local). Configurable per agent group.
   </Card>
 </CardGroup>
 
-## How the skills system works
+## Channels
 
-NanoClaw uses a skills-based architecture instead of bundling all integrations into the core codebase. This approach:
+Install with a skill invocation in Claude Code. The skill copies the adapter from the `channels` branch into your fork and walks you through platform-specific auth.
 
-- **Keeps your installation lean** - Only add what you need
-- **Maintains clean code** - No unused features cluttering the codebase
-- **Enables customization** - Each installation is tailored to your needs
-- **Prevents bloat** - The base system stays minimal and understandable
+### Documented channels
 
-Learn more about the [skills system](/integrations/skills-system).
+<CardGroup cols={2}>
+  <Card title="WhatsApp" icon="message" href="/integrations/whatsapp">
+    `/add-whatsapp` (Baileys, WhatsApp Web API) or `/add-whatsapp-cloud` (Cloud API, DMs only)
+  </Card>
 
-## Channel capabilities
+  <Card title="Telegram" icon="paper-plane" href="/integrations/telegram">
+    `/add-telegram` — grammy framework, BotFather token
+  </Card>
 
-All channel integrations support:
+  <Card title="Discord" icon="comments" href="/integrations/discord">
+    `/add-discord` — discord.js, bot application token
+  </Card>
 
-- **Isolated contexts** - Each chat/channel has its own memory and filesystem
-- **Trigger patterns** - Configure when the assistant responds (`@Andy`, etc.)
-- **Scheduled tasks** - Set up recurring jobs that can message you
-- **Container isolation** - Every context runs in its own sandboxed environment
-- **Multi-channel support** - Run multiple channels simultaneously
+  <Card title="Slack" icon="hashtag" href="/integrations/slack">
+    `/add-slack` — Socket Mode (no public URL required)
+  </Card>
 
-## Adding an integration
+  <Card title="Gmail" icon="envelope" href="/integrations/gmail">
+    `/add-gmail` — OAuth for reading and sending
+  </Card>
+</CardGroup>
 
-To add an integration, use the corresponding skill command in Claude Code:
+### Also available on the `channels` branch
 
-```bash
-/add-whatsapp    # Add WhatsApp
-/add-telegram    # Add Telegram
-/add-discord     # Add Discord
-/add-slack       # Add Slack
-/add-gmail       # Add Gmail
+| Skill | Platform | Notes |
+|-------|----------|-------|
+| `/add-teams` | Microsoft Teams | Bot framework |
+| `/add-imessage` | Apple iMessage | macOS-only; uses AppleScript bridge |
+| `/add-matrix` | Matrix | Federated; supports Element and self-hosted homeservers |
+| `/add-gchat` | Google Chat | Workspace accounts |
+| `/add-webex` | Cisco Webex | Bot token |
+| `/add-linear` | Linear | Issue comments, triage workflows |
+| `/add-github` | GitHub | PR comments, issue reactions, webhooks |
+| `/add-wechat` | WeChat | WeChat Work API |
+| `/add-resend` | Email (outbound) | Transactional sends via Resend |
+| `/claw` | Local terminal | Talk to your agent from a CLI — no platform account required |
+
+Documentation for these is rolling out post-v2 launch. The skill itself is self-documenting via `SKILL.md` on the `channels` branch — ask Claude Code to walk you through any of them.
+
+## Providers
+
+By default, NanoClaw uses Claude via the official [Claude Agent SDK](https://docs.anthropic.com/en/api/agent-sdk). Other providers drop in as skills from the `providers` branch and can be configured per agent group:
+
+| Skill | Provider | Use case |
+|-------|----------|----------|
+| `/add-codex` | OpenAI Codex | ChatGPT subscription or OpenAI API key |
+| `/add-opencode` | OpenCode | OpenRouter, Google, DeepSeek, and more via OpenCode |
+| `/add-ollama-provider` | Ollama | Local open-weight models — no cloud calls |
+| `/add-ollama-tool` | Ollama (tool mode) | Use local Ollama as a tool inside Claude agents |
+
+`agent_provider` is a column on `agent_groups` in the central database — each agent group can run a different provider. Mix and match in the same install.
+
+## How channel skills work
+
+1. **Skill invocation** — you run `/add-<channel>` in Claude Code from your NanoClaw directory
+2. **Copy, don't merge** — the skill reads the adapter source from the `channels` branch (not your trunk) and copies only the files for that channel into your fork
+3. **Platform auth** — the skill prompts for the tokens, OAuth flows, or QR pairing each platform requires
+4. **First messaging group** — the skill registers your first chat/channel/group from that platform so you can test immediately
+5. **Verify** — a round-trip test confirms inbound + outbound work before the skill exits
+
+To update installed channel skills when the `channels` branch gets improvements:
+
+```
+/update-skills
 ```
 
-Each skill will:
+To remove a channel, revert the skill's commit:
 
-1. Merge the skill's git branch into your fork
-2. Guide you through platform-specific setup
-3. Help you configure authentication
-4. Register your first chat/channel
-5. Verify the connection works
+```
+git revert <skill-commit-sha>
+```
 
-<Tip>
-  Skills can be combined. For example, you can run WhatsApp, Telegram, and Discord simultaneously, each with its own registered chats.
-</Tip>
+## Running multiple channels
 
-## Choosing your channels
+Channels are peers — none is privileged. Run one, or run Telegram + Discord + GitHub + a local CLI all at once. For each channel you add, decide how it relates to existing agents:
 
-There is no default channel — you choose what you need during `/setup`. You can run a single platform or combine several simultaneously. All channels are peers; none is privileged over the others.
+- **Separate agent groups** — each channel has its own workspace, memory, and personality
+- **Same agent, separate sessions** — one workspace; per-channel conversation threads
+- **Shared session** — multiple channels feed one conversation (webhook + chat is the classic case)
+
+The choice is per channel, configurable via `/manage-channels`. See [Channel isolation model](/concepts/groups) for details.
 
 ## Next steps
 
 <CardGroup cols={2}>
   <Card title="Skills system" icon="puzzle-piece" href="/integrations/skills-system">
-    Learn how the skills system works and how to manage installed skills
+    How skill branches work, how to update, and how to author your own
   </Card>
-  
-  <Card title="WhatsApp" icon="message" href="/integrations/whatsapp">
-    Set up WhatsApp integration
+  <Card title="Customization" icon="wrench" href="/features/customization">
+    Trigger words, timeouts, engage modes, sender scope
+  </Card>
+  <Card title="Security" icon="shield" href="/concepts/security">
+    Sender policies, user roles, OneCLI credentials
+  </Card>
+  <Card title="Channel isolation" icon="layer-group" href="/concepts/groups">
+    Decide how channels relate to agent groups
   </Card>
 </CardGroup>

--- a/integrations/skills-system.mdx
+++ b/integrations/skills-system.mdx
@@ -5,6 +5,10 @@ tag: "UPDATED"
 keywords: ["skills", "git branches", "plugins", "marketplace"]
 ---
 
+<Warning>
+This page describes the v1 skill model (one `skill/*` branch per feature, merged into your fork). v2 consolidated channel adapters onto a single `channels` branch and alternative providers onto a `providers` branch — `/add-<name>` skills now copy from the relevant branch rather than merging a dedicated skill branch. A v2-focused rewrite is pending. See [Integrations overview](/integrations/overview) for the current model.
+</Warning>
+
 NanoClaw's skills system lets you add integrations and features by merging git branches into your fork. This keeps the base codebase minimal while enabling powerful customization — all using standard git operations.
 
 ## Philosophy: Skills over features
@@ -15,7 +19,7 @@ From the NanoClaw README:
 
 This approach means:
 
-- The base NanoClaw codebase stays small (~43.8k tokens)
+- The base NanoClaw codebase stays in one head (~127k tokens at v2.0.0 — still fits Claude's context window for repo-wide reasoning)
 - Each installation is customized to your exact needs
 - No configuration sprawl or unused features
 - The code remains understandable and modifiable

--- a/integrations/slack.mdx
+++ b/integrations/slack.mdx
@@ -6,6 +6,10 @@ description: Add Slack as a messaging channel for NanoClaw using the /add-slack 
 import SyncEnv from "/snippets/sync-env.mdx";
 import RestartService from "/snippets/restart-service.mdx";
 
+<Warning>
+This page is pending a v2 rewrite. The `/add-slack` skill flow still works, but some mechanics described below reflect v1 architecture — in v2, channel adapters live on a single `channels` branch. See [Integrations overview](/integrations/overview) for current context.
+</Warning>
+
 Add Slack as a messaging channel for NanoClaw. Perfect for team workspaces and professional communication.
 
 ## Overview

--- a/integrations/telegram.mdx
+++ b/integrations/telegram.mdx
@@ -6,6 +6,10 @@ description: Add Telegram support using the /add-telegram skill
 import SyncEnv from "/snippets/sync-env.mdx";
 import RestartService from "/snippets/restart-service.mdx";
 
+<Warning>
+This page is pending a v2 rewrite. The `/add-telegram` skill flow still works, but some mechanics described below reflect v1 architecture — in v2, channel adapters live on a single `channels` branch. See [Integrations overview](/integrations/overview) for current context.
+</Warning>
+
 Add Telegram as a messaging channel for NanoClaw. Telegram can run alongside existing channels or replace them entirely.
 
 ## Overview

--- a/integrations/whatsapp.mdx
+++ b/integrations/whatsapp.mdx
@@ -4,7 +4,11 @@ description: WhatsApp support via the /add-whatsapp skill using the Baileys libr
 tag: "UPDATED"
 ---
 
-WhatsApp is a messaging channel for NanoClaw, installed via the `/add-whatsapp` skill. It uses the Baileys library and merges the `skill/whatsapp` branch into your fork.
+<Warning>
+This page is pending a v2 rewrite. The `/add-whatsapp` skill flow still works, but some mechanics described below (e.g., per-channel `skill/*` branch merges) reflect v1 architecture — in v2, channel adapters live on a single `channels` branch, and session IO uses two databases per session. See [Integrations overview](/integrations/overview) for current context.
+</Warning>
+
+WhatsApp is a messaging channel for NanoClaw, installed via the `/add-whatsapp` skill. It uses the Baileys library.
 
 ## Overview
 

--- a/integrations/x-twitter.mdx
+++ b/integrations/x-twitter.mdx
@@ -4,6 +4,10 @@ description: Connect NanoClaw to X (Twitter) for automated posting and interacti
 keywords: ["x", "twitter", "social media", "posting", "integration"]
 ---
 
+<Warning>
+This page is pending a v2 rewrite. The `/x-integration` skill still exists, but some mechanics described below reflect v1 architecture. See [Integrations overview](/integrations/overview) for current context.
+</Warning>
+
 NanoClaw can connect to X (formerly Twitter) as a channel, allowing the agent to post tweets, respond to mentions, and interact with the platform.
 
 ## Architecture

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -1,15 +1,15 @@
 ---
 title: "What is NanoClaw?"
-description: An AI assistant that runs agents securely in their own containers. Lightweight, built to be easily understood and completely customized for your needs.
+description: From AI assistant to AI team. Multiple Claude agents running in parallel, talking to each other, isolated in their own containers — installed and customized through Claude itself.
 icon: "house"
 sidebarTitle: "Introduction"
 tag: "UPDATED"
-keywords: ["nanoclaw", "ai assistant", "claude", "docker", "container isolation", "v2", "agent sdk"]
+keywords: ["nanoclaw", "ai team", "multi-agent", "claude", "agent sdk", "container isolation", "v2", "chat sdk"]
 ---
 
-NanoClaw is an AI assistant that runs Claude agents in their own Linux containers, connected to your messaging platforms. Each agent has its own filesystem, memory, and credentials — isolation that enforces privacy at the OS level, not behind application-layer permission checks.
+NanoClaw started as a way to run a single Claude agent on WhatsApp. v2 turns it into a team. Spawn multiple agents, wire them to any mix of 15+ messaging channels, have them route work to each other, and keep every one of them isolated in its own Linux container.
 
-One host process, one container per active session, and a codebase small enough to hold in your head.
+One host process on your machine. One container per active session. A codebase small enough to hold in your head — and small enough for Claude Code to hold in its context window.
 
 <CardGroup cols={2}>
   <Card title="Quick start" icon="rocket" href="/quickstart">
@@ -19,36 +19,54 @@ One host process, one container per active session, and a codebase small enough 
     Requirements, platform notes, and what the installer does
   </Card>
   <Card title="Architecture" icon="diagram-project" href="/concepts/architecture">
-    Two-database session model, entity model, Bun runtime
+    The session DB, the entity model, and the inbox/outbox pattern
   </Card>
   <Card title="Security" icon="shield" href="/concepts/security">
     Container isolation, OneCLI credentials, sender policies
   </Card>
 </CardGroup>
 
+## From AI assistant to AI team
+
+Most agents handle one conversation at a time. NanoClaw v2 runs as many parallel conversations as you want, on as many channels as you want, with as many agents as you want — and lets them coordinate.
+
+A single pattern drives the whole system: every message goes through an inbox, every response comes out of an outbox. User chats, webhooks, scheduled jobs, and agent-to-agent calls are all just rows in a queue.
+
+Example: three agent groups sharing one Discord channel for PR review.
+
+- A **worker** agent spawns per thread — one reviewer per PR.
+- A **manager** agent reads every thread and tracks what's in flight.
+- A **supervisor** agent stays silent until a worker requests human approval, then DMs you a card to approve or reject.
+
+Three agents, one channel, one pattern. No separate scheduler, no separate RPC layer, no separate approval system — just messages addressed to different inboxes.
+
 ## Why NanoClaw
 
-### Container isolation, not just permission checks
+### Agents that stay out of each other's filesystems
 
-Agents run in Linux containers with true filesystem isolation — they only see what's explicitly mounted. Bash and file-editing tools are safe because commands execute inside the container, not on your host. Credentials never enter the container; they're injected at the HTTPS layer by [OneCLI Agent Vault](/advanced/security-model#credential-vault).
+Every agent runs in a Linux container with true filesystem isolation — it only sees what's explicitly mounted. Bash and file-editing tools are safe because commands execute inside the container, not on your host. Credentials never enter the container; they're injected at the HTTPS layer by [OneCLI Agent Vault](/advanced/security-model#credential-vault).
 
-### Skills over features
+### One pattern for messages, schedules, and routing
 
-Trunk ships the registry and infrastructure. Channel adapters live on a long-lived `channels` branch. Alternative agent providers live on `providers`. You run a skill like `/add-telegram` or `/add-opencode` and it copies exactly the module you need into your fork. You end up with code that does what you asked for and nothing else.
+Scheduling is a timestamp column on a message row. Agent-to-agent delegation is a row written to another agent's inbox. Multi-user approvals are messages routed to an owner's DM with an action card attached. You only learn one model.
 
-### Multi-channel
+### Multi-channel by design
 
-Install any subset of: WhatsApp, Telegram, Discord, Slack, Microsoft Teams, iMessage, Matrix, Google Chat, Webex, Linear, GitHub, WeChat, or email via Resend. Plus a local CLI channel for terminal-first use. Run one, or run them all in parallel.
+Install any subset of: WhatsApp, WhatsApp Cloud, Telegram, Discord, Slack, Microsoft Teams, Google Chat, Webex, iMessage, Matrix, WeChat, Linear, GitHub, Resend (email), Emacs, or the local CLI channel. Channels are thin adapters over [Vercel's Chat SDK](https://chat-sdk.dev/docs/adapters) — a new adapter is typically a short TypeScript file.
 
-### Flexible isolation
+### Flexible isolation per channel
 
-For every channel you add, decide how it relates to your existing agents:
+For every channel you add, decide how it shares context with your existing agents:
 
 - **Separate agent groups** — each channel gets its own workspace, memory, and personality. Nothing crosses.
-- **Same agent, separate sessions** — one workspace, one memory, but per-channel conversation threads.
+- **Same agent, separate sessions** — one workspace and one memory, but per-channel conversation threads.
 - **Shared session** — multiple channels feed into a single conversation (GitHub webhooks + a Slack channel + email, all in one thread).
 
 Pick per channel via `/manage-channels`. See [Channel isolation model](/concepts/groups).
+
+### Point anyone at your agent, keep yourself in the loop
+
+Invite coworkers, clients, or friends into a group your agent is in. They get their own agent relationship in minutes — no admin setup for you. Sensitive actions (unknown senders, irreversible tools) route to your DMs as approval cards. You say yes, the agent proceeds; you say no, it stops.
 
 ### Scheduled tasks
 
@@ -60,15 +78,21 @@ Recurring jobs that run Claude and message you back:
 @Andy every Monday at 8am, compile AI news from Hacker News and TechCrunch and message me a briefing
 ```
 
+Same inbox, same flow, same tools — a scheduled task is a message with a `process_after` timestamp.
+
+### Skills, not features
+
+Trunk ships the runtime and the entity model. Channels live on a `channels` branch. Alternative agent providers live on `providers`. You run `/add-telegram` or `/add-opencode` and the skill copies exactly the module you need into your fork. Your install ends up with the code that does what you asked for — and nothing else.
+
 ### AI-native, hybrid by design
 
-The install and onboarding flow is a scripted, deterministic path. When a step needs judgment — a failed install, a guided decision, a customization — control hands off to Claude Code. Beyond setup there's no monitoring dashboard either: describe the problem in chat and Claude Code handles it.
+The install and onboarding flow is a scripted, deterministic path. When a step needs judgment — a failed install, a guided decision, a customization — control hands off to Claude Code. Beyond setup, there's no monitoring dashboard either: describe the problem in chat and Claude Code handles it.
 
 ## Philosophy
 
 <CardGroup cols={1}>
   <Card title="Small enough to understand" icon="magnifying-glass">
-    One process, a few source files, no microservices. Ask Claude Code to walk you through the codebase — the whole repo fits comfortably in its context.
+    One process, a few source files, no microservices. Ask Claude Code to walk you through the codebase — the whole repo fits comfortably in its context window.
   </Card>
 
   <Card title="Secure by isolation" icon="lock">
@@ -94,11 +118,12 @@ The install and onboarding flow is a scripted, deterministic path. When a step n
 
 ## Core architecture (v2)
 
-- **Host process** — Node 22 + pnpm. Handles channels, routing, delivery, and the agent entity model in a central SQLite database.
-- **Agent container** — Bun 1.3+ running TypeScript directly (no compile step). Each session gets its own container, its own filesystem, and a pair of session databases.
-- **Two-database session IO** — `inbound.db` (host writes, container reads) and `outbound.db` (container writes, host reads). One writer per file eliminates SQLite cross-mount contention. No stdin piping, no IPC files.
+- **Host process** — Node 22 + pnpm. Runs channels, routing, delivery, and the entity model over a central SQLite database.
+- **Agent container** — Bun 1.3+ running TypeScript directly (no compile step). Each session gets its own container and its own pair of session databases.
+- **Inbox/outbox session model** — `inbound.db` (host writes, container reads) and `outbound.db` (container writes, host reads). One writer per file eliminates SQLite cross-mount contention. No stdin piping, no IPC files.
 - **Entity model** — agent groups (workspaces) and messaging groups (platform channels) are independent. `messaging_group_agents` rows wire them together with per-wiring engage mode, sender scope, and session mode.
 - **Delivery loop** — two polls: an active poll (1s) for running sessions, a sweep (60s) for liveness and recovery. Heartbeat-based stale detection, not wall-clock timeouts.
+- **Channel adapters** — thin wrappers over [Vercel's Chat SDK](https://chat-sdk.dev/docs/adapters) on a `channels` branch. Add only what you use.
 - **Credentials** — [OneCLI Agent Vault](https://github.com/onecli/onecli) is the sole credential path. Containers receive placeholder tokens; the vault injects real auth at request time and enforces per-agent policies.
 
 <Info>

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -1,130 +1,128 @@
 ---
 title: "What is NanoClaw?"
-description: A lightweight, secure AI assistant that runs agents in isolated containers and connects to your messaging platforms
+description: An AI assistant that runs agents securely in their own containers. Lightweight, built to be easily understood and completely customized for your needs.
 icon: "house"
 sidebarTitle: "Introduction"
 tag: "UPDATED"
-keywords: ["nanoclaw", "ai assistant", "claude", "docker", "container isolation"]
+keywords: ["nanoclaw", "ai assistant", "claude", "docker", "container isolation", "v2", "agent sdk"]
 ---
 
-NanoClaw provides the core functionality of complex AI assistants, but in a codebase small enough to understand: one process and a handful of files. Claude agents run in their own Linux containers with filesystem isolation, not merely behind permission checks.
+NanoClaw is an AI assistant that runs Claude agents in their own Linux containers, connected to your messaging platforms. Each agent has its own filesystem, memory, and credentials — isolation that enforces privacy at the OS level, not behind application-layer permission checks.
+
+One host process, one container per active session, and a codebase small enough to hold in your head.
 
 <CardGroup cols={2}>
   <Card title="Quick start" icon="rocket" href="/quickstart">
-    Get NanoClaw running in minutes with Claude Code handling setup
+    Get running in one command with `bash nanoclaw.sh`
   </Card>
   <Card title="Installation" icon="download" href="/installation">
-    Detailed installation instructions for macOS, Linux, and Windows (WSL2)
-  </Card>
-  <Card title="Security" icon="shield" href="/concepts/security">
-    Learn about container isolation and security boundaries
+    Requirements, platform notes, and what the installer does
   </Card>
   <Card title="Architecture" icon="diagram-project" href="/concepts/architecture">
-    Understand how NanoClaw works under the hood
+    Two-database session model, entity model, Bun runtime
+  </Card>
+  <Card title="Security" icon="shield" href="/concepts/security">
+    Container isolation, OneCLI credentials, sender policies
   </Card>
 </CardGroup>
 
-## Key features
+## Why NanoClaw
 
-### Container isolation
+### Container isolation, not just permission checks
 
-Agents run in Linux containers (Apple Container on macOS, or Docker) with true filesystem isolation. They can only see what's explicitly mounted.
+Agents run in Linux containers with true filesystem isolation — they only see what's explicitly mounted. Bash and file-editing tools are safe because commands execute inside the container, not on your host. Credentials never enter the container; they're injected at the HTTPS layer by [OneCLI Agent Vault](/advanced/security-model#credential-vault).
 
-```bash
-Channel (WA/TG/DC/Slack/Gmail) → SQLite → Polling loop → Container (Claude Agent SDK) → Response
-```
+### Skills over features
 
-### Multi-messenger support
+Trunk ships the registry and infrastructure. Channel adapters live on a long-lived `channels` branch. Alternative agent providers live on `providers`. You run a skill like `/add-telegram` or `/add-opencode` and it copies exactly the module you need into your fork. You end up with code that does what you asked for and nothing else.
 
-Message NanoClaw from any connected platform:
-- **WhatsApp** (via `/add-whatsapp`)
-- **Telegram** (via `/add-telegram`)
-- **Discord** (via `/add-discord`)
-- **Slack** (via `/add-slack`)
-- **Gmail** (via `/add-gmail`)
+### Multi-channel
 
-All channels are installed via [skills](/integrations/skills-system) — pick the ones you need during `/setup`.
+Install any subset of: WhatsApp, Telegram, Discord, Slack, Microsoft Teams, iMessage, Matrix, Google Chat, Webex, Linear, GitHub, WeChat, or email via Resend. Plus a local CLI channel for terminal-first use. Run one, or run them all in parallel.
 
-### Isolated group context
+### Flexible isolation
 
-Each group has its own:
-- `CLAUDE.md` memory file
-- Isolated filesystem
-- Separate container sandbox with only that filesystem mounted
+For every channel you add, decide how it relates to your existing agents:
 
-### Agent swarms
+- **Separate agent groups** — each channel gets its own workspace, memory, and personality. Nothing crosses.
+- **Same agent, separate sessions** — one workspace, one memory, but per-channel conversation threads.
+- **Shared session** — multiple channels feed into a single conversation (GitHub webhooks + a Slack channel + email, all in one thread).
 
-<Note>
-NanoClaw is the first personal AI assistant to support [Agent Swarms](https://code.claude.com/docs/en/agent-teams). Spin up teams of agents that collaborate in your chat.
-</Note>
+Pick per channel via `/manage-channels`. See [Channel isolation model](/concepts/groups).
 
 ### Scheduled tasks
 
-Set up recurring jobs that run Claude and message you back:
+Recurring jobs that run Claude and message you back:
 
 ```
 @Andy send an overview of the sales pipeline every weekday morning at 9am
 @Andy review the git history for the past week each Friday and update the README if there's drift
-@Andy every Monday at 8am, compile news on AI developments and message me a briefing
+@Andy every Monday at 8am, compile AI news from Hacker News and TechCrunch and message me a briefing
 ```
+
+### AI-native, hybrid by design
+
+The install and onboarding flow is a scripted, deterministic path. When a step needs judgment — a failed install, a guided decision, a customization — control hands off to Claude Code. Beyond setup there's no monitoring dashboard either: describe the problem in chat and Claude Code handles it.
 
 ## Philosophy
 
 <CardGroup cols={1}>
   <Card title="Small enough to understand" icon="magnifying-glass">
-    One process, a few source files and no microservices. Ask Claude Code to walk you through the entire codebase.
+    One process, a few source files, no microservices. Ask Claude Code to walk you through the codebase — the whole repo fits comfortably in its context.
   </Card>
-  
+
   <Card title="Secure by isolation" icon="lock">
-    Agents run in Linux containers and can only see what's explicitly mounted. Bash access is safe because commands run inside the container, not on your host.
+    Agents run in Linux containers and see only what you mount. Credentials never enter the container — OneCLI injects them at request time.
   </Card>
-  
+
   <Card title="Built for the individual user" icon="user">
-    NanoClaw isn't a monolithic framework; it's software that fits each user's exact needs. Make your own fork and have Claude Code modify it to match your needs.
+    Not a monolithic framework. You make your own fork and have Claude Code modify it to fit. Bespoke, not bloatware.
   </Card>
-  
+
   <Card title="Customization = code changes" icon="code">
-    No configuration sprawl. Want different behavior? Modify the code. The codebase is small enough that it's safe to make changes.
+    No config file sprawl. Want different behavior? Edit the code. The codebase is small enough that it's safe to do so.
   </Card>
-  
-  <Card title="AI-native" icon="robot">
-    No installation wizard; Claude Code guides setup. No monitoring dashboard; ask Claude what's happening. No debugging tools; describe the problem and Claude fixes it.
-  </Card>
-  
+
   <Card title="Skills over features" icon="puzzle-piece">
-    Instead of adding features to the codebase, contributors submit Claude Code skills like `/add-telegram` that transform your fork. You end up with clean code that does exactly what you need.
+    Contributors ship Claude Code skills like `/add-telegram` that transform your fork. Trunk stays lean; your fork ships exactly the modules you asked for.
+  </Card>
+
+  <Card title="Best harness, best model" icon="robot">
+    Claude Code with the official Claude Agent SDK is the default. Drop in other providers per agent group: `/add-codex` for OpenAI, `/add-opencode` for OpenRouter/Google/DeepSeek, `/add-ollama-provider` for local models.
   </Card>
 </CardGroup>
 
-## Core architecture
+## Core architecture (v2)
 
-NanoClaw is built with simplicity in mind:
-
-- **Single Node.js process** - No microservices or complex orchestration
-- **SQLite database** - Per-group message queue with concurrency control
-- **Container runtime** - Apple Container (macOS) or Docker (macOS/Linux)
-- **Claude Agent SDK** - Runs Claude Code directly in containers
-- **IPC via filesystem** - Simple, reliable inter-process communication
+- **Host process** — Node 22 + pnpm. Handles channels, routing, delivery, and the agent entity model in a central SQLite database.
+- **Agent container** — Bun 1.3+ running TypeScript directly (no compile step). Each session gets its own container, its own filesystem, and a pair of session databases.
+- **Two-database session IO** — `inbound.db` (host writes, container reads) and `outbound.db` (container writes, host reads). One writer per file eliminates SQLite cross-mount contention. No stdin piping, no IPC files.
+- **Entity model** — agent groups (workspaces) and messaging groups (platform channels) are independent. `messaging_group_agents` rows wire them together with per-wiring engage mode, sender scope, and session mode.
+- **Delivery loop** — two polls: an active poll (1s) for running sessions, a sweep (60s) for liveness and recovery. Heartbeat-based stale detection, not wall-clock timeouts.
+- **Credentials** — [OneCLI Agent Vault](https://github.com/onecli/onecli) is the sole credential path. Containers receive placeholder tokens; the vault injects real auth at request time and enforces per-agent policies.
 
 <Info>
-**Codebase size**: ~43.8k tokens (22% of Claude's context window). Small enough to understand completely.
+**Codebase size**: ~127k tokens (~64% of Claude's context window). Big for v1; still small enough that Claude Code can reason over the whole repo.
 </Info>
 
-## Key source files
+## Key source files (host)
 
 | File | Purpose |
-|------|----------|
-| `src/index.ts` | Orchestrator: state, message loop, agent invocation |
-| `src/channels/*.ts` | Channel adapters (WhatsApp, Telegram, etc.) |
-| `src/ipc.ts` | IPC watcher and task processing |
-| `src/router.ts` | Message formatting and outbound routing |
-| `src/group-queue.ts` | Per-group queue with global concurrency limit |
-| `src/container-runner.ts` | Spawns streaming agent containers |
-| `src/task-scheduler.ts` | Runs scheduled tasks |
-| `src/remote-control.ts` | Remote Control session management |
-| `src/db.ts` | SQLite operations (messages, groups, sessions, state) |
-| `groups/*/CLAUDE.md` | Per-group memory |
+|------|---------|
+| `src/index.ts` | Orchestrator: startup, channel registration, routing |
+| `src/router.ts` | Inbound routing: identity → agent group → session |
+| `src/delivery.ts` | Outbound delivery polls (active 1s, sweep 60s) |
+| `src/host-sweep.ts` | Heartbeat liveness, stuck-tool detection, processing-ack sync |
+| `src/session-manager.ts` | Session lifecycle: spawn, wake, idle-kill, DB provisioning |
+| `src/container-runner.ts` | Container spawn and OneCLI config application |
+| `src/db/schema.ts` | Reference schemas — central, inbound, outbound |
+| `src/db/session-db.ts` | Per-session DB helpers (host-side) |
+| `src/channels/` | Channel adapter interfaces |
+| `container/agent-runner/src/` | Bun-run agent-runner (read-only mounted into containers) |
+| `groups/<folder>/CLAUDE.md` | Per-agent-group memory |
 
-## Community
+## Community and source
 
-Questions? Ideas? [Join the Discord](https://discord.gg/VDdww8qS42). NanoClaw is MIT licensed and available on [GitHub](https://github.com/qwibitai/NanoClaw).
+- **Source**: [github.com/qwibitai/nanoclaw](https://github.com/qwibitai/nanoclaw)
+- **Discord**: [community server](https://discord.gg/VDdww8qS42)
+- **License**: MIT

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -1,194 +1,128 @@
 ---
 title: Quick start
-description: Get NanoClaw running in 5 minutes with Claude Code
+description: Get NanoClaw running in one command with the scripted installer.
 icon: "bolt"
 tag: "UPDATED"
-keywords: ["setup", "install", "getting started", "claude code"]
+keywords: ["setup", "install", "getting started", "nanoclaw.sh", "bash", "claude code"]
 ---
 
-# Quick start
-
-Get NanoClaw up and running in minutes. Claude Code handles everything: dependencies, authentication, container setup, and service configuration.
+From a fresh machine to an agent you can message — one command, a handful of prompts, a few minutes.
 
 <Note>
-This guide assumes you have Node.js 20+ and Claude Code installed. See [Installation](/installation) for detailed requirements.
+This guide covers the default installer. If you want to customize the install path (skip steps, change the Anthropic secret name), see [Installation](/installation).
 </Note>
 
-## Setup process
+## The one-command flow
 
 <Steps>
-  <Step title="Fork and clone the repository">
-    Fork [qwibitai/nanoclaw](https://github.com/qwibitai/nanoclaw) on GitHub, then clone your fork:
+  <Step title="Clone the repository">
+    Clone upstream directly if you just want to try things out:
 
     ```bash
-    git clone https://github.com/<you>/nanoclaw.git
+    git clone https://github.com/qwibitai/nanoclaw.git
     cd nanoclaw
     ```
 
-    <Info>
-    Forking gives you a remote to push your customizations to. If you just want to try things out, `git clone https://github.com/qwibitai/nanoclaw.git` works too — you can migrate to a fork later.
-    </Info>
+    If you plan to customize, fork [qwibitai/nanoclaw](https://github.com/qwibitai/nanoclaw) on GitHub first and clone your fork. You can always add the fork remote later — the installer and `/update-nanoclaw` skill handle both shapes.
   </Step>
 
-  <Step title="Launch Claude Code">
-    Open Claude Code in the NanoClaw directory:
-
+  <Step title="Run the installer">
     ```bash
-    claude
+    bash nanoclaw.sh
     ```
 
-    This launches Claude Code with access to the NanoClaw codebase.
-  </Step>
+    This is the whole install command. `nanoclaw.sh` walks you through:
 
-  <Step title="Run the setup command">
-    In Claude Code, run:
-
-    ```
-    /setup
-    ```
-
-    Claude Code will automatically handle:
-    - Installing Node.js dependencies
-    - Setting up your container runtime (Apple Container or Docker)
+    - Installing Node 22, pnpm, and Docker if they're missing
+    - Verifying your environment (platform, WSL detection, container runtime)
     - Building the agent container image
-    - Authenticating with Claude
-    - Installing the skills marketplace plugin
-    - Asking which messaging channels you want
-    - Running the setup skill for each selected channel
-    - Starting the background service
+    - Registering your Anthropic credential with [OneCLI](https://github.com/onecli/onecli)
+    - Pairing your first channel (Telegram, Discord, WhatsApp, or the local CLI)
+    - Installing a systemd or launchd service so NanoClaw starts with your machine
 
-    <Info>
-    The `/setup` skill is AI-native: no installation wizard, just Claude guiding you through each step.
-    </Info>
+    If any step fails, Claude Code is invoked automatically to diagnose and resume from where it broke. You don't have to debug the installer yourself.
   </Step>
 
-  <Step title="Choose your messaging channels">
-    Claude will ask which platforms you want to connect:
+  <Step title="Answer the setup prompts">
+    Running through [clack](https://github.com/natemoo-re/clack), you'll be asked:
 
-    - **WhatsApp** — via whatsapp-web.js (QR code or pairing code auth)
-    - **Telegram** — via grammy (BotFather token)
-    - **Discord** — via discord.js (bot application token)
-    - **Slack** — via @slack/bolt (Socket Mode app)
-    - **Gmail** — via Google API (OAuth credentials)
+    - **Display name** — what you want your agent to be called (default: `Andy`)
+    - **Anthropic credential method** — Claude subscription (OAuth), Anthropic API key, or skip
+    - **First channel** — Telegram, Discord, WhatsApp, or local CLI. You can add more later.
+    - **Channel-specific auth** — bot token for Telegram/Discord, QR code for WhatsApp, nothing for CLI
 
-    Pick one or more. Claude runs the corresponding `/add-*` skill for each selection, walking you through platform-specific authentication and configuration.
-
-    <Note>
-    You can always add more channels later with `/customize` or by running individual skills like `/add-telegram`.
-    </Note>
+    The flow is linear. One question at a time. You can Ctrl+C and restart; the installer picks up where you left off.
   </Step>
 
-  <Step title="Configure your main channel">
-    Claude will ask you to configure:
+  <Step title="Authorize Anthropic">
+    The one step that hands off from the scripted flow: `claude setup-token` opens a browser for OAuth and prints a long-lived token back into your terminal. The installer captures the status and returns to the clack flow once the token is stored in OneCLI.
 
-    **Trigger word**: The word that activates NanoClaw (default: `@Andy`)
-
-    **Main channel**: The chat where you have full admin control over all groups. Depending on your platform this might be:
-    - A self-chat or DM with the bot
-    - A private group or channel
-    - A dedicated conversation
-
-    **Mount allowlist** (optional): Allow agents to access external directories
-
-    <Info>
-    Your main channel has admin privileges. Other groups get standard access.
-    </Info>
-  </Step>
-
-  <Step title="Verify the setup">
-    Claude will verify that everything is running correctly:
-
-    ✓ Service running
-    ✓ Credentials configured
-    ✓ Messaging channel(s) authenticated
-    ✓ Main channel registered
-    ✓ Container runtime ready
-
-    If any checks fail, Claude will help you fix them.
+    If you chose to skip Anthropic auth or use an API key instead, this step is skipped or replaced with a password prompt.
   </Step>
 
   <Step title="Send your first message">
-    Open your connected messaging platform and send a message to your main channel:
+    When the installer finishes, it prints the invocation pattern for your chosen channel. For Telegram that looks like:
 
     ```
     @Andy hello!
     ```
 
-    NanoClaw should respond. You're all set!
+    For the local CLI:
 
-    <Tip>
-    In self-chat or DM mode, the trigger word is optional. Just send any message and NanoClaw will respond.
-    </Tip>
+    ```bash
+    pnpm claw
+    ```
+
+    Your agent responds. You're set.
   </Step>
 </Steps>
 
-## What happens during setup?
+## What the installer writes to disk
 
-Here's what Claude Code does when you run `/setup`:
+NanoClaw is transparent about what it does. Every run produces three log streams:
 
-<Accordion title="1. Bootstrap dependencies">
-  - Verifies Node.js 20+ is installed
-  - Runs `npm install` to install dependencies
-  - Tests that native modules (better-sqlite3) load correctly
-  - Detects your platform (macOS/Linux) and environment (WSL, headless)
-</Accordion>
+| Level | Where | What's in it |
+|-------|-------|--------------|
+| Terminal (clack) | Your screen | Branded status + prompts, spinner per step |
+| Progression log | `logs/setup.log` | One entry per step: timestamp, duration, status, key facts |
+| Raw per-step logs | `logs/setup-steps/NN-step-name.log` | Full verbatim stdout + stderr from the step |
 
-<Accordion title="2. Container runtime setup">
-  - **macOS**: Offers choice between Docker (default) or Apple Container (native)
-  - **Linux**: Uses Docker (only option)
-  - Installs the chosen runtime if not present
-  - Starts the runtime service
-  - Builds the agent container image
-  - Tests that containers can run successfully
-</Accordion>
+If something looks wrong after install, `logs/setup.log` is the first file to read.
 
-<Accordion title="3. Claude authentication">
-  - Asks if you have a Claude subscription (Pro/Max) or Anthropic API key
-  - **Subscription**: Guides you to run `claude setup-token` and add the long-lived token to `.env` as `CLAUDE_CODE_OAUTH_TOKEN`
-  - **API key**: Guides you to add `ANTHROPIC_API_KEY` to `.env`
-  - These credentials allow agents to authenticate with Claude Code
+## What happens behind the scenes
 
-  <Warning>
-  Do not copy tokens from `~/.claude/.credentials.json` — these are short-lived keychain tokens that expire within hours and will cause container 401 errors. Always use `claude setup-token` for OAuth.
-  </Warning>
-</Accordion>
+<AccordionGroup>
+  <Accordion title="Phase 1 — bootstrap (bash)">
+    - Installs Node 22 via nvm, corepack-enables pnpm
+    - Runs `pnpm install --frozen-lockfile`
+    - Verifies `better-sqlite3` loads on your platform
+    - Detects WSL, headless environments, and Apple Silicon
+    - Emits a `BOOTSTRAP` status block to the progression log
+  </Accordion>
 
-<Accordion title="4. Upstream remote and marketplace">
-  - Checks if the `upstream` remote exists; adds it if not: `git remote add upstream https://github.com/qwibitai/nanoclaw.git`
-  - Verifies `origin` points to your fork (not `qwibitai`)
-  - Installs the skills marketplace plugin so feature skills are available
-</Accordion>
+  <Accordion title="Phase 2 — setup:auto (TypeScript via pnpm)">
+    Driven by `setup/auto.ts`. Each sub-step emits a structured status block and writes its raw output to `logs/setup-steps/NN-<name>.log`:
 
-<Accordion title="5. Channel installation">
-  - Asks which messaging channels you want (WhatsApp, Telegram, Discord, Slack, Gmail)
-  - Runs the corresponding `/add-*` skill for each selected channel
-  - Each skill merges its `skill/*` branch and walks you through platform-specific auth
-  - After a channel is set up, offers relevant add-ons (e.g., Agent Swarm, voice transcription)
-</Accordion>
+    - **environment** — Docker / Apple Container detection, runtime selection
+    - **container** — builds `nanoclaw-agent:latest` via `container/build.sh`
+    - **onecli** — installs OneCLI Agent Vault and registers your Anthropic secret
+    - **channel pairing** — runs the `add-<channel>` skill you picked
+    - **service** — launchd (macOS) / systemd (Linux) / `start-nanoclaw.sh` wrapper (WSL without systemd)
+    - **diagnostics** — optional opt-in PostHog event with platform + channel choice
+  </Accordion>
 
-<Accordion title="6. Channel configuration">
-  - Syncs groups/chats from your connected platforms
-  - Registers your main channel in the database
-  - Creates the main group folder at `groups/main/`
-  - Sets up the `CLAUDE.md` memory file
-  - Creates mount allowlist at `~/.config/nanoclaw/mount-allowlist.json` (skipped if the file already exists, preserving your customizations)
-</Accordion>
+  <Accordion title="The Anthropic exception">
+    `claude setup-token` owns the TTY during OAuth. It opens your browser, prints the token, and inherits stdio fully — we don't mirror the token to any log file (that would add attack surface). Control returns to the clack flow on exit.
+  </Accordion>
 
-<Accordion title="7. Service installation">
-  - **macOS**: Creates launchd service at `~/Library/LaunchAgents/com.nanoclaw.plist`
-  - **Linux**: Creates systemd service (user or system level); enables `loginctl linger` for non-root users so the service survives SSH logout
-  - **WSL without systemd**: Creates `start-nanoclaw.sh` wrapper script
-  - Starts the service
-  - Verifies the service is running
-</Accordion>
-
-<Accordion title="8. Optional diagnostics">
-  At the end of setup, Claude may ask if you'd like to share anonymous diagnostics (OS, architecture, NanoClaw version, selected channels). You'll see the exact data before anything is sent. Choose **Yes**, **No**, or **Never ask again** to permanently opt out. See [Security overview](/concepts/security#7-diagnostics-and-telemetry) for details.
-</Accordion>
+  <Accordion title="Service installation">
+    - **macOS** — creates launchd service at `~/Library/LaunchAgents/com.nanoclaw.plist`
+    - **Linux (systemd)** — user service at `~/.config/systemd/user/nanoclaw.service`; enables `loginctl linger` so the service survives SSH logout
+    - **WSL without systemd** — creates a `start-nanoclaw.sh` wrapper; you run it manually on login or wire it to `.bashrc`
+  </Accordion>
+</AccordionGroup>
 
 ## Usage examples
-
-Once setup is complete, you can start using NanoClaw from any connected channel:
 
 <CodeGroup>
 ```text Basic conversation
@@ -203,58 +137,49 @@ Once setup is complete, you can start using NanoClaw from any connected channel:
 @Andy monitor Hacker News and message me when there's a trending AI article
 ```
 
-```text Admin commands (main channel only)
+```text Admin commands (from a channel you own or administer)
 @Andy list all scheduled tasks
 @Andy pause the standup reminder
-@Andy join the Family Chat group
+@Andy manage-channels
 @Andy show me what groups I'm in
 ```
 </CodeGroup>
 
+## Monitoring and logs
+
+```bash
+# Live log stream
+tail -f logs/nanoclaw.log
+
+# Service status
+launchctl list | grep nanoclaw     # macOS
+systemctl --user status nanoclaw   # Linux
+```
+
+Or just ask:
+
+```
+@Andy why isn't the scheduler running?
+@Andy show me the last 50 log lines
+@Andy why did this message not get a response?
+```
+
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Customizing NanoClaw" icon="wrench" href="/features/customization">
-    Learn how to modify NanoClaw for your needs
+  <Card title="Add more channels" icon="plus" href="/integrations/overview">
+    `/add-slack`, `/add-whatsapp`, `/add-matrix` — install from the `channels` branch
+  </Card>
+  <Card title="Customize" icon="wrench" href="/features/customization">
+    Change the trigger word, tune timeouts, adjust engage modes
   </Card>
   <Card title="Security model" icon="shield" href="/concepts/security">
-    Understand how container isolation works
-  </Card>
-  <Card title="Adding skills" icon="puzzle-piece" href="/integrations/skills-system">
-    Install additional capabilities like `/add-telegram`
+    Sender allowlists, user roles, unknown-sender policies
   </Card>
   <Card title="Troubleshooting" icon="life-ring" href="/advanced/troubleshooting">
-    Fix common issues
+    Common issues and how Claude Code helps you fix them
   </Card>
 </CardGroup>
-
-## Monitoring and logs
-
-Check what NanoClaw is doing:
-
-```bash
-# View real-time logs
-tail -f logs/nanoclaw.log
-
-# Check service status
-# macOS
-launchctl list | grep nanoclaw
-
-# Linux
-systemctl --user status nanoclaw
-```
-
-Or just ask Claude Code:
-
-```
-Why isn't the scheduler running?
-What's in the recent logs?
-Why did this message not get a response?
-```
-
-<Tip>
-That's the AI-native approach: no monitoring dashboard, just ask Claude what's happening.
-</Tip>
 
 ## Updating NanoClaw
 
@@ -264,11 +189,8 @@ To pull upstream changes and merge with your customizations:
 /update-nanoclaw
 ```
 
-Claude Code will:
-- Fetch the latest changes from upstream
-- Merge with your local modifications
-- Run any database migrations
-- Rebuild the container if needed
-- Restart the service
-- Scan the changelog for `[BREAKING]` entries and offer to run migration skills
-- Optionally check for skill updates
+This skill fetches `upstream/main`, merges with your local changes, runs any migrations, rebuilds the container if needed, restarts the service, and scans the changelog for `[BREAKING]` entries — offering to run the `/migrate-nanoclaw` skill when a breaking change applies.
+
+<Tip>
+Migrating from v1? Run `/migrate-nanoclaw` for a clean-base replay of your customizations on top of v2, or `/update-nanoclaw` for a selective cherry-pick. A dedicated v1 → v2 migration guide is coming; until then, the upstream [CHANGELOG](https://github.com/qwibitai/nanoclaw/blob/main/CHANGELOG.md) covers every breaking change.
+</Tip>


### PR DESCRIPTION
## Summary

Phase A of the v2 documentation sprint. Rewrites the pages every v2 user lands on, with every claim verified directly against upstream source (`src/db/schema.ts`, `src/types.ts`, `src/config.ts`, `container/Dockerfile`, `src/delivery.ts`) — upstream `docs/` includes a stale `architecture.md` draft and a `db-session.md` that omits the `container_state` table, so I didn't use them as ground truth.

## What's rewritten

- **`introduction.mdx`** — v2 positioning: two-DB session IO, entity model, Node+Bun runtime split, OneCLI credentials. Token count 43.7k → 127k. Source file table aligned with `src/` as of v2.0.1.
- **`quickstart.mdx`** — one-command `bash nanoclaw.sh` flow replaces the v1 fork-and-clone + `/setup` dance. Documents the three-level setup log contract (terminal / `logs/setup.log` / per-step raw logs) and the Anthropic OAuth exception.
- **`installation.mdx`** — system requirements + platform prerequisites + `bash nanoclaw.sh`. Retains launchd/systemd/WSL service management. File-structure tree updated for `data/v2-sessions/` and per-session `inbound.db` + `outbound.db`.
- **`integrations/overview.mdx`** — reframed around channels (13+ on the `channels` branch) and providers (4 on the `providers` branch).
- **`features/customization.mdx`** — full v2 rewrite. Trigger code matches `src/config.ts`'s `buildTriggerPattern` pattern. Replaced nonexistent `POLL_INTERVAL` / `SCHEDULER_POLL_INTERVAL` with actual `ACTIVE_POLL_MS` / `SWEEP_POLL_MS` from `src/delivery.ts`. Documents per-wiring engage config (`engage_mode`, `sender_scope`, `ignored_message_policy`, `session_mode`). OneCLI / legacy credential proxy as version tabs — the `/use-native-credential-proxy` skill still exists on upstream so both paths are valid.

## v2 update banners

Added `<Warning>` banners to 8 pages that still reflect v1 architecture (`skill/*` branch merges per channel) and are pending Phase B rewrite:

- `integrations/whatsapp.mdx`, `telegram.mdx`, `discord.mdx`, `slack.mdx`, `gmail.mdx`, `x-twitter.mdx`
- `integrations/skills-system.mdx`
- `integrations/ollama.mdx` (Ollama now on the `providers` branch)

## Other

- Token-count sync: `integrations/skills-system.mdx` (43.8k → 127k), `CLAUDE.md` maintenance note
- `changelog/docs-updates.mdx` entry

## Test plan

- [x] `mint validate` passes (run locally)
- [x] `mint broken-links` passes
- [ ] Manual smoke-test: click through intro → quickstart → installation → integrations/overview on the preview deploy
- [ ] Spot-check one banner page still reads sensibly

## What's NOT in this PR

Phase B (post-launch, separate PRs):
- Full rewrites of the 8 banner-tagged pages
- `api/overview.mdx`, `api/skills/*`
- `advanced/troubleshooting.mdx`, `advanced/docker-sandboxes.mdx`, `advanced/remote-control.mdx`
- `features/web-access.mdx`, `features/agent-swarms.mdx`, `features/cli.mdx`, channel-specific feature pages
- Dedicated `/migration/v1-to-v2` page (waits on the migration skill shipping)

## Verified facts cheat sheet

The full list of verified v2 claims I sourced from is at `/tmp/v2-verified-facts.md` locally (not in the repo — it's a working document).

🤖 Generated with [Claude Code](https://claude.com/claude-code)