### PR TITLE
phase-0: add v1-drift warning banners on five pages

### DIFF
--- a/api/overview.mdx
+++ b/api/overview.mdx
@@ -5,6 +5,11 @@ sidebarTitle: "Overview"
 keywords: ["api", "architecture", "data flow"]
 ---
 
+
+<Warning>
+This page describes the v1 file structure. In v2, `src/db.ts` became the `src/db/` directory (split into `agent-groups.ts`, `messaging-groups.ts`, `sessions.ts`, `session-db.ts`, plus a `migrations/` subdirectory). `src/task-scheduler.ts` no longer exists — scheduled tasks are now `messages_in` rows in each session's `inbound.db` (see [Task scheduling](/api/task-scheduling)). The host process is documented across `src/router.ts`, `src/delivery.ts`, `src/host-sweep.ts`, `src/session-manager.ts`, and `src/container-runner.ts`. A v2 rewrite is pending. See [System architecture](/concepts/architecture) and [Message routing](/api/message-routing) for current context.
+</Warning>
+
 NanoClaw is a single Node.js process that connects to messaging channels (WhatsApp, Telegram, Discord, Slack, Gmail) and routes messages to Claude Agent SDK instances running in isolated containers. Each group has its own filesystem and memory.
 
 ## Architecture

--- a/features/agent-swarms.mdx
+++ b/features/agent-swarms.mdx
@@ -4,6 +4,11 @@ description: Spin up teams of specialized Claude agents that collaborate on comp
 keywords: ["agent swarms", "multi-agent", "collaboration"]
 ---
 
+
+<Warning>
+This page describes the v1 "Agent Swarms" framing. v2 ships **agent-to-agent** primitives instead — `TeamCreate` / `TeamDelete` SDK tools plus the `src/modules/agent-to-agent/` host module for cross-agent message routing within an install. A v2 rewrite is pending. See [Integrations overview](/integrations/overview) for current context.
+</Warning>
+
 ## Overview
 
 NanoClaw is the first personal AI assistant to support **Agent Swarms** - teams of specialized agents that collaborate on complex tasks. This feature is powered by Claude Code's experimental agent teams functionality.

--- a/features/image-vision.mdx
+++ b/features/image-vision.mdx
@@ -4,6 +4,11 @@ description: Process image attachments with multimodal AI understanding
 keywords: ["image", "vision", "multimodal", "whatsapp", "attachments"]
 ---
 
+
+<Warning>
+**v1-only feature; not needed in v2.** The `/add-image-vision` skill no longer ships in v2. Image handling is now native to the Claude provider — JPEG, PNG, GIF, and WebP attachments are passed directly to Claude as image content blocks (see `docs/architecture.md` §"Native content blocks" in the framework repo). No skill installation required. This page is pending deletion.
+</Warning>
+
 NanoClaw can understand images sent as message attachments using Claude's multimodal capabilities. The agent sees the image content and can describe, analyze, or act on it.
 
 <Note>

--- a/features/pdf-reader.mdx
+++ b/features/pdf-reader.mdx
@@ -4,6 +4,11 @@ description: Extract and process text from PDF attachments and URLs
 keywords: ["pdf", "document", "text extraction", "whatsapp", "poppler"]
 ---
 
+
+<Warning>
+**v1-only feature; not needed in v2.** The `/add-pdf-reader` skill no longer ships in v2. PDF handling is now native to the Claude provider — PDFs are passed directly to Claude as document content blocks (see `docs/architecture.md` §"Native content blocks" in the framework repo). No skill installation required. This page is pending deletion.
+</Warning>
+
 NanoClaw can extract text from PDF files sent as attachments, shared via URL, or stored locally. The agent can then read, summarize, or answer questions about the document content.
 
 <Note>

--- a/features/voice-transcription.mdx
+++ b/features/voice-transcription.mdx
@@ -4,6 +4,11 @@ description: Transcribe voice messages using OpenAI Whisper API or local whisper
 keywords: ["voice", "transcription", "whisper", "speech-to-text", "whatsapp"]
 ---
 
+
+<Warning>
+**v1-only feature.** The `/add-voice-transcription` skill no longer ships in v2 — it is not present on trunk, the `channels` branch, or the `providers` branch. Voice transcription was a v1 fork-only capability tied to WhatsApp via the deprecated `nanoclaw-whatsapp` fork. This page is pending deletion; the instructions below do not apply to v2 installs.
+</Warning>
+
 NanoClaw can transcribe voice messages so the agent understands audio content. Two options are available: cloud-based (OpenAI Whisper API) and fully local (whisper.cpp).
 
 <Note>


### PR DESCRIPTION
These pages are factually wrong against v2 but currently carry no warning,
so a reader treats them as canonical. Phase 0 of the drift-fix queue:
prevent harm now; rewrites/deletions follow.

- features/agent-swarms.mdx — v1 framing of what is now agent-to-agent
  (TeamCreate / TeamDelete + src/modules/agent-to-agent/)
- features/voice-transcription.mdx — /add-voice-transcription does not ship
  in v2 (verified absent from trunk, channels, providers branches)
- features/image-vision.mdx — /add-image-vision does not ship in v2; image
  handling is native via Claude content blocks
- features/pdf-reader.mdx — /add-pdf-reader does not ship in v2; PDF
  handling is native via Claude document content blocks
- api/overview.mdx — describes v1 file structure (src/db.ts,
  src/task-scheduler.ts) that no longer exists

Pages pending full rewrite or deletion in subsequent phases. Banners
follow the existing convention used on integrations/whatsapp.mdx,
telegram.mdx, etc.

Verified against qwibitai/nanoclaw@1b08b58
