### PR TITLE
docs: rewrite Get started group (v2, code-verified) + migration guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -126,7 +126,7 @@
           {
             "group": "Get started",
             "icon": "rocket",
-            "pages": ["introduction", "quickstart", "installation"]
+            "pages": ["introduction", "quickstart", "installation", "migrate-from-v1"]
           },
           {
             "group": "Channels",

--- a/installation.mdx
+++ b/installation.mdx
@@ -1,346 +1,254 @@
 ---
-title: Installation
-description: Requirements and platform-specific setup for macOS, Linux, and Windows (WSL2).
+title: "Installation"
+description: "Requirements, what the installer does under the hood, manual setup, service management, and where NanoClaw puts its files."
 icon: "download"
 tag: "UPDATED"
-keywords: ["requirements", "docker", "node", "apple container", "wsl", "onecli", "bun", "nanoclaw.sh"]
+keywords: ["requirements", "docker", "node", "pnpm", "bun", "wsl", "launchd", "systemd", "onecli", "nanoclaw.sh", "manual install"]
 ---
 
-Everything you need to know before running `bash nanoclaw.sh`. For the one-command install flow itself, see [Quick start](/quickstart).
+{/* verified-against: nanoclaw.sh, setup.sh, setup/probe.sh, setup/auto.ts, setup/index.ts, setup/install-node.sh, setup/install-docker.sh, setup/container.ts, setup/service.ts, setup/set-env.ts, container/Dockerfile, src/container-runtime.ts, src/container-runner.ts, src/claude-md-compose.ts, src/group-init.ts, src/config.ts, src/install-slug.ts, src/session-manager.ts, src/index.ts, package.json @ dc34ceb */}
 
-## System requirements
+This page is the depth companion to [Quick start](/quickstart): what the installer actually does, how to install by hand, how the background service works, and where everything lands on disk. If you just want a running assistant, run `bash nanoclaw.sh` and follow the wizard — quick start covers that flow end to end.
 
-<Tabs>
-  <Tab title="macOS">
-    - macOS 12 (Monterey) or later
-    - Intel or Apple Silicon (M1/M2/M3/M4)
-    - 4 GB RAM minimum, 8 GB recommended
-    - 4 GB free disk space (container image + node_modules)
-  </Tab>
+## Requirements
 
-  <Tab title="Linux">
-    - Ubuntu 22.04+, Debian 12+, or equivalent
-    - x86_64 or aarch64
-    - 2 GB RAM minimum, 4 GB recommended
-    - 4 GB free disk space
-    - systemd (for the user service)
-  </Tab>
-
-  <Tab title="Windows (WSL2)">
-    - Windows 10 2004+ or Windows 11
-    - WSL 2 with Ubuntu 22.04+
-    - 4 GB RAM minimum, 8 GB recommended
-    - 4 GB free disk space (inside the WSL filesystem)
-    - Docker Desktop with WSL 2 backend enabled
-
-    <Note>
-    NanoClaw runs inside WSL, not natively on Windows. All commands go in a WSL terminal.
-    </Note>
-  </Tab>
-</Tabs>
-
-## What the installer needs
-
-`nanoclaw.sh` installs most things for you. This list exists so you know the dependency surface before running it.
-
-| Dependency | Scope | Installer handles it? |
-|---|---|---|
-| Node 22 | Host (orchestrator) | Yes — via nvm if missing |
-| pnpm 10 | Host (package manager) | Yes — via `corepack enable` |
-| Docker (or Apple Container) | Host (container runtime) | Partial — prompts you to install or start it if absent |
-| Build tools (gcc, python3) | Host (for `better-sqlite3` native compile) | No — install beforehand |
-| OneCLI Agent Vault | Host (credential injection) | Yes — installs locally or reuses an existing configured instance |
-| Bun 1.3.12 | Container (agent-runner runtime) | Yes — baked into the agent container image |
-
-### Build tools
-
-`better-sqlite3` is the only host dependency that needs native compilation. Install the platform toolchain before running `nanoclaw.sh`:
-
-<Tabs>
-  <Tab title="macOS">
-    ```bash
-    xcode-select --install
-    ```
-  </Tab>
-
-  <Tab title="Linux">
-    ```bash
-    sudo apt-get update
-    sudo apt-get install -y build-essential python3
-    ```
-  </Tab>
-
-  <Tab title="Windows (WSL2)">
-    Same as Linux, inside your WSL terminal:
-    ```bash
-    sudo apt-get update
-    sudo apt-get install -y build-essential python3
-    ```
-  </Tab>
-</Tabs>
-
-### Container runtime
-
-Docker is the default and works on all three platforms. Apple Container is an opt-in alternative on macOS 15+.
-
-<Tabs>
-  <Tab title="Docker (default)">
-    **macOS:**
-    ```bash
-    brew install --cask docker
-    open -a Docker
-    ```
-
-    **Linux:**
-    ```bash
-    curl -fsSL https://get.docker.com | sh
-    sudo usermod -aG docker $USER
-    sudo systemctl enable --now docker
-    # Log out and back in for group membership to take effect
-    ```
-
-    **Windows (WSL2):** Install [Docker Desktop](https://docs.docker.com/desktop/install/windows-install/), then enable WSL integration in Settings → Resources → WSL Integration for your distro.
-
-    <Warning>
-    WSL users: do not install Docker Engine inside WSL directly. Use Docker Desktop's WSL 2 backend. Installing both causes conflicts.
-    </Warning>
-  </Tab>
-
-  <Tab title="Apple Container (macOS 15+)">
-    Lightweight native macOS runtime. Opt-in after setup via `/convert-to-apple-container`.
-
-    ```bash
-    brew install container
-    container --version
-    ```
-
-    <Note>
-    The default installer picks Docker. To switch, run `/convert-to-apple-container` after NanoClaw is running. The skill modifies the runtime integration and uses `git revert` as the rollback path.
-    </Note>
-  </Tab>
-</Tabs>
-
-### Advanced installer environment
-
-`nanoclaw.sh` and `setup:auto` read environment variables when you need to debug or script part of setup.
-
-| Env var | Use |
+| | Requirement |
 |---|---|
-| `NANOCLAW_SKIP` | Comma-separated setup steps to skip while debugging (`environment`, `container`, `onecli`, `auth`, `mounts`, `service`, `cli-agent`, `timezone`, `channel`, `verify`, `first-chat`) |
-| `NANOCLAW_DISPLAY_NAME` | Skip the operator display-name prompt |
-| `NANOCLAW_AGENT_NAME` | Set the messaging-channel agent name; the CLI scratch agent remains `Terminal Agent` |
-| `SECRET_NAME` | OneCLI secret name for `setup/register-claude-token.sh` (default: `Anthropic`) |
-| `HOST_PATTERN` | OneCLI host pattern for `setup/register-claude-token.sh` (default: `api.anthropic.com`) |
+| Platform | macOS or Linux. Windows works through WSL2 — the installer detects WSL and treats it as Linux. |
+| RAM | 4 GB+. The installer warns below 3,700 MB (a "4 GB" VM typically reports 3,700–3,900 MB after kernel reserves) and lets you override. |
+| Node.js | 20 or newer on the host (`engines` in `package.json`). Installed for you if missing. |
+| git | To clone the repository. Not auto-installed. |
+| Claude credential | A Claude subscription (sign-in via browser), an OAuth token (`sk-ant-oat…`), or an Anthropic API key (`sk-ant-api…`). |
 
-If OneCLI is already installed and configured, setup asks whether to reuse it. For custom Anthropic-compatible model endpoints, set `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN` in `.env`.
+Two hosts the installer explicitly flags in pre-flight:
 
-## Run the installer
+- **Google Compute Engine VMs** — GCE blocks the sudo commands setup needs, so NanoClaw is unlikely to run there. The installer detects GCE via DMI and warns before doing anything. Use a different provider.
+- **Root on Linux** — discouraged. The installer offers instructions for creating a regular user instead. If you insist, it installs a system-level systemd unit rather than a user one.
 
-Once the system dependencies above are in place:
+### What's installed for you
+
+`nanoclaw.sh` installs everything below if it's missing. You don't need to pre-install any of it.
+
+| Dependency | Where it runs | How it's installed |
+|---|---|---|
+| Homebrew (macOS only) | Host | Official installer, after a prompt. Pulls in Apple's Command Line Tools (can take 5–10 minutes on a factory Mac). |
+| Node 22 | Host | `uvx nodeenv -n lts` if `uvx` is present; otherwise `brew install node@22` (macOS) or NodeSource + `apt-get` (Linux). Skipped if you already have Node 20+. |
+| pnpm 10 | Host | `corepack enable`, falling back to `npm install -g pnpm@<pinned>` at the version from `packageManager`. |
+| Docker | Host | `brew install --cask docker` (macOS) or `get.docker.com` + `usermod -aG docker` (Linux/WSL). Setup also starts the daemon and works around stale group membership (`sg docker` re-exec, or a temporary ACL on the socket) so you don't have to log out and back in. |
+| OneCLI vault | Host | Installed by the wizard, or reuses an existing healthy OneCLI instance if it finds one. |
+| Bun 1.3.12 | Container | Baked into the agent container image. Never touches the host. |
+
+Build tools (Xcode Command Line Tools on macOS, `gcc`/`make` on Linux) are checked and reported but not installed. They only matter if `better-sqlite3` has to compile from source — setup verifies the native binding loads and fails loudly if it doesn't.
+
+## What the installer does under the hood
+
+`bash nanoclaw.sh` is a three-stage chain:
+
+1. **`nanoclaw.sh`** — pre-flight checks (RAM floor, GCE detection, root warning, Homebrew prompt on macOS), then runs the bootstrap under a spinner. Bash only — nothing else exists on the machine yet.
+2. **`setup.sh`** — detects the platform (macOS / Linux / WSL), installs Node 22 via `setup/install-node.sh` if Node 20+ isn't present, gets pnpm onto the PATH, runs `pnpm install --frozen-lockfile`, and verifies the `better-sqlite3` native module loads.
+3. **`pnpm run setup:auto`** — the interactive wizard (`setup/auto.ts`). This is where the container build, OneCLI vault, Claude auth, service install, and channel pairing happen. [Quick start](/quickstart) walks through every wizard step.
+
+Every run writes two logs: a progression log at `logs/setup.log` (one entry per step) and verbatim per-step output under `logs/setup-steps/NN-name.log`. When something fails, start there.
+
+## One runtime on the host, another in the container
+
+NanoClaw deliberately splits runtimes:
+
+- **Host**: Node 20+ and pnpm. The wizard compiles TypeScript with `tsc` and the service runs `node dist/index.js`.
+- **Agent container**: Bun 1.3.12 runs the agent-runner TypeScript directly — no build step. The image (from `container/Dockerfile`) is based on `node:22-slim` with `tini` as PID 1, Chromium for browser automation, and globally installed CLIs — `@anthropic-ai/claude-code` and `vercel` pinned for reproducibility, `agent-browser` tracking latest.
+
+Two consequences worth knowing:
+
+- **Agent source is never baked into the image.** The host bind-mounts `container/agent-runner/src` read-only at `/app/src`, so agent-runner changes take effect on the next container spawn without a rebuild. The host's own `src/` is different: the service runs the compiled `dist/`, so host changes need `pnpm run build` and a service restart.
+- **The image is per-checkout**: `nanoclaw-agent-v2-<slug>:latest`, where the slug is the first 8 hex chars of `sha1(projectRoot)`. Two NanoClaw installs on one host never clobber each other's image, service, or containers.
+
+**Docker is the only supported runtime.** `src/container-runtime.ts` hardcodes the binary (`CONTAINER_RUNTIME_BIN = 'docker'`) behind a single-file abstraction — all runtime-specific logic lives in that one file, but nothing else is wired up today.
+
+If you render Chinese, Japanese, or Korean text, set `INSTALL_CJK_FONTS=true` in `.env` before the container build — it adds Noto CJK fonts (~200 MB) to the image.
+
+## Manual installation
+
+If you'd rather not run `nanoclaw.sh` (or it failed partway), the pieces compose by hand:
 
 ```bash
 git clone https://github.com/nanocoai/nanoclaw.git
 cd nanoclaw
-bash nanoclaw.sh
+pnpm install
+pnpm run setup:auto
 ```
 
-The installer walks through bootstrap, container build, OneCLI credential registration, channel pairing, and service installation. Progress streams to your terminal; full per-step logs land in `logs/setup.log` and `logs/setup-steps/`.
+`setup:auto` is the same wizard the one-liner hands off to — it builds the container image, sets up credentials, and installs the background service. Without it, you can run the host in the foreground:
 
-For the step-by-step breakdown of what each phase does, see [Quick start](/quickstart).
+```bash
+pnpm run build && pnpm start   # compiled, what the service runs
+pnpm run dev                   # tsx, no build step
+```
 
-## File structure after install
+### Re-running individual steps
+
+`pnpm run setup` is a step runner, not a second wizard. Use it to re-run one piece of setup without going through the whole flow:
+
+```bash
+pnpm run setup -- --step container   # rebuild and re-test the agent image
+pnpm run setup -- --step service     # rebuild TypeScript and reinstall the service
+pnpm run setup -- --step verify      # end-to-end health check
+```
+
+Available steps: `timezone`, `set-env`, `environment`, `container`, `register`, `pair-telegram`, `groups`, `whatsapp-auth`, `signal-auth`, `mounts`, `service`, `verify`, `onecli`, `auth`, `cli-agent`.
+
+### Scripting the wizard
+
+`setup:auto` reads environment variables for unattended or partial runs:
+
+| Env var | Use |
+|---|---|
+| `NANOCLAW_SKIP` | Comma-separated wizard steps to skip: `environment`, `container`, `onecli`, `auth`, `mounts`, `service`, `cli-agent`, `first-chat`, `timezone`, `channel`, `verify` |
+| `NANOCLAW_DISPLAY_NAME` | Skip the "what should the assistant call you" prompt |
+| `NANOCLAW_AGENT_NAME` | Set the messaging-channel agent name |
+| `SECRET_NAME` | OneCLI secret name (default: `Anthropic`) |
+| `HOST_PATTERN` | OneCLI host pattern (default: `api.anthropic.com`) |
+
+For Anthropic-compatible custom endpoints, set `ANTHROPIC_BASE_URL` in `.env` — the host passes it through to the agent SDK inside the container.
+
+## Running as a service
+
+The wizard's service step compiles TypeScript (`pnpm run build`), writes a service definition that runs `node dist/index.js` from the project root, starts it, and symlinks `bin/ncl` into `~/.local/bin` so the [ncl CLI](/operate/ncl-cli) works from anywhere. Service names embed the per-checkout slug, so look yours up rather than guessing.
+
+<Tabs>
+  <Tab title="macOS (launchd)">
+    The plist lands at `~/Library/LaunchAgents/com.nanoclaw-v2-<slug>.plist` with `RunAtLoad` and `KeepAlive` — it starts at login and restarts on crash.
+
+    ```bash
+    # Find your label
+    launchctl list | grep nanoclaw
+
+    # Restart
+    launchctl kickstart -k gui/$(id -u)/com.nanoclaw-v2-<slug>
+
+    # Stop / start
+    launchctl unload ~/Library/LaunchAgents/com.nanoclaw-v2-<slug>.plist
+    launchctl load   ~/Library/LaunchAgents/com.nanoclaw-v2-<slug>.plist
+
+    # Logs (stdout and stderr go to files, not the system log)
+    tail -f logs/nanoclaw.log logs/nanoclaw.error.log
+    ```
+  </Tab>
+
+  <Tab title="Linux (systemd)">
+    A user unit lands at `~/.config/systemd/user/nanoclaw-v2-<slug>.service` with `Restart=always`. (If you set up as root, it's a system unit at `/etc/systemd/system/` instead — drop the `--user` flag.)
+
+    ```bash
+    # Find your unit
+    systemctl --user list-units 'nanoclaw-v2-*'
+
+    systemctl --user restart nanoclaw-v2-<slug>
+    systemctl --user status  nanoclaw-v2-<slug>
+
+    # Logs append to files, not the journal
+    tail -f logs/nanoclaw.log logs/nanoclaw.error.log
+    ```
+
+    <Note>
+    Setup runs `loginctl enable-linger` so the user service survives SSH logout. Verify with `loginctl show-user $USER | grep Linger`.
+    </Note>
+  </Tab>
+
+  <Tab title="No systemd (WSL fallback)">
+    On WSL (or any Linux) without a systemd user session, setup writes a wrapper script instead of a unit:
+
+    ```bash
+    bash start-nanoclaw.sh        # start (stops any previous instance first)
+    kill $(cat nanoclaw.pid)      # stop
+    tail -f logs/nanoclaw.log     # logs
+    ```
+
+    To get a real service, enable systemd in WSL (`/etc/wsl.conf` → `[boot] systemd=true`, then `wsl --shutdown` from PowerShell) and re-run `pnpm run setup -- --step service`.
+  </Tab>
+</Tabs>
+
+## Where files live
+
+Everything stateful lives inside the checkout, with two exceptions: security allowlists in `~/.config/nanoclaw/` (kept outside the project so they're never mounted into containers) and the service definition.
 
 <Tree>
   <Tree.Folder name="nanoclaw" defaultOpen>
-    <Tree.Folder name="src">
-      <Tree.File name="index.ts" />
-      <Tree.File name="session-manager.ts" />
-      <Tree.File name="container-runner.ts" />
-      <Tree.Folder name="db" />
-      <Tree.Folder name="channels" />
-    </Tree.Folder>
+    <Tree.Folder name="src" />
+    <Tree.Folder name="dist" />
     <Tree.Folder name="container">
       <Tree.File name="Dockerfile" />
-      <Tree.File name="entrypoint.sh" />
+      <Tree.File name="build.sh" />
+      <Tree.File name="CLAUDE.md" />
       <Tree.Folder name="agent-runner" />
     </Tree.Folder>
     <Tree.Folder name="groups" defaultOpen>
       <Tree.Folder name="main" defaultOpen>
+        <Tree.File name="CLAUDE.local.md" />
         <Tree.File name="CLAUDE.md" />
         <Tree.File name="container.json" />
       </Tree.Folder>
     </Tree.Folder>
     <Tree.Folder name="data" defaultOpen>
       <Tree.File name="v2.db" />
-      <Tree.Folder name="env" />
       <Tree.Folder name="v2-sessions" defaultOpen>
         <Tree.Folder name="{agent_group_id}" defaultOpen>
-          <Tree.Folder name="{session_id}" defaultOpen>
+          <Tree.Folder name="{session_id}">
             <Tree.File name="inbound.db" />
             <Tree.File name="outbound.db" />
             <Tree.File name=".heartbeat" />
           </Tree.Folder>
+          <Tree.Folder name=".claude-shared" />
         </Tree.Folder>
       </Tree.Folder>
+      <Tree.Folder name="env">
+        <Tree.File name="env" />
+      </Tree.Folder>
+      <Tree.Folder name="ipc" />
+      <Tree.File name="cli.sock" />
     </Tree.Folder>
     <Tree.Folder name="logs">
       <Tree.File name="nanoclaw.log" />
+      <Tree.File name="nanoclaw.error.log" />
       <Tree.File name="setup.log" />
       <Tree.Folder name="setup-steps" />
     </Tree.Folder>
+    <Tree.Folder name="bin">
+      <Tree.File name="ncl" />
+    </Tree.Folder>
     <Tree.File name=".env" />
     <Tree.File name="nanoclaw.sh" />
-    <Tree.File name="package.json" />
   </Tree.Folder>
 </Tree>
 
-**External files** (outside the project directory):
+The highlights:
 
 | Path | Purpose |
-|------|---------|
-| `~/.config/nanoclaw/mount-allowlist.json` | Which host directories agents can mount |
-| `~/.config/nanoclaw/sender-allowlist.json` | Optional per-channel sender access control |
-| `~/Library/LaunchAgents/com.nanoclaw-v2-<slug>.plist` (macOS) | launchd service definition |
-| `~/.config/systemd/user/nanoclaw-v2-<slug>.service` (Linux) | systemd user-service definition |
-
-## Container image contents
-
-The agent container image is scoped per checkout, with a name like `nanoclaw-agent-v2-<slug>:latest`. It is built from `container/Dockerfile`:
-
-- **Base**: `node:22-slim`
-- **tini** as PID 1 — reaps Chromium zombies, forwards signals so `outbound.db` writes finalize on SIGTERM
-- **Bun 1.3.12** runs the agent-runner TypeScript directly (no `tsc` build step)
-- **Chromium** for browser automation via `agent-browser`
-- **Global Node CLIs (pnpm)**: `@anthropic-ai/claude-code`, `agent-browser`, `vercel`
-- **Non-root `node` user**, `/workspace/group` as working directory
-- **Source is never baked in** — `/app/src` is a read-only bind mount from the host, so code changes take effect without rebuilding
-
-Optional: `INSTALL_CJK_FONTS=true` in `.env` adds Chinese/Japanese/Korean font support (~200 MB).
-
-## Service management
-
-NanoClaw runs as a background service so the host stays responsive to channel events between your messages.
-
-<Tabs>
-  <Tab title="macOS (launchd)">
-    ```bash
-    # Start / stop
-    # Replace <label> with com.nanoclaw-v2-<slug>
-    launchctl load ~/Library/LaunchAgents/<label>.plist
-    launchctl unload ~/Library/LaunchAgents/<label>.plist
-
-    # Restart
-    launchctl kickstart -k gui/$(id -u)/<label>
-
-    # Status
-    launchctl list | grep nanoclaw
-
-    # Logs
-    tail -f logs/nanoclaw.log
-    ```
-  </Tab>
-
-  <Tab title="Linux (systemd)">
-    ```bash
-    # Replace <unit> with nanoclaw-v2-<slug>
-    systemctl --user start <unit>
-    systemctl --user stop <unit>
-    systemctl --user restart <unit>
-    systemctl --user status <unit>
-
-    # Enable on boot
-    systemctl --user enable <unit>
-
-    # Logs
-    journalctl --user -u <unit> -f
-    ```
-
-    <Note>
-    **VM / SSH users:** the installer runs `loginctl enable-linger` so the service survives SSH logout. Verify with `loginctl show-user $USER | grep Linger`.
-    </Note>
-  </Tab>
-
-  <Tab title="WSL (without systemd)">
-    If WSL doesn't have systemd enabled, the installer drops a wrapper script:
-
-    ```bash
-    bash start-nanoclaw.sh
-    pkill -f "bun.*src/index.ts"     # stop
-    tail -f logs/nanoclaw.log        # logs
-    ```
-
-    To enable systemd in WSL (recommended):
-    ```bash
-    echo -e "[boot]\nsystemd=true" | sudo tee /etc/wsl.conf
-    # Restart WSL from PowerShell: wsl --shutdown
-    ```
-  </Tab>
-</Tabs>
-
-## Troubleshooting
-
-### `better-sqlite3` build errors
-
-```bash
-pnpm rebuild better-sqlite3
-# or
-rm -rf node_modules pnpm-lock.yaml && pnpm install
-```
-
-If the error mentions Python: `sudo apt-get install python3` (Linux/WSL) or `xcode-select --install` (macOS).
-
-### Container build fails
-
-```bash
-# Docker
-docker builder prune -f
-./container/build.sh
-
-# Apple Container
-container builder stop && container builder rm && container builder start
-./container/build.sh
-```
-
-### Service won't start
-
-Check the error log and the setup progression log:
-
-```bash
-cat logs/nanoclaw.error.log
-cat logs/setup.log
-```
-
-Ask the agent itself for a diagnostic once it's up:
-
-```
-@Andy /debug
-```
-
-### WSL: Docker integration
-
-If `docker` commands aren't found in WSL, enable WSL integration in Docker Desktop (Settings → Resources → WSL Integration → toggle your distro). Restart WSL from PowerShell if needed:
-
-```powershell
-wsl --shutdown
-```
-
-### WSL: slow builds
-
-Clone into the Linux filesystem (`~/nanoclaw`), not `/mnt/c/`. The 9P bridge to Windows drives is 10-100× slower than native Linux FS operations.
+|---|---|
+| `groups/<folder>/CLAUDE.local.md` | Per-group agent instructions — this is the file you edit. |
+| `groups/<folder>/CLAUDE.md` | Regenerated at every container spawn from the shared base plus enabled skills. Don't edit it — your changes get overwritten. |
+| `groups/<folder>/container.json` | Per-group container overrides. |
+| `container/CLAUDE.md` | Shared base instructions for all agents, mounted read-only into every container. |
+| `data/v2.db` | Host state database (registered groups, tasks, sessions). |
+| `data/v2-sessions/` | Per-session message queues — `inbound.db` (host writes) and `outbound.db` (container writes). |
+| `data/env/env` | Container-mounted copy of `.env`, synced by setup. |
+| `~/.config/nanoclaw/mount-allowlist.json` | Which host directories agents may mount. Never mounted into containers. |
+| `~/.config/nanoclaw/sender-allowlist.json` | Optional per-channel sender access control. |
+| `~/.local/bin/ncl` | Symlink to `bin/ncl` so the CLI works from any directory. |
+| `~/Library/LaunchAgents/com.nanoclaw-v2-<slug>.plist` | launchd service (macOS). |
+| `~/.config/systemd/user/nanoclaw-v2-<slug>.service` | systemd user service (Linux). |
 
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Quick start" icon="rocket" href="/quickstart">
-    Run `bash nanoclaw.sh` and send your first message
+  <Card title="Quick start" icon="bolt" href="/quickstart">
+    The one-command flow and the wizard, step by step.
   </Card>
   <Card title="Architecture" icon="diagram-project" href="/concepts/architecture">
-    How the two-DB session model works
+    How the host, containers, and the two-DB session model fit together.
   </Card>
-  <Card title="Integrations" icon="plug" href="/channels/overview">
-    Add channels: Telegram, Slack, Discord, and more
+  <Card title="The ncl CLI" icon="terminal" href="/operate/ncl-cli">
+    Inspect agents, groups, and sessions from the command line.
   </Card>
-  <Card title="Customization" icon="wrench" href="/guides/customize-an-agent">
-    Change the trigger word, adjust timeouts, tune engage modes
+  <Card title="Troubleshooting" icon="life-ring" href="/operate/troubleshooting">
+    Setup failures start at `logs/setup.log`; runtime issues at `logs/nanoclaw.log`.
   </Card>
 </CardGroup>

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -1,153 +1,68 @@
 ---
 title: "What is NanoClaw?"
-description: From AI assistant to AI team. Multiple Claude agents running in parallel, talking to each other, isolated in their own containers — installed and customized through Claude itself.
+description: "A multi-agent Claude assistant. One host process, one Docker container per session, and a SQLite queue that carries every message in the system."
 icon: "house"
 sidebarTitle: "Introduction"
 tag: "UPDATED"
-keywords: ["nanoclaw", "ai team", "multi-agent", "claude", "agent sdk", "container isolation", "v2", "chat sdk"]
+keywords: ["nanoclaw", "multi-agent", "claude", "container isolation", "inbox outbox", "sqlite", "channels", "skills", "v2"]
 ---
 
-NanoClaw started as a way to run a single Claude agent on WhatsApp. v2 turns it into a team. Spawn multiple agents, wire them to messaging channels, have them route work to each other, and keep every one of them isolated in its own Linux container.
+{/* verified-against: src/index.ts, src/router.ts, src/channels/index.ts, src/container-runtime.ts, src/container-runner.ts, src/db/schema.ts, src/modules/, container/agent-runner/src/mcp-tools/agents.ts, agents.instructions.md, core.ts, .claude/skills/, .claude/skills/add-telegram/SKILL.md, repo-tokens/badge.svg, package.json @ dc34ceb */}
 
-One host process on your machine. One container per active session. A codebase small enough to hold in your head — and small enough for Claude Code to hold in its context window.
+NanoClaw runs Claude agents that talk to you over your messaging apps — and to each other. One Node host process handles routing and delivery. Every active session gets its own Docker container, so agents can run Bash and edit files without touching your host or each other.
+
+A single pattern drives the whole system: every message is a row in a SQLite queue. A user chat, an inbound webhook, a scheduled job, an agent delegating to another agent — all of them land in an inbox table (`messages_in`), and every response leaves through an outbox (`messages_out`). A scheduled task is just a message with a `process_after` timestamp. There is no separate scheduler, RPC layer, or job system to learn.
 
 <CardGroup cols={2}>
-  <Card title="Quick start" icon="rocket" href="/quickstart">
-    Get running in one command with `bash nanoclaw.sh`
+  <Card title="Run it" icon="rocket" href="/quickstart">
+    Clone, install, and talk to your first agent.
   </Card>
-  <Card title="Installation" icon="download" href="/installation">
-    Requirements, platform notes, and what the installer does
+  <Card title="Coming from v1 or OpenClaw" icon="route" href="/migrate-from-v1">
+    What changed, what carries over, and the migration skills that do the work.
   </Card>
-  <Card title="Architecture" icon="diagram-project" href="/concepts/architecture">
-    The session DB, the entity model, and the inbox/outbox pattern
+  <Card title="Make it yours" icon="wrench" href="/extend/overview">
+    Add channels, tools, skills, and alternative agent providers to your fork.
   </Card>
-  <Card title="Security" icon="shield" href="/concepts/security">
-    Container isolation, OneCLI credentials, sender policies
-  </Card>
-</CardGroup>
-
-## From AI assistant to AI team
-
-Most agents handle one conversation at a time. NanoClaw v2 runs as many parallel conversations as you want, on as many channels as you want, with as many agents as you want — and lets them coordinate.
-
-A single pattern drives the whole system: every message goes through an inbox, every response comes out of an outbox. User chats, webhooks, scheduled jobs, and agent-to-agent calls are all just rows in a queue.
-
-Example: three agent groups sharing one Discord channel for PR review.
-
-- A **worker** agent spawns per thread — one reviewer per PR.
-- A **manager** agent reads every thread and tracks what's in flight.
-- A **supervisor** agent stays silent until a worker requests human approval, then DMs you a card to approve or reject.
-
-Three agents, one channel, one pattern. No separate scheduler, no separate RPC layer, no separate approval system — just messages addressed to different inboxes.
-
-## Why NanoClaw
-
-### Agents that stay out of each other's filesystems
-
-Every agent runs in a Linux container with true filesystem isolation — it only sees what's explicitly mounted. Bash and file-editing tools are safe because commands execute inside the container, not on your host. Credentials never enter the container; they're injected at the HTTPS layer by [OneCLI Agent Vault](/concepts/security#credential-vault).
-
-### One pattern for messages, schedules, and routing
-
-Scheduling is a timestamp column on a message row. Agent-to-agent delegation is a row written to another agent's inbox. Multi-user approvals are messages routed to an owner's DM with an action card attached. You only learn one model.
-
-### Multi-channel by design
-
-Install any subset of: Telegram, Discord, WhatsApp, Signal, Microsoft Teams, Slack, iMessage, Google Chat, Webex, Matrix, WeChat, Linear, GitHub, Resend (email), Emacs, or the local CLI channel. Channels are adapters over the NanoClaw channel interface; Chat SDK-backed channels use [Vercel's Chat SDK](https://chat-sdk.dev/docs/adapters), while native channels keep their platform-specific runtime.
-
-### Flexible isolation per channel
-
-For every channel you add, decide how it shares context with your existing agents:
-
-- **Separate agent groups** — each channel gets its own workspace, memory, and personality. Nothing crosses.
-- **Same agent, separate sessions** — one workspace and one memory, but per-channel conversation threads.
-- **Shared session** — multiple channels feed into a single conversation (GitHub webhooks + a Slack channel + email, all in one thread).
-
-Pick per channel via `/manage-channels`. See [Channel isolation model](/concepts/entity-model).
-
-### Point anyone at your agent, keep yourself in the loop
-
-Invite coworkers, clients, or friends into a group your agent is in. They get their own agent relationship in minutes — no admin setup for you. Sensitive actions (unknown senders, irreversible tools) route to your DMs as approval cards. You say yes, the agent proceeds; you say no, it stops.
-
-### Scheduled tasks
-
-Recurring jobs that run Claude and message you back:
-
-```
-@Andy send an overview of the sales pipeline every weekday morning at 9am
-@Andy review the git history for the past week each Friday and update the README if there's drift
-@Andy every Monday at 8am, compile AI news from Hacker News and TechCrunch and message me a briefing
-```
-
-Same inbox, same flow, same tools — a scheduled task is a message with a `process_after` timestamp.
-
-### Skills, not features
-
-Trunk ships the runtime and the entity model. Channels live on a `channels` branch. Alternative agent providers live on `providers`. You run `/add-telegram` or `/add-opencode` and the skill copies exactly the module you need into your fork. Your install ends up with the code that does what you asked for — and nothing else.
-
-### AI-native, hybrid by design
-
-The install and onboarding flow is a scripted, deterministic path. When a step needs judgment — a failed install, a guided decision, a customization — control hands off to Claude Code. Beyond setup, there's no monitoring dashboard either: describe the problem in chat and Claude Code handles it.
-
-## Philosophy
-
-<CardGroup cols={1}>
-  <Card title="Small enough to understand" icon="magnifying-glass">
-    One process, a few source files, no microservices. Ask Claude Code to walk you through the codebase — the whole repo fits comfortably in its context window.
-  </Card>
-
-  <Card title="Secure by isolation" icon="lock">
-    Agents run in Linux containers and see only what you mount. Credentials never enter the container — OneCLI injects them at request time.
-  </Card>
-
-  <Card title="Built for the individual user" icon="user">
-    Not a monolithic framework. You make your own fork and have Claude Code modify it to fit. Bespoke, not bloatware.
-  </Card>
-
-  <Card title="Customization = code changes" icon="code">
-    No config file sprawl. Want different behavior? Edit the code. The codebase is small enough that it's safe to do so.
-  </Card>
-
-  <Card title="Skills over features" icon="puzzle-piece">
-    Contributors ship Claude Code skills like `/add-telegram` that transform your fork. Trunk stays lean; your fork ships exactly the modules you asked for.
-  </Card>
-
-  <Card title="Best harness, best model" icon="robot">
-    Claude Code with the official Claude Agent SDK is the default. Drop in other providers per agent group: `/add-codex` for OpenAI, `/add-opencode` for OpenRouter/Google/DeepSeek, `/add-ollama-provider` for local models.
+  <Card title="How it works" icon="diagram-project" href="/concepts/architecture">
+    The entity model, session databases, and the inbox/outbox pattern in depth.
   </Card>
 </CardGroup>
 
-## Core architecture (v2)
+## How a message flows
 
-- **Host process** — Node 22 + pnpm. Runs channels, routing, delivery, and the entity model over a central SQLite database.
-- **Agent container** — Bun 1.3+ running TypeScript directly (no compile step). Each session gets its own container and its own pair of session databases.
-- **Inbox/outbox session model** — `inbound.db` (host writes, container reads) and `outbound.db` (container writes, host reads). One writer per file eliminates SQLite cross-mount contention. No stdin piping, no IPC files.
-- **Entity model** — agent groups (workspaces) and messaging groups (platform channels) are independent. `messaging_group_agents` rows wire them together with per-wiring engage mode, sender scope, and session mode.
-- **Delivery loop** — two polls: an active poll (1s) for running sessions, a sweep (60s) for liveness and recovery. Heartbeat-based stale detection, not wall-clock timeouts.
-- **Channel adapters** — modules on the `channels` branch that implement NanoClaw's channel interface. Some use [Vercel's Chat SDK](https://chat-sdk.dev/docs/adapters); native channels keep platform-specific runtime code.
-- **Credentials** — [OneCLI Agent Vault](https://github.com/onecli/onecli) is the sole credential path. Containers receive placeholder tokens; the vault injects real auth at request time and enforces per-agent policies.
+Every channel — Telegram, Discord, a webhook, the built-in CLI — feeds the same pipeline:
 
-<Info>
-**Codebase size**: ~133k tokens (~67% of Claude's context window). Big for v1; still small enough that Claude Code can reason over the whole repo.
-</Info>
+```mermaid
+flowchart LR
+    A[Channel adapter] --> B[Router]
+    B --> C[("Inbox<br/>messages_in")]
+    C --> D[Agent container]
+    D --> E[("Outbox<br/>messages_out")]
+    E --> F[Delivery poll]
+    F --> A
+```
 
-## Key source files (host)
+The router resolves who sent the message, which agent group should handle it, and which session it belongs to, then writes the row and wakes the container. The container processes its inbox and writes replies to its outbox; the host's delivery polls pick them up and hand them back to the channel adapter. Agent-to-agent messages follow the exact same path — an agent's `send_message` is a row addressed to another agent's inbox.
 
-| File | Purpose |
-|------|---------|
-| `src/index.ts` | Orchestrator: startup, channel registration, routing |
-| `src/router.ts` | Inbound routing: identity → agent group → session |
-| `src/delivery.ts` | Outbound delivery polls (active 1s, sweep 60s) |
-| `src/host-sweep.ts` | Heartbeat liveness, stuck-tool detection, processing-ack sync |
-| `src/session-manager.ts` | Session lifecycle: spawn, wake, idle-kill, DB provisioning |
-| `src/container-runner.ts` | Container spawn and OneCLI config application |
-| `src/db/schema.ts` | Reference schemas — central, inbound, outbound |
-| `src/db/session-db.ts` | Per-session DB helpers (host-side) |
-| `src/channels/` | Channel adapter interfaces |
-| `container/agent-runner/src/` | Bun-run agent-runner (read-only mounted into containers) |
-| `groups/<folder>/CLAUDE.md` | Per-agent-group memory |
+## Why it's built this way
 
-## Community and source
+**Container isolation.** Agents run in Docker containers and see only what you explicitly mount. Bash and file edits execute inside the container, never on your host. Each session gets its own container, so parallel conversations can't interfere with each other.
 
-- **Source**: [github.com/nanocoai/nanoclaw](https://github.com/nanocoai/nanoclaw)
+**Small enough to hold in context.** The codebase is ~185k tokens — small enough for Claude Code to hold in context. That's also how you customize it: edit the code, not a config sprawl.
+
+**Channels are skills, not bundled features.** Main ships exactly one channel — the local CLI. Everything else lives on the `channels` branch and gets copied into your fork by a skill: `/add-telegram`, `/add-discord`, `/add-whatsapp`, `/add-slack`, `/add-signal`, `/add-imessage`, and several more. Your install contains the adapters you asked for and nothing else. The same mechanism covers alternative agent providers (`/add-codex`, `/add-opencode`, `/add-ollama-provider`).
+
+## Agents that work together
+
+An agent can spawn long-lived companion agents with `create_agent` — each with its own container, workspace, and persistent memory — and delegate to them over the same message queue. That's enough to build real teams: a worker per task, a manager that tracks what's in flight, a supervisor that pings you for approval. See the [multi-agent swarm guide](/guides/multi-agent-swarm).
+
+## Who this is for
+
+- **Operators** — you want a personal AI assistant on your own machine, reachable from your messaging apps. Start with the [quickstart](/quickstart).
+- **Builders** — you want to extend it: new channels, tools, skills, or agent providers in your own fork. Start with [extending NanoClaw](/extend/overview).
+- **Evaluators and contributors** — you want to judge the design before trusting it. Start with the [architecture](/concepts/architecture) and the [security model](/concepts/security).
+
+## Source and community
+
+- **Source**: [github.com/nanocoai/nanoclaw](https://github.com/nanocoai/nanoclaw) (MIT)
 - **Discord**: [community server](https://discord.gg/VDdww8qS42)
-- **License**: MIT

--- a/migrate-from-v1.mdx
+++ b/migrate-from-v1.mdx
@@ -1,0 +1,179 @@
+---
+title: "Migrate from v1 or OpenClaw"
+description: "Move a NanoClaw v1 install to v2 with migrate-v2.sh and the /migrate-from-v1 skill, or import an OpenClaw setup with /migrate-from-openclaw."
+icon: "route"
+tag: "NEW"
+keywords: ["migration", "v1", "v2", "upgrade", "OpenClaw", "migrate-v2.sh", "migrate-from-v1", "migrate-from-openclaw", "handoff"]
+---
+
+{/* verified-against: migrate-v2.sh, migrate-v2-reset.sh, setup/migrate-v2/*.ts, .claude/skills/migrate-from-v1/SKILL.md, .claude/skills/migrate-from-openclaw/SKILL.md, .claude/skills/migrate-nanoclaw/SKILL.md @ dc34ceb */}
+
+NanoClaw v2 is a ground-up rewrite — you don't upgrade in place, you migrate into a fresh v2 checkout. There are two supported paths:
+
+- **From NanoClaw v1**: run `bash migrate-v2.sh` in the v2 checkout. It copies your state deterministically, then hands off to Claude to finish the judgment calls.
+- **From OpenClaw**: run the `/migrate-from-openclaw` skill in Claude Code. It's a guided conversation, not a batch script — see [Migrating from OpenClaw](#migrating-from-openclaw).
+
+Starting fresh with no previous install? You don't need this page — go to the [quick start](/quickstart).
+
+<Note>
+There's also a `/migrate-nanoclaw` skill in the repo. That one is for upgrading a **customized fork** to a newer upstream — it extracts your customizations into a guide and replays them on a clean base instead of `git merge`. It's not a v1 → v2 or OpenClaw path; use it later, once you're on v2 and tracking upstream.
+</Note>
+
+## What carries over — and what doesn't
+
+The migration never modifies your v1 install. It reads from it (the v1 checkout is treated as read-only throughout) and writes into the v2 checkout.
+
+| v1 state | What happens in v2 |
+|---|---|
+| `.env` keys | Merged into v2's `.env`. Existing v2 keys are never overwritten. |
+| Registered groups | Seeded into the central database (`data/v2.db`) as agent groups, messaging groups, and the wiring between them. |
+| Group folders | Copied into `groups/`. Each v1 `CLAUDE.md` becomes `CLAUDE.local.md` — v2 composes `CLAUDE.md` at container spawn, so your customizations move to the local file. v1 `container_config` becomes `container.json` (or a `.v1-container-config.json` sidecar if it can't be parsed). |
+| Conversations | Session state and Claude Code transcripts are copied, and the v1 session ID is written as the continuation — your agent resumes the exact same conversation in v2. |
+| Scheduled tasks | Active tasks are ported into v2's task model (task rows in each session's inbound database). |
+| Channel auth | Credentials for the channels you select — both env keys and on-disk auth state like the WhatsApp keystore — are copied, and the channel code is installed. |
+| Container skills | Skills under `container/skills/` that v2 doesn't already ship are copied over. |
+
+Two things are intentionally left behind, plus one the script defers:
+
+- **Message history.** The script reads v1's `store/messages.db` to discover groups and tasks, but never copies the messages themselves — v2 has no equivalent table, and your agent's memory of past conversations carries over through the session transcripts instead.
+- **v1 source customizations.** v2's architecture is fundamentally different; forked `src/` code isn't portable. The post-migration skill helps you copy portable pieces (skills, docs) and stashes the rest as reference.
+- **Your owner account and access policy.** The script doesn't seed users or roles — that needs human confirmation, so the `/migrate-from-v1` skill handles it after the handoff.
+
+## Run the migration
+
+The script is idempotent — re-running it skips what's already done, so a failed step never forces you to start over.
+
+<Steps>
+  <Step title="Get a v2 checkout next to v1">
+    Clone v2 as a sibling of your v1 directory — the script auto-detects v1 by scanning sibling directories for a `store/messages.db`:
+
+    ```bash
+    git clone https://github.com/nanocoai/nanoclaw.git nanoclaw-v2
+    cd nanoclaw-v2
+    ```
+
+    If v1 lives somewhere else, point at it explicitly:
+
+    ```bash
+    NANOCLAW_V1_PATH=~/path/to/nanoclaw bash migrate-v2.sh
+    ```
+  </Step>
+
+  <Step title="Run the script in a real terminal">
+    ```bash
+    bash migrate-v2.sh
+    ```
+
+    The script refuses to run inside a tool subprocess — it has interactive prompts (channel selection, service switchover) and streams progress. If you're in Claude Code, exit first or open a separate terminal.
+  </Step>
+
+  <Step title="Phase 0: preflight">
+    Installs prerequisites (Node, pnpm, dependencies) via the standard bootstrap, locates your v1 install, and validates its database — it aborts if the `registered_groups` table is missing. Then it reports what it found:
+
+    ```text
+    ·  v1 state: 4 groups, 2 active tasks, 12 env keys
+    ✓  Phase 0 complete — ready to migrate
+    ```
+  </Step>
+
+  <Step title="Phase 1: core state">
+    Five sub-steps, each logged separately under `logs/migrate-steps/`: merge `.env`, seed the v2 database, copy group folders, copy session data, port scheduled tasks. Steps that exit successfully but skip some rows surface their errors inline so partial migrations don't go unnoticed.
+  </Step>
+
+  <Step title="Phase 2: channels">
+    An interactive multiselect asks which channels to bring over (Telegram, Discord, Slack, WhatsApp, Teams, Matrix, iMessage, and more). For each selection the script copies the channel's auth state and runs its installer. To skip the prompt — for unattended runs — set `NANOCLAW_CHANNELS=telegram,discord` before running.
+  </Step>
+
+  <Step title="Phase 3: infrastructure">
+    Installs Docker if missing, sets up the OneCLI credential vault, registers your Anthropic credential (skipped if `.env` already has `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN`), copies v1 container skills v2 doesn't have, and builds the agent container image.
+  </Step>
+
+  <Step title="Service switchover">
+    If your v1 service is running, the script offers to switch: it stops v1, installs and starts the v2 service, and asks you to send a real test message to your bot. Then you choose — **keep v2** (v1 is disabled but its service file is kept on disk for rollback) or **revert** (v2 stops, v1 restarts). Switching is non-destructive either way; rolling back later is one command:
+
+    ```bash
+    # Linux
+    systemctl --user stop <v2-unit> && systemctl --user start nanoclaw
+    # macOS
+    launchctl unload ~/Library/LaunchAgents/<v2-label>.plist && launchctl load ~/Library/LaunchAgents/com.nanoclaw.plist
+    ```
+
+    The v2 unit name is install-specific (`nanoclaw-v2-<slug>` / `com.nanoclaw-v2-<slug>`) — the script prints it in the summary.
+  </Step>
+
+  <Step title="Phase 4: handoff">
+    The script writes `logs/setup-migration/handoff.json` — per-step results, overall status, and a follow-up list — prints a summary of what was done and what still needs a human, then launches Claude with the `/migrate-from-v1` skill automatically (if the `claude` CLI is installed; otherwise run it yourself).
+  </Step>
+</Steps>
+
+## After the handoff
+
+`/migrate-from-v1` picks up where the script stopped — the parts that need human judgment. It reads `handoff.json` first, then works through:
+
+1. **Get v2 routing real messages.** Fixes any failed steps that block message routing, then has you send a test message before going deeper. v1 stays paused, not modified.
+2. **Owner and access.** v2 auto-creates a `users` row for every sender it sees; the skill confirms which one is you and grants the `owner` role. Then it asks how open the bot should be — the script left every group on `public` so the switchover test would work, and the skill offers to tighten it to `strict` (known users only) or `request_approval`, seeding known senders from your v1 message history if you want.
+3. **Clean up `CLAUDE.local.md`.** The migration copied your entire v1 `CLAUDE.md` per group, including v1 boilerplate that v2 now provides through composed fragments. The skill diffs each file against the v1 template, strips the stock sections, keeps your customizations and agent identity, and shows you the result before writing.
+4. **Container config.** Verifies that `container.json` mount paths still exist on this machine, and resolves any `.v1-container-config.json` sidecars left by unparseable v1 configs.
+5. **Fork customizations.** If your v1 was a customized fork, the skill walks the commits with you — portable items (container skills, Claude skills, docs) get copied; v1 source changes get stashed to `docs/v1-fork-reference/` since they don't translate.
+
+When it's done it runs an end-to-end health check (`setup/index.ts --step verify`) and restarts the service.
+
+## Starting over
+
+`migrate-v2-reset.sh` wipes the v2 checkout back to clean so you can re-run the migration from scratch:
+
+```bash
+bash migrate-v2-reset.sh && bash migrate-v2.sh
+```
+
+It removes `data/`, `logs/`, the merged `.env`, group folders copied from v1, and untracked skills and channel code added during migration, then restores the tracked versions of those paths from git. It keeps `node_modules/` (expensive to reinstall) and **never touches your v1 install**.
+
+## Migrating from OpenClaw
+
+OpenClaw users skip the script entirely — there's no deterministic mapping between the two systems, so the migration is a conversation. From the v2 checkout, open Claude Code and run:
+
+```text
+/migrate-from-openclaw
+```
+
+The skill detects your OpenClaw installation at the standard locations (`~/.openclaw`, `~/.clawdbot`, or a path you give it), summarizes what it found, and then works through each area with you — reading your data, explaining where it belongs in v2, and showing every change before applying it. Credentials are always masked when displayed.
+
+What maps where:
+
+| OpenClaw | NanoClaw v2 |
+|---|---|
+| An agent | An agent group (its own container, workspace, and memory) |
+| A chat or group | A messaging group, wired to an agent group |
+| `IDENTITY.md` / `SOUL.md` | `container/CLAUDE.md` (shared across agents) or a group's `CLAUDE.local.md`, your choice |
+| `USER.md`, `MEMORY.md`, daily memory files | `user-context.md`, `memories.md`, and `daily-memories/` in the group folder |
+| Skills | Copied into `container/skills/` — the SKILL.md format is shared, so they're portable |
+| Channel tokens (Telegram, Discord, Slack) | `.env` — the host process reads them |
+| Anthropic and other API keys | The OneCLI vault — injected per request, never in container env |
+| Cron jobs | v2 scheduled tasks, created through the agent's `schedule_task` tool |
+| MCP servers | Per-agent-group container config |
+| `allowFrom` / `dmPolicy` allowlists | `unknown_sender_policy` per messaging group, plus user roles and group members |
+
+A few OpenClaw-specific notes:
+
+- **WhatsApp re-authenticates from scratch.** Stale Baileys encryption sessions break decryption, so the skill deliberately doesn't copy WhatsApp auth state — you scan a QR code again during setup.
+- **Some features don't map.** Exec approvals are replaced by container isolation; webhooks, human delay, and TTS have no v2 primitive — the skill discusses alternatives case by case.
+- **Progress is recoverable.** The skill keeps a `migration-state.md` file in the project root as its source of truth, so a lost session picks up where it left off.
+
+The skill ends by validating its own work with a shipped test suite, then points you at `/setup` to finish the install — select the channels you migrated when setup asks.
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Connect more channels" icon="tower-broadcast" href="/channels/overview">
+    Anything you didn't migrate installs any time with `/add-<name>`.
+  </Card>
+  <Card title="The entity model" icon="diagram-project" href="/concepts/entity-model">
+    Agent groups, messaging groups, users, and roles — the v2 model your v1 state was mapped onto.
+  </Card>
+  <Card title="The ncl CLI" icon="terminal" href="/operate/ncl-cli">
+    Inspect the migrated groups, sessions, and users from the command line.
+  </Card>
+  <Card title="Troubleshooting" icon="life-ring" href="/operate/troubleshooting">
+    Migration logs live in `logs/migrate-v2.log` and `logs/migrate-steps/`.
+  </Card>
+</CardGroup>

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -3,198 +3,88 @@ title: Quick start
 description: Get NanoClaw running in one command with the scripted installer.
 icon: "bolt"
 tag: "UPDATED"
-keywords: ["setup", "install", "getting started", "nanoclaw.sh", "bash", "claude code"]
+keywords: ["setup", "install", "getting started", "nanoclaw.sh", "setup wizard", "first agent"]
 ---
 
-From a fresh machine to an agent you can message — one command, a handful of prompts, a few minutes.
+{/* verified-against: nanoclaw.sh, setup.sh, setup/auto.ts, setup/probe.sh, setup/install-node.sh, setup/channels/*.ts, scripts/init-first-agent.ts, .claude/skills/setup/SKILL.md, package.json @ dc34ceb */}
 
-<Note>
-This guide covers the default installer. If you want to skip steps, reuse an existing OneCLI instance, or point Anthropic traffic at a custom endpoint, see [Installation](/installation).
-</Note>
+From a fresh machine to an agent you can message — one command and a handful of prompts.
+
+## Prerequisites
+
+- **macOS or Linux** (WSL works) with **4 GB+ RAM** — the installer warns below ~3.7 GB
+- **git** to clone the repository
+- A **Claude subscription** (Pro or Max), an OAuth token, or an Anthropic API key
+
+Everything else — Homebrew on macOS, Node 22, pnpm, Docker, the OneCLI vault — is installed by the script if missing. Two caveats from the installer's pre-flight checks: don't run as root on Linux (it walks you through creating a user instead), and Google Cloud VMs are known not to work.
 
 ## The one-command flow
 
 <Steps>
-  <Step title="Clone the repository">
-    Clone upstream directly if you just want to try things out:
-
+  <Step title="Clone and run">
     ```bash
     git clone https://github.com/nanocoai/nanoclaw.git
     cd nanoclaw
-    ```
-
-    If you plan to customize, fork [nanocoai/nanoclaw](https://github.com/nanocoai/nanoclaw) on GitHub first and clone your fork. You can always add the fork remote later — the installer and `/update-nanoclaw` skill handle both shapes.
-  </Step>
-
-  <Step title="Run the installer">
-    ```bash
     bash nanoclaw.sh
     ```
 
-    This is the whole install command. `nanoclaw.sh` walks you through:
-
-    - Installing Node 22, pnpm, and Docker if they're missing
-    - Verifying your environment (platform, WSL detection, container runtime)
-    - Building the agent container image
-    - Registering your Anthropic credential with [OneCLI](https://github.com/onecli/onecli)
-    - Pairing your first channel (Telegram, Discord, WhatsApp, Signal, Teams, Slack, iMessage, or the local CLI)
-    - Installing a systemd or launchd service so NanoClaw starts with your machine
-
-    If any step fails, Claude Code is invoked automatically to diagnose and resume from where it broke. You don't have to debug the installer yourself.
+    The script runs pre-flight checks (RAM, root user, Homebrew on macOS), installs the basics — Node 22, pnpm, and native modules — under a single spinner, then hands off to the interactive setup wizard (`pnpm run setup:auto`). If a step fails during the wizard, it offers Claude-assisted recovery inline and resumes from the step that broke instead of starting over.
   </Step>
 
-  <Step title="Answer the setup prompts">
-    Running through [clack](https://github.com/natemoo-re/clack), you'll be asked:
+  <Step title="Answer the wizard">
+    Press Enter on **Standard setup** (or pick **Advanced** to override defaults), then the wizard walks through:
 
-    - **Display name** — what you want your agent to be called (default: `Andy`)
-    - **Anthropic credential method** — Claude subscription (OAuth), Anthropic API key, or skip
-    - **First channel** — Telegram, Discord, WhatsApp, Signal, Teams, Slack, iMessage, or local CLI. You can add more later.
-    - **Channel-specific auth** — pairing code, QR code, bot token, app credentials, or no extra auth for CLI, depending on the platform
-
-    The flow is linear. One question at a time. You can Ctrl+C and restart; the installer picks up where you left off.
-  </Step>
-
-  <Step title="Authorize Anthropic">
-    The one step that hands off from the scripted flow: `claude setup-token` opens a browser for OAuth and prints a long-lived token back into your terminal. The installer captures the status and returns to the clack flow once the token is stored in OneCLI.
-
-    If you chose to skip Anthropic auth or use an API key instead, this step is skipped or replaced with a password prompt.
+    1. **System check** — verifies your environment
+    2. **Sandbox build** — builds the agent container image. First build pulls a base image and takes 3–10 minutes on a fresh machine.
+    3. **OneCLI vault** — installs the credential vault, or offers to reuse an existing OneCLI instance. Your agent never sees your API keys; the vault injects them into approved requests as they leave the sandbox.
+    4. **Connect to Claude** — sign in with your Claude subscription (opens a browser), paste an OAuth token (`sk-ant-oat…`), or paste an API key (`sk-ant-api…`)
+    5. **Access rules** — writes the assistant's filesystem access rules (empty to start — the sandbox only sees what you explicitly share later)
+    6. **Background service** — starts NanoClaw under launchd (macOS) or a systemd user service (Linux)
+    7. **Your name** — what the assistant should call you
+    8. **First contact** — the wizard pings your assistant and waits for a reply. First startup takes 30–60 seconds while the sandbox warms up. You can pause here and chat from the terminal.
+    9. **Timezone** — auto-detected, confirmed with you
+    10. **Channel** — connect Telegram (recommended), Discord, WhatsApp, Signal, iMessage, Slack, or Microsoft Teams — or skip and use the terminal. Other channels install after setup with `/add-<name>` in Claude Code.
+    11. **Final check** — makes sure everything works together: credentials, service, and configured channels, flagging anything left to fix
   </Step>
 
   <Step title="Send your first message">
-    When the installer finishes, it prints the invocation pattern for your chosen channel. For Telegram that looks like:
+    If you connected a channel, the wizard wires your first agent and the assistant DMs you a welcome — check your phone and say hi.
 
-    ```
-    @Andy hello!
-    ```
-
-    For the local CLI:
+    If you skipped the channel step, chat from the terminal:
 
     ```bash
     pnpm run chat hi
     ```
 
-    Your agent responds. You're set.
+    Either way, you can watch what's happening live:
+
+    ```bash
+    tail -f logs/nanoclaw.log
+    ```
   </Step>
 </Steps>
 
-## What the installer writes to disk
+## What just happened
 
-NanoClaw is transparent about what it does. Every run produces three log streams:
+You now have a host service (launchd or systemd) running NanoClaw from this checkout. It routes messages between your channels and agents, where each agent runs in its own Docker container sandbox that wakes on incoming messages and sleeps when idle. Your Anthropic credential lives in the OneCLI vault — never inside the container. Agent workspaces live under `groups/`, runtime state under `data/`, and logs under `logs/`. See [Architecture](/concepts/architecture) for the full picture.
 
-| Level | Where | What's in it |
-|-------|-------|--------------|
-| Terminal (clack) | Your screen | Branded status + prompts, spinner per step |
-| Progression log | `logs/setup.log` | One entry per step: timestamp, duration, status, key facts |
-| Raw per-step logs | `logs/setup-steps/NN-step-name.log` | Full verbatim stdout + stderr from the step |
-
-If something looks wrong after install, `logs/setup.log` is the first file to read.
-
-## What happens behind the scenes
-
-<AccordionGroup>
-  <Accordion title="Phase 1 — bootstrap (bash)">
-    - Installs Node 22 via nvm, corepack-enables pnpm
-    - Runs `pnpm install --frozen-lockfile`
-    - Verifies `better-sqlite3` loads on your platform
-    - Detects WSL, headless environments, and Apple Silicon
-    - Emits a `BOOTSTRAP` status block to the progression log
-  </Accordion>
-
-  <Accordion title="Phase 2 — setup:auto (TypeScript via pnpm)">
-    Driven by `setup/auto.ts`. Each sub-step emits a structured status block and writes its raw output to `logs/setup-steps/NN-<name>.log`:
-
-    - **environment** — Docker / Apple Container detection, runtime selection
-    - **container** — builds the checkout-scoped agent image via `container/build.sh`
-    - **onecli** — installs OneCLI Agent Vault or reuses an existing configured instance
-    - **auth** — registers Anthropic credentials in OneCLI
-    - **cli-agent** — wires the terminal agent and confirms it responds before optional channel setup
-    - **timezone** — detects or resolves your IANA timezone
-    - **channel pairing** — runs the selected setup flow for Telegram, Discord, WhatsApp, Signal, Teams, Slack, or iMessage
-    - **service** — launchd (macOS) / systemd (Linux) / `start-nanoclaw.sh` wrapper (WSL without systemd)
-    - **verify** — checks credentials, service status, registered groups, and first-agent connectivity
-    - **diagnostics** — optional opt-in PostHog event with platform + channel choice
-  </Accordion>
-
-  <Accordion title="The Anthropic exception">
-    `claude setup-token` owns the TTY during OAuth. It opens your browser, prints the token, and inherits stdio fully — we don't mirror the token to any log file (that would add attack surface). Control returns to the clack flow on exit.
-  </Accordion>
-
-  <Accordion title="Service installation">
-    - **macOS** — creates a launchd service named like `com.nanoclaw-v2-<slug>` in `~/Library/LaunchAgents/`
-    - **Linux (systemd)** — user service named like `nanoclaw-v2-<slug>.service`; enables `loginctl linger` so the service survives SSH logout
-    - **WSL without systemd** — creates a `start-nanoclaw.sh` wrapper; you run it manually on login or wire it to `.bashrc`
-  </Accordion>
-</AccordionGroup>
-
-## Usage examples
-
-<CodeGroup>
-```text Basic conversation
-@Andy what's the weather like today?
-@Andy write a Python script to parse CSV files
-@Andy summarize this document [attach file]
-```
-
-```text Scheduled tasks
-@Andy send me a daily standup reminder at 9am on weekdays
-@Andy every Friday at 5pm, review this week's git commits and summarize changes
-@Andy monitor Hacker News and message me when there's a trending AI article
-```
-
-```text Admin commands (from a channel you own or administer)
-@Andy list all scheduled tasks
-@Andy pause the standup reminder
-@Andy manage-channels
-@Andy show me what groups I'm in
-```
-</CodeGroup>
-
-## Monitoring and logs
-
-```bash
-# Live log stream
-tail -f logs/nanoclaw.log
-
-# Service status
-launchctl list | grep nanoclaw     # macOS
-systemctl --user list-units 'nanoclaw*'  # Linux
-```
-
-Or just ask:
-
-```
-@Andy why isn't the scheduler running?
-@Andy show me the last 50 log lines
-@Andy why did this message not get a response?
-```
+<Note>
+Coming from NanoClaw v1? Run `bash migrate-v2.sh` before setup — see the [migration guide](/migrate-from-v1).
+</Note>
 
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Add more channels" icon="plus" href="/channels/overview">
-    `/add-slack`, `/add-whatsapp`, `/add-signal` — install or wire channels from the current channel setup flows
+  <Card title="Add more channels" icon="tower-broadcast" href="/channels/overview">
+    Connect Telegram, Discord, WhatsApp, Slack, and more — during setup or any time after.
   </Card>
-  <Card title="Customize" icon="wrench" href="/guides/customize-an-agent">
-    Change the trigger word, tune timeouts, adjust engage modes
+  <Card title="The ncl CLI" icon="terminal" href="/operate/ncl-cli">
+    Inspect agents, groups, and sessions from the command line.
   </Card>
-  <Card title="Security model" icon="shield" href="/concepts/security">
-    Sender allowlists, user roles, unknown-sender policies
+  <Card title="Customize an agent" icon="wand-magic-sparkles" href="/guides/customize-an-agent">
+    Edit instructions, mounts, and behavior for your first agent.
   </Card>
   <Card title="Troubleshooting" icon="life-ring" href="/operate/troubleshooting">
-    Common issues and how Claude Code helps you fix them
+    Setup logs live in `logs/setup.log`; runtime issues start at `logs/nanoclaw.log`.
   </Card>
 </CardGroup>
-
-## Updating NanoClaw
-
-To pull upstream changes and merge with your customizations:
-
-```
-/update-nanoclaw
-```
-
-This skill fetches `upstream/main`, merges with your local changes, runs any migrations, rebuilds the container if needed, restarts the service, and scans the changelog for `[BREAKING]` entries — offering to run the `/migrate-nanoclaw` skill when a breaking change applies.
-
-<Tip>
-Migrating from v1? Run `/migrate-nanoclaw` for a clean-base replay of your customizations on top of v2, or `/update-nanoclaw` for a selective cherry-pick. A dedicated v1 → v2 migration guide is coming; until then, the upstream [CHANGELOG](https://github.com/nanocoai/nanoclaw/blob/main/CHANGELOG.md) covers every breaking change.
-</Tip>


### PR DESCRIPTION
PR 2 of 9 (spec: docs/superpowers/specs/2026-06-10-docs-portal-v2-refactor-design.md). All pages verified against upstream nanocoai/nanoclaw@dc34ceb (v2.1.4) — every page carries a verified-against comment.

## Pages
- **introduction.mdx** (rewritten): audience router with 4-card grid, Mermaid message-flow diagram, token count refreshed to 185k from repo-tokens/badge.svg
- **quickstart.mdx** (rewritten): the real bash nanoclaw.sh flow + all 11 wizard steps in actual setup/auto.ts order. Dropped fabrications found in the old page (wrong default assistant name, nonexistent PostHog opt-in step)
- **installation.mdx** (rewritten): requirements from probe.sh/nanoclaw.sh, bootstrap chain, Node-host/Bun-container split, manual install, launchd/systemd services, runtime file tree. Dropped the Apple Container section (zero presence in v2 code) and a WSL claim contradicting the actual installer
- **migrate-from-v1.mdx** (NEW): migrate-v2.sh phase-by-phase, what carries over vs not, the Claude handoff skill, reset script, OpenClaw migration section

Validation: mint validate ✅ · mint broken-links ✅