### PR TITLE
docs: refresh v2 setup and runtime docs

### DIFF
--- a/advanced/container-runtime.mdx
+++ b/advanced/container-runtime.mdx
@@ -79,8 +79,8 @@ The agent container is built from `container/Dockerfile` and includes:
 
 Agent groups can specify custom packages in `container.json`. The host builds a derived Docker image:
 
-- Tag: `nanoclaw-agent:{agentGroupId}`
-- Built on top of `nanoclaw-agent:latest`
+- Tag: derived from the checkout-scoped base image and agent group
+- Built on top of `nanoclaw-agent-v2-<slug>:latest`
 - Adds custom apt and npm packages
 
 ## Two-database IO model

--- a/api/configuration.mdx
+++ b/api/configuration.mdx
@@ -18,8 +18,8 @@ Configuration is read from `.env` file or `process.env`, with hardcoded fallback
   Whether the assistant has its own phone number or dedicated account. Set to `"true"` to enable.
 </ParamField>
 
-<ParamField path="CONTAINER_IMAGE" type="string" default="nanoclaw-agent:latest">
-  Docker image to use for agent containers. Per-agent-group images are tagged as `nanoclaw-agent:{agentGroupId}`.
+<ParamField path="CONTAINER_IMAGE" type="string" default="nanoclaw-agent-v2-&lt;slug&gt;:latest">
+  Docker image to use for agent containers. The default is scoped to the checkout path via `src/install-slug.ts` so multiple NanoClaw installs can coexist on one host.
 </ParamField>
 
 <ParamField path="CONTAINER_TIMEOUT" type="number" default="1800000">

--- a/concepts/architecture.mdx
+++ b/concepts/architecture.mdx
@@ -41,7 +41,7 @@ graph TB
 
 ### Channel adapters
 
-NanoClaw uses a self-registering adapter pattern for messaging channels. Each channel (WhatsApp, Telegram, Discord, Slack, Gmail) registers at startup. Channels with missing credentials are skipped with a warning.
+NanoClaw uses a self-registering adapter pattern for messaging channels. Installed adapters such as Telegram, Discord, WhatsApp, Signal, Slack, Teams, iMessage, and the local CLI register at startup. Channels with missing credentials are skipped with a warning.
 
 All adapters implement a common interface with `onInbound`, `onInboundEvent`, `onMetadata`, and `onAction` callbacks, allowing the rest of the system to be channel-agnostic.
 

--- a/concepts/containers.mdx
+++ b/concepts/containers.mdx
@@ -151,8 +151,8 @@ Even if the container crashes, all data in session databases and mounted directo
 
 Agent groups can specify custom packages in `container.json`. The host builds a derived Docker image with additional apt and npm packages:
 
-- Image tag: `nanoclaw-agent:{agentGroupId}`
-- Built on top of the base `nanoclaw-agent:latest` image
+- Image tag: derived from the checkout-scoped base image and agent group
+- Built on top of the base `nanoclaw-agent-v2-<slug>:latest` image
 - Cached — only rebuilt when package lists change
 
 ## Timeouts

--- a/features/cli.mdx
+++ b/features/cli.mdx
@@ -19,7 +19,7 @@ Use cases include:
 ## Prerequisites
 
 - Python 3.8 or later
-- NanoClaw installed with a built container image (`nanoclaw-agent:latest`)
+- NanoClaw installed with a built checkout-scoped container image (`nanoclaw-agent-v2-<slug>:latest`)
 - Either `container` (Apple Container, macOS 15+) or `docker` available in `PATH`
 
 ## Installation

--- a/features/messaging.mdx
+++ b/features/messaging.mdx
@@ -119,9 +119,9 @@ Container concurrency is managed globally:
 
 ## Channel routing
 
-Every channel is a thin adapter over [Vercel's Chat SDK](https://chat-sdk.dev/docs/adapters). Adapters implement the same four callbacks (`onInbound`, `onInboundEvent`, `onMetadata`, `onAction`), so routing, fan-out, and delivery don't know or care which platform a message came from.
+Every channel implements the same adapter interface. Chat SDK-backed channels use [Vercel's Chat SDK](https://chat-sdk.dev/docs/adapters); native channels keep platform-specific clients behind the same callbacks (`onInbound`, `onInboundEvent`, `onMetadata`, `onAction`). Routing, fan-out, and delivery do not need platform-specific branches.
 
-15+ adapters live on the `channels` branch (Discord, Slack, Telegram, Teams, Google Chat, WhatsApp, Matrix, iMessage, GitHub, Linear, and more). Install one per fork with `/add-<name>`. See the [integrations overview](/integrations/overview) for the full list.
+Optional adapters live on the `channels` branch or in the current setup flows (Discord, Slack, Telegram, Signal, Teams, Google Chat, WhatsApp, Matrix, iMessage, GitHub, Linear, and more). Install one with `/add-<name>` or select it during `bash nanoclaw.sh`. See the [integrations overview](/integrations/overview) for the full list.
 
 <Warning>
 Channels are installed as skills, not configured through env vars or files. Use `/add-telegram`, `/add-discord`, etc. to copy an adapter module into your fork.

--- a/installation.mdx
+++ b/installation.mdx
@@ -47,9 +47,9 @@ Everything you need to know before running `bash nanoclaw.sh`. For the one-comma
 |---|---|---|
 | Node 22 | Host (orchestrator) | Yes — via nvm if missing |
 | pnpm 10 | Host (package manager) | Yes — via `corepack enable` |
-| Docker (or Apple Container) | Host (container runtime) | Partial — prompts you to install if absent |
+| Docker (or Apple Container) | Host (container runtime) | Partial — prompts you to install or start it if absent |
 | Build tools (gcc, python3) | Host (for `better-sqlite3` native compile) | No — install beforehand |
-| OneCLI Agent Vault | Host (credential injection) | Yes — via `/init-onecli` step |
+| OneCLI Agent Vault | Host (credential injection) | Yes — installs locally or reuses an existing configured instance |
 | Bun 1.3.12 | Container (agent-runner runtime) | Yes — baked into the agent container image |
 
 ### Build tools
@@ -115,10 +115,24 @@ Docker is the default and works on all three platforms. Apple Container is an op
     ```
 
     <Note>
-    The default installer picks Docker. To switch, run `/convert-to-apple-container` after NanoClaw is running. The skill modifies `src/container-runtime.ts`, adjusts mount syntax and stop commands, and handles credential proxy networking if you're using the legacy proxy skill.
+    The default installer picks Docker. To switch, run `/convert-to-apple-container` after NanoClaw is running. The skill modifies the runtime integration and uses `git revert` as the rollback path.
     </Note>
   </Tab>
 </Tabs>
+
+### Advanced installer environment
+
+`nanoclaw.sh` and `setup:auto` read environment variables when you need to debug or script part of setup.
+
+| Env var | Use |
+|---|---|
+| `NANOCLAW_SKIP` | Comma-separated setup steps to skip while debugging (`environment`, `container`, `onecli`, `auth`, `mounts`, `service`, `cli-agent`, `timezone`, `channel`, `verify`, `first-chat`) |
+| `NANOCLAW_DISPLAY_NAME` | Skip the operator display-name prompt |
+| `NANOCLAW_AGENT_NAME` | Set the messaging-channel agent name; the CLI scratch agent remains `Terminal Agent` |
+| `SECRET_NAME` | OneCLI secret name for `setup/register-claude-token.sh` (default: `Anthropic`) |
+| `HOST_PATTERN` | OneCLI host pattern for `setup/register-claude-token.sh` (default: `api.anthropic.com`) |
+
+If OneCLI is already installed and configured, setup asks whether to reuse it. For custom Anthropic-compatible model endpoints, set `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN` in `.env`.
 
 ## Run the installer
 
@@ -156,10 +170,9 @@ For the step-by-step breakdown of what each phase does, see [Quick start](/quick
         <Tree.File name="container.json" />
       </Tree.Folder>
     </Tree.Folder>
-    <Tree.Folder name="store">
-      <Tree.File name="v2.db" />
-    </Tree.Folder>
     <Tree.Folder name="data" defaultOpen>
+      <Tree.File name="v2.db" />
+      <Tree.Folder name="env" />
       <Tree.Folder name="v2-sessions" defaultOpen>
         <Tree.Folder name="{agent_group_id}" defaultOpen>
           <Tree.Folder name="{session_id}" defaultOpen>
@@ -187,12 +200,12 @@ For the step-by-step breakdown of what each phase does, see [Quick start](/quick
 |------|---------|
 | `~/.config/nanoclaw/mount-allowlist.json` | Which host directories agents can mount |
 | `~/.config/nanoclaw/sender-allowlist.json` | Optional per-channel sender access control |
-| `~/Library/LaunchAgents/com.nanoclaw.plist` (macOS) | launchd service definition |
-| `~/.config/systemd/user/nanoclaw.service` (Linux) | systemd user-service definition |
+| `~/Library/LaunchAgents/com.nanoclaw-v2-<slug>.plist` (macOS) | launchd service definition |
+| `~/.config/systemd/user/nanoclaw-v2-<slug>.service` (Linux) | systemd user-service definition |
 
 ## Container image contents
 
-The agent container (`nanoclaw-agent:latest`) is built from `container/Dockerfile`:
+The agent container image is scoped per checkout, with a name like `nanoclaw-agent-v2-<slug>:latest`. It is built from `container/Dockerfile`:
 
 - **Base**: `node:22-slim`
 - **tini** as PID 1 — reaps Chromium zombies, forwards signals so `outbound.db` writes finalize on SIGTERM
@@ -212,11 +225,12 @@ NanoClaw runs as a background service so the host stays responsive to channel ev
   <Tab title="macOS (launchd)">
     ```bash
     # Start / stop
-    launchctl load ~/Library/LaunchAgents/com.nanoclaw.plist
-    launchctl unload ~/Library/LaunchAgents/com.nanoclaw.plist
+    # Replace <label> with com.nanoclaw-v2-<slug>
+    launchctl load ~/Library/LaunchAgents/<label>.plist
+    launchctl unload ~/Library/LaunchAgents/<label>.plist
 
     # Restart
-    launchctl kickstart -k gui/$(id -u)/com.nanoclaw
+    launchctl kickstart -k gui/$(id -u)/<label>
 
     # Status
     launchctl list | grep nanoclaw
@@ -228,16 +242,17 @@ NanoClaw runs as a background service so the host stays responsive to channel ev
 
   <Tab title="Linux (systemd)">
     ```bash
-    systemctl --user start nanoclaw
-    systemctl --user stop nanoclaw
-    systemctl --user restart nanoclaw
-    systemctl --user status nanoclaw
+    # Replace <unit> with nanoclaw-v2-<slug>
+    systemctl --user start <unit>
+    systemctl --user stop <unit>
+    systemctl --user restart <unit>
+    systemctl --user status <unit>
 
     # Enable on boot
-    systemctl --user enable nanoclaw
+    systemctl --user enable <unit>
 
     # Logs
-    journalctl --user -u nanoclaw -f
+    journalctl --user -u <unit> -f
     ```
 
     <Note>

--- a/integrations/overview.mdx
+++ b/integrations/overview.mdx
@@ -1,17 +1,17 @@
 ---
 title: Integrations overview
-description: Channels and providers as skills — add only what you need.
+description: Channels and providers as skills and setup flows — add only what you need.
 tag: "UPDATED"
 keywords: ["integrations", "channels", "providers", "skills", "add-telegram", "add-whatsapp", "add-codex", "add-opencode"]
 ---
 
-NanoClaw trunk ships the registry and infrastructure. Channel adapters and alternative AI providers live on long-lived skill branches — you install them on demand with `/add-<name>` skills. This keeps your fork lean and your code legible: nothing you didn't ask for.
+NanoClaw trunk ships the registry and infrastructure. Channel adapters and alternative AI providers are installed on demand through setup flows and `/add-<name>` skills. This keeps your fork lean and your code legible: nothing you didn't ask for.
 
 ## Two kinds of integration
 
 <CardGroup cols={2}>
   <Card title="Channels" icon="plug" href="#channels">
-    Where messages come from: WhatsApp, Telegram, Discord, Slack, Teams, email, the terminal — 15+ adapters live on the `channels` branch
+    Where messages come from: Telegram, Discord, WhatsApp, Signal, Slack, Teams, iMessage, email, the terminal, and more
   </Card>
   <Card title="Providers" icon="robot" href="#providers">
     Which AI runs the agent: Claude (default), OpenAI Codex, OpenCode (OpenRouter/Google/DeepSeek), Ollama (local). Configurable per agent group.
@@ -20,7 +20,7 @@ NanoClaw trunk ships the registry and infrastructure. Channel adapters and alter
 
 ## Channels
 
-Install with a skill invocation in Claude Code. The skill copies the adapter from the `channels` branch into your fork and walks you through platform-specific auth.
+Install through `bash nanoclaw.sh` during first setup, or with a skill invocation in Claude Code later. Channel flows install the adapter, collect platform-specific auth, register the first messaging group, and restart the service when needed.
 
 ### Documented channels
 
@@ -38,7 +38,11 @@ Install with a skill invocation in Claude Code. The skill copies the adapter fro
   </Card>
 
   <Card title="Slack" icon="hashtag" href="/integrations/slack">
-    `/add-slack` — Socket Mode (no public URL required)
+    `/add-slack` — Slack app credentials plus a public events URL
+  </Card>
+
+  <Card title="Signal" icon="message-circle">
+    `/add-signal` — signal-cli linked-device flow
   </Card>
 </CardGroup>
 
@@ -46,7 +50,7 @@ Install with a skill invocation in Claude Code. The skill copies the adapter fro
 
 | Skill | Platform | Notes |
 |-------|----------|-------|
-| `/add-teams` | Microsoft Teams | Bot framework |
+| `/add-teams` | Microsoft Teams | Bot Framework |
 | `/add-imessage` | Apple iMessage | macOS-only; uses AppleScript bridge |
 | `/add-matrix` | Matrix | Federated; supports Element and self-hosted homeservers |
 | `/add-gchat` | Google Chat | Workspace accounts |
@@ -58,7 +62,7 @@ Install with a skill invocation in Claude Code. The skill copies the adapter fro
 | `/add-resend` | Email (outbound) | Transactional sends via Resend |
 | `/claw` | Local terminal | Talk to your agent from a CLI — no platform account required |
 
-Documentation for these is rolling out post-v2 launch. The skill itself is self-documenting via `SKILL.md` on the `channels` branch — ask Claude Code to walk you through any of them.
+Documentation for these is rolling out post-v2 launch. The skill itself is self-documenting via `SKILL.md` — ask Claude Code to walk you through any of them.
 
 ## Providers
 
@@ -75,19 +79,15 @@ By default, NanoClaw uses Claude via the official [Claude Agent SDK](https://doc
 
 ## How channel skills work
 
-1. **Skill invocation** — you run `/add-<channel>` in Claude Code from your NanoClaw directory
-2. **Copy, don't merge** — the skill reads the adapter source from the `channels` branch (not your trunk) and copies only the files for that channel into your fork
-3. **Platform auth** — the skill prompts for the tokens, OAuth flows, or QR pairing each platform requires
-4. **First messaging group** — the skill registers your first chat/channel/group from that platform so you can test immediately
-5. **Verify** — a round-trip test confirms inbound + outbound work before the skill exits
+1. **Skill or setup invocation** — you pick a channel in `bash nanoclaw.sh` or run `/add-<channel>` later from Claude Code
+2. **Adapter install** — the flow adds the channel adapter and any platform package dependencies
+3. **Platform auth** — the flow prompts for tokens, OAuth flows, QR pairing, or linked-device setup
+4. **First messaging group** — the flow registers your first chat/channel/group from that platform so you can test immediately
+5. **Verify** — a round-trip test confirms inbound + outbound work before the flow exits
 
-To update installed channel skills when the `channels` branch gets improvements:
+To pick up channel installer improvements, rerun the relevant `/add-<channel>` workflow. The installer fetches the current `channels` branch and updates the files it owns.
 
-```
-/update-skills
-```
-
-To remove a channel, revert the skill's commit:
+To remove a channel, revert the commit that installed it:
 
 ```
 git revert <skill-commit-sha>
@@ -107,7 +107,7 @@ The choice is per channel, configurable via `/manage-channels`. See [Channel iso
 
 <CardGroup cols={2}>
   <Card title="Skills system" icon="puzzle-piece" href="/integrations/skills-system">
-    How skill branches work, how to update, and how to author your own
+    How skills work, how to update, and how to author your own
   </Card>
   <Card title="Customization" icon="wrench" href="/features/customization">
     Trigger words, timeouts, engage modes, sender scope

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -7,7 +7,7 @@ tag: "UPDATED"
 keywords: ["nanoclaw", "ai team", "multi-agent", "claude", "agent sdk", "container isolation", "v2", "chat sdk"]
 ---
 
-NanoClaw started as a way to run a single Claude agent on WhatsApp. v2 turns it into a team. Spawn multiple agents, wire them to any mix of 15+ messaging channels, have them route work to each other, and keep every one of them isolated in its own Linux container.
+NanoClaw started as a way to run a single Claude agent on WhatsApp. v2 turns it into a team. Spawn multiple agents, wire them to messaging channels, have them route work to each other, and keep every one of them isolated in its own Linux container.
 
 One host process on your machine. One container per active session. A codebase small enough to hold in your head — and small enough for Claude Code to hold in its context window.
 
@@ -52,7 +52,7 @@ Scheduling is a timestamp column on a message row. Agent-to-agent delegation is 
 
 ### Multi-channel by design
 
-Install any subset of: WhatsApp, WhatsApp Cloud, Telegram, Discord, Slack, Microsoft Teams, Google Chat, Webex, iMessage, Matrix, WeChat, Linear, GitHub, Resend (email), Emacs, or the local CLI channel. Channels are thin adapters over [Vercel's Chat SDK](https://chat-sdk.dev/docs/adapters) — a new adapter is typically a short TypeScript file.
+Install any subset of: Telegram, Discord, WhatsApp, Signal, Microsoft Teams, Slack, iMessage, Google Chat, Webex, Matrix, WeChat, Linear, GitHub, Resend (email), Emacs, or the local CLI channel. Channels are adapters over the NanoClaw channel interface; Chat SDK-backed channels use [Vercel's Chat SDK](https://chat-sdk.dev/docs/adapters), while native channels keep their platform-specific runtime.
 
 ### Flexible isolation per channel
 
@@ -123,11 +123,11 @@ The install and onboarding flow is a scripted, deterministic path. When a step n
 - **Inbox/outbox session model** — `inbound.db` (host writes, container reads) and `outbound.db` (container writes, host reads). One writer per file eliminates SQLite cross-mount contention. No stdin piping, no IPC files.
 - **Entity model** — agent groups (workspaces) and messaging groups (platform channels) are independent. `messaging_group_agents` rows wire them together with per-wiring engage mode, sender scope, and session mode.
 - **Delivery loop** — two polls: an active poll (1s) for running sessions, a sweep (60s) for liveness and recovery. Heartbeat-based stale detection, not wall-clock timeouts.
-- **Channel adapters** — thin wrappers over [Vercel's Chat SDK](https://chat-sdk.dev/docs/adapters) on a `channels` branch. Add only what you use.
+- **Channel adapters** — modules on the `channels` branch that implement NanoClaw's channel interface. Some use [Vercel's Chat SDK](https://chat-sdk.dev/docs/adapters); native channels keep platform-specific runtime code.
 - **Credentials** — [OneCLI Agent Vault](https://github.com/onecli/onecli) is the sole credential path. Containers receive placeholder tokens; the vault injects real auth at request time and enforces per-agent policies.
 
 <Info>
-**Codebase size**: ~127k tokens (~64% of Claude's context window). Big for v1; still small enough that Claude Code can reason over the whole repo.
+**Codebase size**: ~133k tokens (~67% of Claude's context window). Big for v1; still small enough that Claude Code can reason over the whole repo.
 </Info>
 
 ## Key source files (host)

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -9,7 +9,7 @@ keywords: ["setup", "install", "getting started", "nanoclaw.sh", "bash", "claude
 From a fresh machine to an agent you can message — one command, a handful of prompts, a few minutes.
 
 <Note>
-This guide covers the default installer. If you want to customize the install path (skip steps, change the Anthropic secret name), see [Installation](/installation).
+This guide covers the default installer. If you want to skip steps, reuse an existing OneCLI instance, or point Anthropic traffic at a custom endpoint, see [Installation](/installation).
 </Note>
 
 ## The one-command flow
@@ -37,7 +37,7 @@ This guide covers the default installer. If you want to customize the install pa
     - Verifying your environment (platform, WSL detection, container runtime)
     - Building the agent container image
     - Registering your Anthropic credential with [OneCLI](https://github.com/onecli/onecli)
-    - Pairing your first channel (Telegram, Discord, WhatsApp, or the local CLI)
+    - Pairing your first channel (Telegram, Discord, WhatsApp, Signal, Teams, Slack, iMessage, or the local CLI)
     - Installing a systemd or launchd service so NanoClaw starts with your machine
 
     If any step fails, Claude Code is invoked automatically to diagnose and resume from where it broke. You don't have to debug the installer yourself.
@@ -48,8 +48,8 @@ This guide covers the default installer. If you want to customize the install pa
 
     - **Display name** — what you want your agent to be called (default: `Andy`)
     - **Anthropic credential method** — Claude subscription (OAuth), Anthropic API key, or skip
-    - **First channel** — Telegram, Discord, WhatsApp, or local CLI. You can add more later.
-    - **Channel-specific auth** — bot token for Telegram/Discord, QR code for WhatsApp, nothing for CLI
+    - **First channel** — Telegram, Discord, WhatsApp, Signal, Teams, Slack, iMessage, or local CLI. You can add more later.
+    - **Channel-specific auth** — pairing code, QR code, bot token, app credentials, or no extra auth for CLI, depending on the platform
 
     The flow is linear. One question at a time. You can Ctrl+C and restart; the installer picks up where you left off.
   </Step>
@@ -70,7 +70,7 @@ This guide covers the default installer. If you want to customize the install pa
     For the local CLI:
 
     ```bash
-    pnpm claw
+    pnpm run chat hi
     ```
 
     Your agent responds. You're set.
@@ -104,10 +104,14 @@ If something looks wrong after install, `logs/setup.log` is the first file to re
     Driven by `setup/auto.ts`. Each sub-step emits a structured status block and writes its raw output to `logs/setup-steps/NN-<name>.log`:
 
     - **environment** — Docker / Apple Container detection, runtime selection
-    - **container** — builds `nanoclaw-agent:latest` via `container/build.sh`
-    - **onecli** — installs OneCLI Agent Vault and registers your Anthropic secret
-    - **channel pairing** — runs the `add-<channel>` skill you picked
+    - **container** — builds the checkout-scoped agent image via `container/build.sh`
+    - **onecli** — installs OneCLI Agent Vault or reuses an existing configured instance
+    - **auth** — registers Anthropic credentials in OneCLI
+    - **cli-agent** — wires the terminal agent and confirms it responds before optional channel setup
+    - **timezone** — detects or resolves your IANA timezone
+    - **channel pairing** — runs the selected setup flow for Telegram, Discord, WhatsApp, Signal, Teams, Slack, or iMessage
     - **service** — launchd (macOS) / systemd (Linux) / `start-nanoclaw.sh` wrapper (WSL without systemd)
+    - **verify** — checks credentials, service status, registered groups, and first-agent connectivity
     - **diagnostics** — optional opt-in PostHog event with platform + channel choice
   </Accordion>
 
@@ -116,8 +120,8 @@ If something looks wrong after install, `logs/setup.log` is the first file to re
   </Accordion>
 
   <Accordion title="Service installation">
-    - **macOS** — creates launchd service at `~/Library/LaunchAgents/com.nanoclaw.plist`
-    - **Linux (systemd)** — user service at `~/.config/systemd/user/nanoclaw.service`; enables `loginctl linger` so the service survives SSH logout
+    - **macOS** — creates a launchd service named like `com.nanoclaw-v2-<slug>` in `~/Library/LaunchAgents/`
+    - **Linux (systemd)** — user service named like `nanoclaw-v2-<slug>.service`; enables `loginctl linger` so the service survives SSH logout
     - **WSL without systemd** — creates a `start-nanoclaw.sh` wrapper; you run it manually on login or wire it to `.bashrc`
   </Accordion>
 </AccordionGroup>
@@ -153,7 +157,7 @@ tail -f logs/nanoclaw.log
 
 # Service status
 launchctl list | grep nanoclaw     # macOS
-systemctl --user status nanoclaw   # Linux
+systemctl --user list-units 'nanoclaw*'  # Linux
 ```
 
 Or just ask:
@@ -168,7 +172,7 @@ Or just ask:
 
 <CardGroup cols={2}>
   <Card title="Add more channels" icon="plus" href="/integrations/overview">
-    `/add-slack`, `/add-whatsapp`, `/add-matrix` — install from the `channels` branch
+    `/add-slack`, `/add-whatsapp`, `/add-signal` — install or wire channels from the current channel setup flows
   </Card>
   <Card title="Customize" icon="wrench" href="/features/customization">
     Change the trigger word, tune timeouts, adjust engage modes

--- a/snippets/restart-service.mdx
+++ b/snippets/restart-service.mdx
@@ -1,11 +1,13 @@
 <CodeGroup>
 ```bash macOS
-npm run build
-launchctl kickstart -k gui/$(id -u)/com.nanoclaw
+pnpm run build
+launchctl list | grep nanoclaw
+launchctl kickstart -k gui/$(id -u)/<label>
 ```
 
 ```bash Linux
-npm run build
-systemctl --user restart nanoclaw
+pnpm run build
+systemctl --user list-units 'nanoclaw*'
+systemctl --user restart <unit>
 ```
 </CodeGroup>


### PR DESCRIPTION
## What does this change?

Refreshes the first-run and runtime docs against the current NanoClaw v2 source. This keeps the portal aligned with the deterministic `bash nanoclaw.sh` setup flow, checkout-scoped service and image names, current first-channel choices, OneCLI reuse behavior, and the current channel adapter model.

This also removes unsupported installer flag claims and corrects the Slack overview so it no longer describes Slack as Socket Mode without a public URL.

## Pages affected

- `introduction.mdx`
- `quickstart.mdx`
- `installation.mdx`
- `integrations/overview.mdx`
- `snippets/restart-service.mdx`
- `advanced/container-runtime.mdx`
- `api/configuration.mdx`
- `concepts/architecture.mdx`
- `concepts/containers.mdx`
- `features/cli.mdx`
- `features/messaging.mdx`

## Checklist

- [x] Previewed locally with `mint dev`
- [x] Added new pages to `docs.json` navigation (if applicable — no new pages added)
- [x] Links and cross-references work
- [x] Follows the [writing guidelines](../CONTRIBUTING.md#writing-guidelines)

Validation:

- `mint validate`
- `mint dev --port 3010`
- `curl -I http://localhost:3010` returned a local preview redirect to `/introduction`