### PR TITLE
docs: rewrite Operate group — config, ncl, credentials, hardening, upgrades, troubleshooting

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -136,7 +136,7 @@
           {
             "group": "Operate",
             "icon": "gauge",
-            "pages": ["operate/ncl-cli", "operate/hardening", "operate/troubleshooting"]
+            "pages": ["operate/configuration", "operate/ncl-cli", "operate/credentials", "operate/hardening", "operate/upgrading", "operate/troubleshooting"]
           },
           {
             "group": "Build with agents",

--- a/operate/configuration.mdx
+++ b/operate/configuration.mdx
@@ -1,0 +1,115 @@
+---
+title: "Configuration"
+description: "Configure a NanoClaw install — environment variables in .env and per-group container config in the database."
+tag: "NEW"
+keywords: ["configuration", "environment variables", ".env", "container config", "ASSISTANT_NAME", "CONTAINER_TIMEOUT", "LOG_LEVEL", "container_configs"]
+---
+
+{/* verified-against: src/config.ts, src/env.ts, src/log.ts, src/webhook-server.ts, src/egress-lockdown.ts, src/container-config.ts, src/db/container-configs.ts, setup/set-env.ts @ dc34ceb */}
+
+NanoClaw has two configuration layers:
+
+1. **Install-wide environment variables** in `.env` at the project root — identity, container limits, logging, credentials. They apply to the whole install.
+2. **Per-group container config** in the database — each agent group has a row in the `container_configs` table controlling its provider, model, mounts, packages, and MCP servers.
+
+## Environment variables
+
+NanoClaw reads `.env` directly with its own parser — values are **not** loaded into `process.env`, so secrets don't leak to child processes. A variable set in the actual process environment takes precedence over the same key in `.env`.
+
+Some channels run in containers and can't see the host's `.env`. For those, setup mirrors `.env` to `data/env/env`, which is mounted into the channel container. The two files must stay in sync — the `set-env` setup step handles both:
+
+```bash
+pnpm exec tsx setup/index.ts --step set-env -- --key ASSISTANT_NAME --value "Jarvis" --sync-container
+```
+
+You can also edit `.env` by hand and copy it yourself: `cp .env data/env/env`.
+
+### Identity
+
+| Variable | Default | What it does |
+|---|---|---|
+| `ASSISTANT_NAME` | `Andy` | The assistant's name. Also sets the default trigger, `@<name>`. |
+| `ASSISTANT_HAS_OWN_NUMBER` | `false` | Set `true` when the assistant runs on its own WhatsApp number instead of yours. |
+
+### Containers
+
+| Variable | Default | What it does |
+|---|---|---|
+| `CONTAINER_TIMEOUT` | `1800000` (30 min) | Max runtime for an agent container, in milliseconds. |
+| `IDLE_TIMEOUT` | `1800000` (30 min) | How long a container stays alive after its last result, waiting for follow-ups. |
+| `MAX_CONCURRENT_CONTAINERS` | `5` | Cap on simultaneously running agent containers. |
+| `CONTAINER_MAX_OUTPUT_SIZE` | `10485760` (10 MB) | Max output captured from a container. |
+| `MAX_MESSAGES_PER_PROMPT` | `10` | How many queued messages are batched into a single agent prompt. |
+| `CONTAINER_IMAGE` | per-install tag | Agent image override. The default tag includes an install slug so two checkouts on one host don't clobber each other's `nanoclaw-agent` image. |
+
+### Network and time
+
+| Variable | Default | What it does |
+|---|---|---|
+| `WEBHOOK_PORT` | `3000` | Port for the local webhook server. |
+| `TZ` | system timezone, else `UTC` | IANA timezone for scheduled tasks and message timestamps. Invalid values are skipped, not errored. |
+
+### Logging
+
+| Variable | Default | What it does |
+|---|---|---|
+| `LOG_LEVEL` | `info` | One of `debug`, `info`, `warn`, `error`. |
+
+### Credentials
+
+| Variable | Default | What it does |
+|---|---|---|
+| `ONECLI_URL` | — | URL of the OneCLI Agent Vault. |
+| `ONECLI_API_KEY` | — | API key for the vault. |
+
+See [Credentials](/operate/credentials) for how agents get API keys at runtime.
+
+### Security
+
+| Variable | Default | What it does |
+|---|---|---|
+| `NANOCLAW_EGRESS_LOCKDOWN` | `false` | Set `true` to force all agent traffic through the OneCLI gateway on an internal Docker network. Fails fast if the gateway isn't running. |
+| `NANOCLAW_EGRESS_NETWORK` | `nanoclaw-egress` | Name of the locked-down Docker network. |
+| `ONECLI_GATEWAY_CONTAINER` | `onecli` | Name of the gateway container attached as the only egress hop. |
+
+See [Hardening](/operate/hardening) for the full egress lockdown and sandboxing story.
+
+## Per-group container config
+
+Each agent group has a row in the `container_configs` table (the central SQLite database). At spawn time NanoClaw materializes it to `groups/<folder>/container.json` — don't edit that file by hand, it's overwritten on every spawn.
+
+Fields per group:
+
+| Field | What it controls |
+|---|---|
+| `provider` | Which agent CLI runs in the container (e.g. Claude Code, OpenCode). |
+| `model`, `effort` | Model and reasoning effort passed to the provider. |
+| `assistant_name` | Per-group assistant name override. |
+| `max_messages_per_prompt` | Per-group override of the install-wide batching limit. |
+| `image_tag` | Custom container image for this group. |
+| `cli_scope` | What the group's agent can do via the internal CLI: `disabled`, `group` (own group only, the default), or `global`. |
+| `skills` | Skill list for the group, or `all`. |
+| `mcp_servers` | MCP servers available inside the container. |
+| `packages_apt`, `packages_npm` | Extra packages installed in the container. |
+| `additional_mounts` | Extra host directories mounted into the container (subject to the mount allowlist at `~/.config/nanoclaw/mount-allowlist.json`). |
+
+To change a group's config, ask the agent in that group, or use the [`claw` CLI](/operate/ncl-cli). For adding MCP servers, mounts, and providers, see [Extending NanoClaw](/extend/overview) and [Ollama integration](/extend/providers).
+
+## Applying changes
+
+Environment variables are read at startup, so after editing `.env`:
+
+1. If any channel runs in a container, sync the copy: `cp .env data/env/env`.
+2. Restart the service:
+
+```bash
+# macOS
+launchctl kickstart -k gui/$(id -u)/com.nanoclaw-v2-<slug>
+
+# Linux
+systemctl --user restart nanoclaw-v2-<slug>
+```
+
+Per-group container config needs no restart — it's read fresh from the database every time a container spawns.
+
+See [Installation](/installation) for service management details and finding your install slug.

--- a/operate/configuration.mdx
+++ b/operate/configuration.mdx
@@ -48,7 +48,7 @@ These are read from `process.env` at startup. Set them in the service definition
 |---|---|---|
 | `CONTAINER_TIMEOUT` | `1800000` (30 min) | Max runtime for an agent container, in milliseconds. |
 | `IDLE_TIMEOUT` | `1800000` (30 min) | How long a container stays alive after its last result, waiting for follow-ups. |
-| `MAX_CONCURRENT_CONTAINERS` | `5` | Cap on simultaneously running agent containers. |
+| `MAX_CONCURRENT_CONTAINERS` | `5` | Intended cap on simultaneously running agent containers. Parsed at startup but not enforced anywhere as of v2.1.4 — setting it has no effect. |
 | `CONTAINER_MAX_OUTPUT_SIZE` | `10485760` (10 MB) | Max output captured from a container. |
 | `MAX_MESSAGES_PER_PROMPT` | `10` | How many queued messages are batched into a single agent prompt. |
 | `CONTAINER_IMAGE` | per-install tag | Full agent image override (name and tag). |

--- a/operate/configuration.mdx
+++ b/operate/configuration.mdx
@@ -1,22 +1,36 @@
 ---
 title: "Configuration"
-description: "Configure a NanoClaw install — environment variables in .env and per-group container config in the database."
+description: "Configure a NanoClaw install — environment variables in .env and the service environment, plus per-group container config in the database."
 tag: "NEW"
 keywords: ["configuration", "environment variables", ".env", "container config", "ASSISTANT_NAME", "CONTAINER_TIMEOUT", "LOG_LEVEL", "container_configs"]
 ---
 
-{/* verified-against: src/config.ts, src/env.ts, src/log.ts, src/webhook-server.ts, src/egress-lockdown.ts, src/container-config.ts, src/db/container-configs.ts, setup/set-env.ts @ dc34ceb */}
+{/* verified-against: src/config.ts, src/env.ts, src/log.ts, src/webhook-server.ts, src/egress-lockdown.ts, src/providers/claude.ts, src/container-config.ts, src/db/container-configs.ts, setup/set-env.ts, setup/service.ts @ dc34ceb */}
 
 NanoClaw has two configuration layers:
 
-1. **Install-wide environment variables** in `.env` at the project root — identity, container limits, logging, credentials. They apply to the whole install.
+1. **Install-wide environment variables** — identity, container limits, logging, credentials. They apply to the whole install.
 2. **Per-group container config** in the database — each agent group has a row in the `container_configs` table controlling its provider, model, mounts, packages, and MCP servers.
 
 ## Environment variables
 
-NanoClaw reads `.env` directly with its own parser — values are **not** loaded into `process.env`, so secrets don't leak to child processes. A variable set in the actual process environment takes precedence over the same key in `.env`.
+Variables come from two sources, and the distinction matters:
 
-Some channels run in containers and can't see the host's `.env`. For those, setup mirrors `.env` to `data/env/env`, which is mounted into the channel container. The two files must stay in sync — the `set-env` setup step handles both:
+- A **small set is read from `.env`** at the project root by NanoClaw's own parser. These work with a plain "edit `.env`, restart" flow. Values are not loaded into `process.env`, so secrets don't leak to child processes; a value already in the process environment takes precedence.
+- **Everything else is read from `process.env` only.** The launchd plist, systemd unit, and nohup wrapper that setup generates set just `PATH` and `HOME` — they do **not** source `.env`. Putting these variables in `.env` has no effect; you have to set them in the service environment (see [Applying changes](#applying-changes)).
+
+### Read from .env
+
+| Variable | Default | What it does |
+|---|---|---|
+| `ASSISTANT_NAME` | `Andy` | The assistant's name. Also sets the default trigger, `@<name>`. |
+| `ASSISTANT_HAS_OWN_NUMBER` | `false` | Set `true` when the assistant runs on its own WhatsApp number instead of yours. |
+| `ONECLI_URL` | — | URL of the OneCLI Agent Vault. |
+| `ONECLI_API_KEY` | — | API key for the vault. See [Credentials](/operate/credentials). |
+| `TZ` | system timezone, else `UTC` | IANA timezone for scheduled tasks and message timestamps. Invalid values are skipped, not errored. |
+| `ANTHROPIC_BASE_URL` | — | Custom Anthropic-compatible endpoint for the Claude provider. Only active when setup has configured a custom endpoint; the real auth token stays on the host and is injected by the OneCLI proxy. |
+
+Some channels run in containers and can't see the host's `.env`. For those, setup mirrors `.env` to `data/env/env`, which is mounted into the channel container. Keep the two in sync — the `set-env` setup step handles both:
 
 ```bash
 pnpm exec tsx setup/index.ts --step set-env -- --key ASSISTANT_NAME --value "Jarvis" --sync-container
@@ -24,14 +38,11 @@ pnpm exec tsx setup/index.ts --step set-env -- --key ASSISTANT_NAME --value "Jar
 
 You can also edit `.env` by hand and copy it yourself: `cp .env data/env/env`.
 
-### Identity
+### Process environment only
 
-| Variable | Default | What it does |
-|---|---|---|
-| `ASSISTANT_NAME` | `Andy` | The assistant's name. Also sets the default trigger, `@<name>`. |
-| `ASSISTANT_HAS_OWN_NUMBER` | `false` | Set `true` when the assistant runs on its own WhatsApp number instead of yours. |
+These are read from `process.env` at startup. Set them in the service definition or export them in your shell before `pnpm run dev` — `.env` won't work.
 
-### Containers
+**Containers**
 
 | Variable | Default | What it does |
 |---|---|---|
@@ -40,31 +51,17 @@ You can also edit `.env` by hand and copy it yourself: `cp .env data/env/env`.
 | `MAX_CONCURRENT_CONTAINERS` | `5` | Cap on simultaneously running agent containers. |
 | `CONTAINER_MAX_OUTPUT_SIZE` | `10485760` (10 MB) | Max output captured from a container. |
 | `MAX_MESSAGES_PER_PROMPT` | `10` | How many queued messages are batched into a single agent prompt. |
-| `CONTAINER_IMAGE` | per-install tag | Agent image override. The default tag includes an install slug so two checkouts on one host don't clobber each other's `nanoclaw-agent` image. |
+| `CONTAINER_IMAGE` | per-install tag | Full agent image override (name and tag). |
+| `CONTAINER_IMAGE_BASE` | per-install name | Base image name override. The default includes an install slug so two checkouts on one host don't clobber each other's `nanoclaw-agent` image. |
 
-### Network and time
+**Network and logging**
 
 | Variable | Default | What it does |
 |---|---|---|
 | `WEBHOOK_PORT` | `3000` | Port for the local webhook server. |
-| `TZ` | system timezone, else `UTC` | IANA timezone for scheduled tasks and message timestamps. Invalid values are skipped, not errored. |
+| `LOG_LEVEL` | `info` | One of `debug`, `info`, `warn`, `error`, `fatal`. |
 
-### Logging
-
-| Variable | Default | What it does |
-|---|---|---|
-| `LOG_LEVEL` | `info` | One of `debug`, `info`, `warn`, `error`. |
-
-### Credentials
-
-| Variable | Default | What it does |
-|---|---|---|
-| `ONECLI_URL` | — | URL of the OneCLI Agent Vault. |
-| `ONECLI_API_KEY` | — | API key for the vault. |
-
-See [Credentials](/operate/credentials) for how agents get API keys at runtime.
-
-### Security
+**Security**
 
 | Variable | Default | What it does |
 |---|---|---|
@@ -93,14 +90,11 @@ Fields per group:
 | `packages_apt`, `packages_npm` | Extra packages installed in the container. |
 | `additional_mounts` | Extra host directories mounted into the container (subject to the mount allowlist at `~/.config/nanoclaw/mount-allowlist.json`). |
 
-To change a group's config, ask the agent in that group, or use the [`claw` CLI](/operate/ncl-cli). For adding MCP servers, mounts, and providers, see [Extending NanoClaw](/extend/overview) and [Ollama integration](/extend/providers).
+To change a group's config, ask the agent in that group, or use [`ncl`](/operate/ncl-cli). For adding MCP servers, mounts, and providers, see [Extending NanoClaw](/extend/overview) and [Ollama integration](/extend/providers).
 
 ## Applying changes
 
-Environment variables are read at startup, so after editing `.env`:
-
-1. If any channel runs in a container, sync the copy: `cp .env data/env/env`.
-2. Restart the service:
+**`.env`-read variables**: edit `.env`, sync the container copy if any channel runs in a container (`cp .env data/env/env`), then restart the service:
 
 ```bash
 # macOS
@@ -109,6 +103,16 @@ launchctl kickstart -k gui/$(id -u)/com.nanoclaw-v2-<slug>
 # Linux
 systemctl --user restart nanoclaw-v2-<slug>
 ```
+
+**Process-environment variables**: add them to the service definition, then reload it.
+
+- **macOS**: edit `~/Library/LaunchAgents/com.nanoclaw-v2-<slug>.plist`, add a key to the `EnvironmentVariables` dict, then `launchctl unload` + `launchctl load` the plist.
+- **Linux (systemd)**: add an `Environment=KEY=value` line to the unit, then `systemctl --user daemon-reload && systemctl --user restart nanoclaw-v2-<slug>`.
+- **Dev shell**: `export LOG_LEVEL=debug` before `pnpm run dev`.
+
+<Warning>
+Re-running the service setup step regenerates the plist or unit file, wiping manual `Environment` edits — re-apply them afterwards.
+</Warning>
 
 Per-group container config needs no restart — it's read fresh from the database every time a container spawns.
 

--- a/operate/credentials.mdx
+++ b/operate/credentials.mdx
@@ -1,0 +1,103 @@
+---
+title: "Credentials"
+description: "How NanoClaw keeps raw API keys out of agent containers — the OneCLI Agent Vault, credential stubs, approval cards, and the .env opt-out."
+tag: "NEW"
+keywords: ["credentials", "OneCLI", "Agent Vault", "secrets", "approval", "onecli-managed", "credential proxy", "ANTHROPIC_BASE_URL"]
+---
+
+{/* verified-against: src/modules/approvals/onecli-approvals.ts, src/modules/approvals/primitive.ts, src/cli/resources/approvals.ts, src/config.ts, src/egress-lockdown.ts, src/providers/claude.ts, setup/onecli.ts, setup/auto.ts, setup/register-claude-token.sh, container/skills/onecli-gateway/SKILL.md, .claude/skills/init-onecli/SKILL.md, .claude/skills/use-native-credential-proxy/SKILL.md, .claude/skills/add-gmail-tool/SKILL.md @ dc34ceb */}
+
+NanoClaw's credential invariant: **agent containers never hold raw API keys**. Secrets live in the OneCLI Agent Vault on the host, and the vault's gateway injects them into outbound HTTPS requests in flight. An agent that is prompt-injected, jailbroken, or just curious can dump its entire environment and filesystem and find nothing worth stealing.
+
+## How the vault works
+
+Every container is launched with `HTTPS_PROXY` pointing at the vault's gateway. When the agent calls a real API URL — `api.anthropic.com`, `api.github.com`, `gmail.googleapis.com` — the gateway intercepts the request, matches the host against its stored secrets, and rewrites the auth header with the real token before the request leaves for the internet. Standard HTTP clients (curl, fetch, requests, axios, git) honor `HTTPS_PROXY` automatically, so the agent just makes normal requests with no auth headers at all.
+
+If the target service isn't connected yet, the gateway returns an error with a `connect_url` the agent surfaces to you, instead of a silent failure.
+
+NanoClaw talks to the vault through two values in `.env`: `ONECLI_URL` (where the gateway lives) and `ONECLI_API_KEY` (the host's own credential for the vault API).
+
+### Credential stubs
+
+Some tools insist on finding a credential locally before they'll start — MCP servers especially. For these, the container gets **stub files** whose secret values are the placeholder string `"onecli-managed"`. The Gmail tool is the worked example: the Gmail MCP server reads `~/.gmail-mcp/credentials.json` containing `"access_token": "onecli-managed"`, happily starts, and sends `Authorization: Bearer onecli-managed` — which the gateway rewrites to the real OAuth token on its way to `gmail.googleapis.com`. Files containing `onecli-managed` are managed by OneCLI; agents are instructed never to modify or delete them.
+
+## Setting it up
+
+The [setup wizard](/installation) handles the vault as one of its steps, with three paths:
+
+- **Fresh install (default)** — runs the OneCLI installer (a Docker Compose stack plus the `onecli` CLI), points the CLI at the new instance, and writes `ONECLI_URL` to `.env`.
+- **Reuse existing** — if setup detects a working `onecli` on the host, it asks before reinstalling. Choosing reuse leaves the running gateway untouched (re-running the installer would rebind the listener and break other apps using it) and just records its URL.
+- **Remote vault** — set `NANOCLAW_ONECLI_API_HOST` before running setup to point at a OneCLI instance on another machine. Setup installs only the CLI, health-checks the remote URL, and writes `ONECLI_URL`. Pass the remote vault's API token via `NANOCLAW_ONECLI_API_TOKEN` so setup can authenticate the CLI and write `ONECLI_API_KEY`.
+
+On an existing install (for example after `/update-nanoclaw` brings in OneCLI as a breaking change), run the `/init-onecli` skill instead. It installs the vault, migrates any credentials it finds in `.env` (Anthropic keys, `OPENAI_API_KEY`, and similar container-facing secrets) into the vault, and removes the raw values from `.env`. Channel tokens like `TELEGRAM_BOT_TOKEN` stay in `.env` — the host process uses those, not the containers.
+
+## Anthropic credentials
+
+The wizard's auth step offers three ways to connect Claude, all of which end up as a vault secret rather than an env var:
+
+<Tabs>
+  <Tab title="Claude subscription (Pro/Max)">
+    Setup runs `claude setup-token` under a PTY so the browser OAuth flow works, captures the resulting `sk-ant-oat…` token, and registers it:
+
+    ```bash
+    onecli secrets create \
+      --name Anthropic \
+      --type anthropic \
+      --value "$token" \
+      --host-pattern api.anthropic.com
+    ```
+  </Tab>
+  <Tab title="API key or existing OAuth token">
+    Paste a `sk-ant-api…` key (from console.anthropic.com) or a `sk-ant-oat…` token you already have. Setup validates the shape and runs the same `onecli secrets create --type anthropic --host-pattern api.anthropic.com` registration.
+  </Tab>
+  <Tab title="Custom endpoint">
+    Set `NANOCLAW_ANTHROPIC_BASE_URL` and `NANOCLAW_ANTHROPIC_AUTH_TOKEN` before setup to use an Anthropic-compatible endpoint. The token is stored as a generic secret with header injection (`--header-name Authorization --value-format 'Bearer {value}'`) keyed to the custom hostname. The container only sees `ANTHROPIC_BASE_URL` plus `ANTHROPIC_AUTH_TOKEN=placeholder` — the gateway overwrites the placeholder bearer on the wire.
+  </Tab>
+</Tabs>
+
+## Adding a credential for a new service
+
+Register a secret with a name and a **host pattern** — the host the gateway should inject it for:
+
+```bash
+onecli secrets create \
+  --name GitHub \
+  --type api_key \
+  --value "$TOKEN" \
+  --host-pattern api.github.com
+```
+
+Then grant it to the agent groups that should use it. Note that `set-secrets` **replaces** the agent's whole list, so read and merge first:
+
+```bash
+AGENT_ID=$(onecli agents list | jq -r '.data[] | select(.identifier=="<agentGroupId>") | .id')
+CURRENT=$(onecli agents secrets --id "$AGENT_ID" | jq -r '[.data[]] | join(",")')
+MERGED=$(printf '%s' "$CURRENT,<new-secret-id>" | tr ',' '\n' | sort -u | paste -sd ',' -)
+onecli agents set-secrets --id "$AGENT_ID" --secret-ids "$MERGED"
+```
+
+`<agentGroupId>` is the `agentGroupId` field in the group's `container.json`. The same model powers `setup/register-claude-token.sh`, which accepts `SECRET_NAME` and `HOST_PATTERN` overrides if you want the subscription flow against a different secret name or host.
+
+## Approving credential use
+
+Secrets can be configured in OneCLI to require **manual approval** per request. When the gateway intercepts a request that needs one, it holds the HTTP connection open and asks NanoClaw, which delivers a **Credentials Request card** to an admin DM showing the agent name, the `METHOD host/path`, and a body preview, with Approve / Reject buttons.
+
+- **Who gets the card:** admins of the originating agent group first, then global admins, then owners — the first one with a reachable DM. No eligible approver means auto-deny.
+- **Approving or rejecting:** tap the button on the card. The decision is returned to the gateway, which either injects the credential and lets the request through or fails it.
+- **Expiry:** unanswered cards expire on the gateway's TTL and the request is denied. Cards left over from a previous process are marked "Expired (host restarted)" at startup.
+
+Inspect in-flight approvals with the [ncl CLI](/operate/ncl-cli): `ncl approvals list --status pending`. The CLI is read-only for approvals — decisions happen on the card.
+
+## Opting out: the native credential proxy
+
+If you don't want the vault — a single-user install where `.env` simplicity beats per-agent policies — the `/use-native-credential-proxy` skill adds an explicit opt-out. With `NANOCLAW_NATIVE_CREDENTIALS=true`, NanoClaw reads `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, or `ANTHROPIC_AUTH_TOKEN` (plus optional `ANTHROPIC_BASE_URL`) straight from `.env` and threads them into the container's environment as standard SDK variables.
+
+<Warning>
+This deliberately inverts the v2 invariant: the raw credential enters the container. You lose injection-at-the-boundary, per-agent secret grants, and approval cards. Use it only if you accept that tradeoff.
+</Warning>
+
+The skill is additive — with the flag unset, it's a no-op and the vault path is unchanged. It only covers Anthropic credentials; other service secrets still need the vault or manual handling.
+
+## Egress lockdown
+
+For defense in depth, `NANOCLAW_EGRESS_LOCKDOWN=true` places agents on an internal Docker network where the vault's gateway is the only reachable egress hop — agents physically cannot bypass the proxy. See [Hardening](/operate/hardening) for the full setup.

--- a/operate/hardening.mdx
+++ b/operate/hardening.mdx
@@ -1,128 +1,103 @@
 ---
-title: Docker Sandboxes
-description: Running NanoClaw inside Docker Sandboxes for an extra layer of VM-level isolation
+title: "Hardening"
+description: "Lock down a NanoClaw install — egress lockdown, the mount allowlist, sender policies, the command gate, and container resource limits."
+tag: "UPDATED"
+keywords: ["hardening", "security", "egress lockdown", "NANOCLAW_EGRESS_LOCKDOWN", "mount allowlist", "unknown_sender_policy", "command gate", "container limits"]
 ---
 
-Docker Sandboxes wrap your entire NanoClaw instance — including its agent containers — inside a lightweight micro VM. This gives you **two layers of isolation**: the sandbox VM boundary on the outside, and per-agent Docker containers on the inside.
+{/* verified-against: src/egress-lockdown.ts, src/modules/mount-security/index.ts, src/modules/permissions/{index.ts,access.ts,sender-approval.ts}, src/command-gate.ts, src/router.ts, src/db/schema.ts, src/config.ts, config-examples/mount-allowlist.json, .claude/skills/manage-mounts/SKILL.md, setup/mounts.ts @ dc34ceb */}
 
-## Architecture
+NanoClaw's isolation boundary is the Docker container: each agent runs in its own container with a scoped workspace mount (see [Container lifecycle](/concepts/container-lifecycle)). There is no micro-VM or alternative sandbox runtime — hardening means tightening what those containers can reach. This page walks the defense-in-depth controls from network to filesystem to people.
 
-```mermaid
-graph TB
-    subgraph Sandbox["Docker Sandbox (micro VM)"]
-        NC[NanoClaw Process - Node.js]
-        subgraph DinD["Docker-in-Docker"]
-            C1[Agent Container 1]
-            C2[Agent Container 2]
-        end
-        NC --> DinD
-    end
+## Lock down network egress
 
-    Host[Host Machine] --> Sandbox
+By default, agent containers have normal outbound internet access. Set `NANOCLAW_EGRESS_LOCKDOWN=true` to force all agent traffic through the OneCLI gateway instead:
 
-    style Sandbox fill:#f0fdfa,stroke:#2DD4BF
-    style DinD fill:#ccfbf1,stroke:#14B8A6
+- Agent containers are placed on an `--internal` Docker network (default name `nanoclaw-egress`, override with `NANOCLAW_EGRESS_NETWORK`). Internal networks have no route to the internet.
+- The OneCLI gateway container (default name `onecli`, override with `ONECLI_GATEWAY_CONTAINER`) is attached to that network with the alias `host.docker.internal`, so the injected proxy is the only reachable hop.
+- Agents run non-root without `NET_ADMIN`, so they can't reconfigure the network from inside.
+
+The setup is idempotent and self-healing — NanoClaw creates the network and re-attaches the gateway on every spawn if needed. It also **fails fast**: if lockdown is enabled but the network can't be created or the gateway container can't be attached, NanoClaw throws an `EgressLockdownError` and refuses to spawn the agent rather than silently running it with open egress. If you see that error, start the gateway container (or set `NANOCLAW_EGRESS_LOCKDOWN=false` to opt out).
+
+All three variables are read from `process.env` only — putting them in `.env` has no effect. Set them in the service definition (launchd plist or systemd unit) as described in [Configuration](/operate/configuration#applying-changes):
+
+```bash
+# Linux (systemd unit)
+Environment=NANOCLAW_EGRESS_LOCKDOWN=true
 ```
 
-## Requirements
+## Gate additional mounts
 
-- **Docker Desktop v4.40+** with sandbox capabilities enabled
-- **Anthropic API key**
-- **Platform credentials** for your messaging channels (e.g., Telegram bot token, WhatsApp phone number, Discord bot token, Slack app token)
+Per-group container config can request `additional_mounts` — extra host directories mounted into the container. Every request is validated against an allowlist at `~/.config/nanoclaw/mount-allowlist.json`. The file lives **outside the project root** on purpose: container agents can edit files in their workspace, so the security config has to sit where they can't reach it.
 
-## Setup
+**If the allowlist file doesn't exist, all additional mounts are blocked.** That's the default posture; you opt in by creating the file.
 
-<Steps>
-  <Step title="Patch the Dockerfile for proxy support">
-    Docker Sandboxes use a MITM proxy for network isolation. The Dockerfile must accept proxy build arguments so the container can install packages through the proxy:
+```json mount-allowlist.json
+{
+  "allowedRoots": [
+    { "path": "~/projects", "allowReadWrite": true, "description": "Development projects" },
+    { "path": "~/Documents/work", "allowReadWrite": false, "description": "Work documents (read-only)" }
+  ],
+  "blockedPatterns": ["password", "secret", "token"],
+  "nonMainReadOnly": true
+}
+```
 
-    ```dockerfile
-    ARG http_proxy
-    ARG https_proxy
-    ARG NODE_EXTRA_CA_CERTS
-    ```
-  </Step>
+Validation rules, in order:
 
-  <Step title="Update the build script">
-    Forward proxy environment variables during `docker build` so that package managers (apt, npm) can reach the internet through the sandbox proxy:
+1. **Container path** must be relative, non-empty, and contain no `..` or `:` (prevents path traversal and Docker `-v` option injection). Validated mounts land under `/workspace/extra/`.
+2. **Host path** is tilde-expanded and resolved through symlinks to its real path; it must exist.
+3. **Blocked patterns** — the real path must not match any pattern. Your `blockedPatterns` are merged with a built-in default set (`.ssh`, `.gnupg`, `.aws`, `.kube`, `.docker`, `credentials`, `.env`, `.netrc`, `id_rsa`, `id_ed25519`, and similar) that you can't remove.
+4. **Allowed roots** — the real path must sit under one of `allowedRoots`.
+5. **Read-only by default** — a mount is read-write only when it explicitly requests it *and* the matching root has `allowReadWrite: true`. Otherwise it's forced read-only.
 
-    ```bash
-    docker build \
-      --build-arg http_proxy="$http_proxy" \
-      --build-arg https_proxy="$https_proxy" \
-      ...
-    ```
-  </Step>
+Rejected mounts are logged with the reason and skipped; the container still starts with its valid mounts. Use the `/manage-mounts` skill to view, add, or remove entries conversationally, or write the config through the setup step:
 
-  <Step title="Patch the container runner">
-    Three changes are required in `src/container-runner.ts`:
+```bash
+pnpm exec tsx setup/index.ts --step mounts --force -- --json '{"allowedRoots":[{"path":"/path/to/dir","readOnly":false}],"blockedPatterns":[],"nonMainReadOnly":true}'
+```
 
-    1. **Replace `/dev/null` mounts** with empty files — `/dev/null` bind-mounts don't work inside sandboxes
-    2. **Forward proxy environment variables** to spawned agent containers (`http_proxy`, `https_proxy`, `NODE_EXTRA_CA_CERTS`)
-    3. **Mount the sandbox CA certificate** so agent containers trust the MITM proxy
-  </Step>
+The allowlist is cached in memory, so restart the service after changes.
 
-  <Step title="Configure upstream API calls">
-    If your code makes HTTPS requests to the Anthropic API or other services, configure `HttpsProxyAgent` to route through the sandbox proxy:
+## Restrict who can talk to your agents
 
-    ```typescript
-    import { HttpsProxyAgent } from 'https-proxy-agent';
+Each messaging group carries an `unknown_sender_policy` that decides what happens when someone who isn't an owner, admin, or member of the wired agent group writes in:
 
-    const agent = new HttpsProxyAgent(process.env.https_proxy);
-    ```
-  </Step>
+| Policy | Behavior |
+|---|---|
+| `strict` | Message dropped silently and recorded in `dropped_messages`. |
+| `request_approval` | Message dropped, and an Approve / Deny card is DM'd to an owner or admin. On approve, the sender becomes a group member and the original message is re-routed. Duplicate requests from the same sender are deduplicated while a card is pending. |
+| `public` | Anyone can talk to the agent — the access check is skipped entirely. |
 
-  <Step title="Channel-specific patches">
-    Each messaging channel may need additional proxy configuration:
+Channels auto-created by the router (someone @mentions or DMs the bot in an unwired chat) get `request_approval`. To harden a chat to silent-drop:
 
-    - **Telegram**: Ensure the grammy HTTP client uses the proxy agent
-    - **WhatsApp**: Configure proxy bypass for `web.whatsapp.com` domains, and authenticate via QR code or pairing code
-  </Step>
-</Steps>
+```bash
+ncl messaging-groups update --id <mg-id> --unknown-sender-policy strict
+```
 
-## Troubleshooting
+Check `ncl approvals list --status pending` for in-flight cards and `ncl dropped-messages list` to audit who got dropped and why. Note that the approval flow needs an owner or admin with a reachable DM channel — on a fresh install with no owner configured, approval requests are skipped and logged. Wirings can additionally set `sender_scope known`, which requires explicit membership even on a `public` messaging group — see [ncl CLI](/operate/ncl-cli).
 
-<Accordion title="SSL certificate errors">
-  The sandbox MITM proxy terminates TLS connections. If you see `UNABLE_TO_VERIFY_LEAF_SIGNATURE` or similar errors:
+## The command gate
 
-  ```bash
-  export NODE_TLS_REJECT_UNAUTHORIZED=0  # Development only!
-  ```
+Slash commands are classified on the host before they ever reach a container:
 
-  For production, mount the sandbox CA certificate and set `NODE_EXTRA_CA_CERTS`.
-</Accordion>
+- **Filtered commands** (`/help`, `/login`, `/logout`, `/doctor`, `/config`, `/remote-control`) are dropped silently — they manipulate host-side CLI state and never reach the agent.
+- **Admin commands** (`/clear`, `/compact`, `/context`, `/cost`, `/files`, `/upload-trace`) require the sender to hold an `owner` or `admin` role in `user_roles`; everyone else gets a "Permission denied" reply.
+- Everything else passes through unchanged.
 
-<Accordion title="Path mounting failures">
-  Ensure NanoClaw lives inside the sandbox workspace directory. Paths outside the workspace are not accessible from within the sandbox.
-</Accordion>
+If the permissions module isn't installed (no `user_roles` table), admin commands are allowed for everyone — install the module to get the role check.
 
-<Accordion title="Agent containers can't reach the network">
-  Verify that proxy environment variables are forwarded to agent containers. Check the container runner patch in Step 3 above.
+## Cap container resources
 
-  ```bash
-  docker exec <container> env | grep -i proxy
-  ```
-</Accordion>
+Four limits bound what a runaway agent can consume. All are read from `process.env` only — set them in the service definition, not `.env` (see [Configuration](/operate/configuration#process-environment-only)):
 
-<Accordion title="WhatsApp authentication issues">
-  WhatsApp's web client needs direct access to `web.whatsapp.com`. Configure a proxy bypass for this domain in your WhatsApp channel adapter.
-</Accordion>
+| Variable | Default | Limits |
+|---|---|---|
+| `CONTAINER_TIMEOUT` | 30 min | Max runtime for an agent container. |
+| `IDLE_TIMEOUT` | 30 min | How long an idle container survives after its last result. |
+| `MAX_CONCURRENT_CONTAINERS` | `5` | Simultaneously running agent containers. |
+| `CONTAINER_MAX_OUTPUT_SIZE` | 10 MB | Output captured from a container. |
 
-## When to use Docker Sandboxes
+## Credentials
 
-| Scenario | Recommended? |
-|----------|-------------|
-| Personal use on trusted hardware | Standard Docker is sufficient |
-| Shared server or multi-tenant environment | Yes — adds VM-level isolation |
-| Running untrusted community skills | Yes — limits blast radius |
-| CI/CD or automated testing | Yes — reproducible isolated environment |
-
-<Note>
-  Docker Sandboxes add latency to container operations due to the nested virtualization layer. For most workloads this is negligible, but latency-sensitive setups may prefer standard Docker.
-</Note>
-
-## Related pages
-
-- [Container runtime](/concepts/container-lifecycle) — Standard container execution details
-- [Security model](/concepts/security) — NanoClaw's security boundaries
-- [Troubleshooting](/operate/troubleshooting) — General debugging guide
+Keep API keys and OAuth tokens out of agent containers entirely — the OneCLI Agent Vault injects them at the proxy layer so agents never see raw secrets. See [Credentials](/operate/credentials).

--- a/operate/hardening.mdx
+++ b/operate/hardening.mdx
@@ -38,8 +38,7 @@ Per-group container config can request `additional_mounts` — extra host direct
     { "path": "~/projects", "allowReadWrite": true, "description": "Development projects" },
     { "path": "~/Documents/work", "allowReadWrite": false, "description": "Work documents (read-only)" }
   ],
-  "blockedPatterns": ["password", "secret", "token"],
-  "nonMainReadOnly": true
+  "blockedPatterns": ["password", "secret", "token"]
 }
 ```
 
@@ -54,8 +53,12 @@ Validation rules, in order:
 Rejected mounts are logged with the reason and skipped; the container still starts with its valid mounts. Use the `/manage-mounts` skill to view, add, or remove entries conversationally, or write the config through the setup step:
 
 ```bash
-pnpm exec tsx setup/index.ts --step mounts --force -- --json '{"allowedRoots":[{"path":"/path/to/dir","readOnly":false}],"blockedPatterns":[],"nonMainReadOnly":true}'
+pnpm exec tsx setup/index.ts --step mounts --force -- --json '{"allowedRoots":[{"path":"/path/to/dir","allowReadWrite":true}],"blockedPatterns":[]}'
 ```
+
+<Note>
+The key the validator reads is `allowReadWrite`. A `readOnly` key (shown in some upstream examples) is silently ignored, leaving the mount read-only. Likewise, a top-level `nonMainReadOnly` field may appear in configs written by setup, but the mount validator doesn't read it.
+</Note>
 
 The allowlist is cached in memory, so restart the service after changes.
 
@@ -65,8 +68,8 @@ Each messaging group carries an `unknown_sender_policy` that decides what happen
 
 | Policy | Behavior |
 |---|---|
-| `strict` | Message dropped silently and recorded in `dropped_messages`. |
-| `request_approval` | Message dropped, and an Approve / Deny card is DM'd to an owner or admin. On approve, the sender becomes a group member and the original message is re-routed. Duplicate requests from the same sender are deduplicated while a card is pending. |
+| `strict` | Message dropped silently and recorded in the dropped-messages log (`ncl dropped-messages list`). |
+| `request_approval` | Message dropped, and an Allow / Deny card is DM'd to an owner or admin. On approve, the sender becomes a group member and the original message is re-routed. Duplicate requests from the same sender are deduplicated while a card is pending. |
 | `public` | Anyone can talk to the agent — the access check is skipped entirely. |
 
 Channels auto-created by the router (someone @mentions or DMs the bot in an unwired chat) get `request_approval`. To harden a chat to silent-drop:
@@ -75,7 +78,7 @@ Channels auto-created by the router (someone @mentions or DMs the bot in an unwi
 ncl messaging-groups update --id <mg-id> --unknown-sender-policy strict
 ```
 
-Check `ncl approvals list --status pending` for in-flight cards and `ncl dropped-messages list` to audit who got dropped and why. Note that the approval flow needs an owner or admin with a reachable DM channel — on a fresh install with no owner configured, approval requests are skipped and logged. Wirings can additionally set `sender_scope known`, which requires explicit membership even on a `public` messaging group — see [ncl CLI](/operate/ncl-cli).
+Sender approvals are handled entirely through the DM card — there's no `ncl` resource for them (`ncl approvals` covers a different approval queue). Use `ncl dropped-messages list` to audit who got dropped and why. Note that the approval flow needs an owner or admin with a reachable DM channel — on a fresh install with no owner configured, approval requests are skipped and logged. Wirings can additionally set `sender_scope known`, which requires explicit membership even on a `public` messaging group — see [ncl CLI](/operate/ncl-cli).
 
 ## The command gate
 

--- a/operate/ncl-cli.mdx
+++ b/operate/ncl-cli.mdx
@@ -1,184 +1,138 @@
 ---
-title: Command-line interface
-description: Run NanoClaw agents from the terminal with the claw CLI — send prompts, pipe input, resume sessions, and script agent interactions
-keywords: ["cli", "claw", "terminal", "command line", "scripting", "automation"]
+title: "The ncl admin CLI"
+description: "Administer a running NanoClaw host from the terminal — inspect and modify groups, wirings, users, sessions, and approvals over the ncl Unix socket."
+tag: "UPDATED"
+keywords: ["ncl", "cli", "admin", "unix socket", "cli_scope", "groups", "wirings", "sessions", "approvals"]
 ---
 
-## Overview
+{/* verified-against: src/cli/client.ts, src/cli/dispatch.ts, src/cli/socket-server.ts, src/cli/crud.ts, src/cli/format.ts, src/cli/transport-errors.ts, src/cli/commands/help.ts, src/cli/resources/{approvals,destinations,dropped-messages,groups,members,messaging-groups,roles,sessions,user-dms,users,wirings}.ts, src/db/container-configs.ts, bin/ncl, setup/service.ts @ dc34ceb */}
 
-`claw` is a Python CLI that sends prompts directly to a NanoClaw agent container from the terminal. It reads registered groups from the NanoClaw database, picks up secrets from `.env`, and pipes a JSON payload into a container run — no chat app required.
+`ncl` is the admin CLI for a running NanoClaw host. It sends one request frame over a Unix socket at `data/ncl.sock` and prints the response — every command reads or mutates the host's central database live, no restart needed. The socket is `chmod 0600`, so only the user that started the host can connect.
 
-Use cases include:
+Don't confuse it with the [CLI channel](/channels/cli), which is a chat adapter for talking *to an agent* from the terminal — `ncl` is for operating the host itself.
 
-- **Scripting and automation** — pipe output from one tool into an agent, or pipe the agent's result into another tool
-- **CI/CD hooks** — call an agent from a GitHub Action or git hook
-- **Dev workflow** — stay in the terminal without context-switching to a chat app
-- **Bootstrapping** — use an agent immediately before any messaging channel is set up
-- **Testing** — faster feedback loop than sending a message through a chat app
+## Invoking ncl
 
-## Prerequisites
-
-- Python 3.8 or later
-- NanoClaw installed with a built checkout-scoped container image (`nanoclaw-agent-v2-<slug>:latest`)
-- Either `container` (Apple Container, macOS 15+) or `docker` available in `PATH`
-
-## Installation
-
-Run the `/claw` skill in Claude Code from your NanoClaw directory:
+Setup symlinks `bin/ncl` into `~/.local/bin`, so after install you can run `ncl` from anywhere. From the project root, `pnpm ncl` works too:
 
 ```bash
-/claw
+ncl groups list
+pnpm ncl groups list   # equivalent, from the checkout
 ```
 
-The skill copies the script into `scripts/claw` and symlinks it to `~/bin/claw`. Verify with:
+The general shape is:
 
 ```bash
-claw --list-groups
+ncl <resource> <verb> [target] [--key value ...] [--json]
 ```
 
-<Note>
-If NanoClaw isn't running or the database doesn't exist yet, the group list will be empty — that's expected.
-</Note>
+Positional words join into the command name, and a trailing positional becomes the target ID — `ncl groups get abc123` and `ncl groups get --id abc123` are the same call. Flags map to columns; hyphens and underscores are interchangeable (`--agent-group-id` = `--agent_group_id`). Run `ncl help` to list every resource, and `ncl <resource> help` for its verbs, columns, and enums.
 
-## Usage
+## Output and errors
 
-### Send a prompt
+By default `ncl` prints a human format: a small aligned table for list results, pretty-printed JSON for single objects, and `error (<code>): <message>` on failure. Pass `--json` to get the raw response frame instead — use that for scripting. Exit codes: `0` success, `1` command error, `2` transport error.
+
+If the host isn't running, `ncl` can't reach the socket and tells you so:
+
+```text
+ncl: cannot reach NanoClaw host (connect ENOENT .../data/ncl.sock).
+Is the host running? Start it with: pnpm run dev
+```
+
+## Agents can run ncl too
+
+The same command surface is exposed to agents inside containers. What an agent may do is controlled per group by `cli_scope` in its container config:
+
+- **`disabled`** — all `ncl` commands are rejected.
+- **`group`** (default) — the agent only sees the `groups`, `sessions`, `destinations`, and `members` resources, pinned to its own group: IDs are auto-filled, rows from other groups are filtered out, and it cannot change its own `cli_scope`.
+- **`global`** — full access to every resource.
+
+Regardless of scope, mutating verbs (`create`, `update`, `delete`, `grant`, `restart`, ...) are approval-gated for agents: the agent gets `approval-pending` and an admin receives a card showing the exact command. From the host socket, the same verbs run immediately — the socket file permissions are the auth boundary. Change the scope with:
 
 ```bash
-# Send to the main group (default)
-claw "What's on my calendar today?"
-
-# Send to a specific group by name (fuzzy match)
-claw -g "family" "Remind everyone about dinner at 7"
-
-# Send to a group by exact JID
-claw -j "120363336345536173@g.us" "Hello"
+ncl groups config update <group-id> --cli-scope disabled
 ```
 
-### Resume a session
+## Working with resources
+
+Representative commands per resource — `ncl <resource> help` shows the full set.
+
+### groups
+
+Agent groups: the agent identities with their own folder, history, and container image. Beyond CRUD, `groups` carries the container-config and lifecycle verbs.
 
 ```bash
-claw -s abc123 "Continue where we left off"
+ncl groups create --name "Research" --folder research
+ncl groups restart <group-id> --rebuild
 ```
 
-The session ID is printed to stderr after each run. Pass it back with `-s` to continue the conversation.
+`restart` kills and respawns the group's containers (`--rebuild` rebuilds the image first — required after package changes; `--message <text>` leaves an on-wake instruction). `delete` cascades through sessions, wirings, roles, memberships, and destinations in one transaction.
 
-### Pipe input from stdin
+Config subcommands edit the group's `container_configs` row — changes apply on the next `restart`:
 
 ```bash
-# Read prompt from stdin
-echo "Summarize this" | claw --pipe -g dev
-
-# Pipe a file
-cat report.txt | claw --pipe "Summarize this report"
+ncl groups config get <group-id>
+ncl groups config update <group-id> --model claude-sonnet-4-5 --effort high
+ncl groups config add-mcp-server <group-id> --name fetch --command npx --args '["mcp-fetch"]'
+ncl groups config add-package <group-id> --apt ffmpeg
 ```
 
-When using `--pipe`, you can combine a positional prompt argument with stdin — the positional argument is prepended to the piped content.
+`config update` accepts `--provider`, `--model`, `--effort`, `--image-tag`, `--assistant-name`, `--max-messages-per-prompt`, and `--cli-scope`.
 
-### List registered groups
+### messaging-groups and wirings
+
+A messaging group is one chat on one platform (unique `channel_type` + `platform_id`); a wiring connects it to an agent group and sets engagement rules. List commands accept column filters and `--limit`:
 
 ```bash
-claw --list-groups
+ncl messaging-groups list --channel_type telegram
+ncl wirings create --messaging-group-id <mg-id> --agent-group-id <group-id> --engage-mode mention-sticky
+ncl wirings update <wiring-id> --session-mode per-thread
 ```
 
-Displays all registered groups with their name, folder, and JID.
+Wiring columns: `engage_mode` (`mention` | `mention-sticky` | `pattern`), `engage_pattern`, `sender_scope` (`all` | `known`), `ignored_message_policy` (`drop` | `accumulate`), `session_mode` (`shared` | `per-thread` | `agent-shared`).
 
-### Advanced options
+### users, roles, and members
+
+Users are per-channel identities (`tg:6037840640`, `discord:1234...`). Roles grant privilege (`owner` is always global; `admin` can be global or scoped to one group with `--group`). Members let unprivileged users talk to a group when its wiring has `sender_scope known`.
 
 ```bash
-# Force a specific container runtime
-claw --runtime docker "Hello"
-
-# Use a custom image tag
-claw --image nanoclaw-agent:dev "Hello"
-
-# Custom timeout for long-running tasks (default: 300s)
-claw --timeout 600 "Run the full analysis"
-
-# Verbose mode — shows command, redacted payload, and exit code
-claw -v "Hello"
+ncl users create --id tg:6037840640 --kind telegram --display-name "Ethan"
+ncl roles grant --user tg:6037840640 --role admin --group <group-id>
+ncl members add --user tg:6037840640 --group <group-id>
 ```
 
-## How it works
+`roles revoke` and `members remove` take the same flags.
 
-`claw` bypasses the messaging channel layer entirely. It:
+### sessions
 
-1. Reads registered groups from the NanoClaw SQLite database
-2. Resolves the target group (by name, folder, or JID)
-3. Loads secrets from `.env` (API keys, OAuth tokens)
-4. Constructs a JSON payload with the prompt, group context, and secrets
-5. Pipes the payload into a container run (`docker run -i --rm` or `container run -i --rm`)
-6. Streams stderr in real time and waits for the output sentinel
-7. Parses the structured output and prints the agent's response to stdout
-
-The agent running inside the container has the same capabilities as when invoked through a chat channel — including group memory, file mounts, and MCP tools.
-
-## Scripting examples
-
-### CI/CD post-deploy check
+Read-only view of the runtime units — one row per (agent group, messaging group, thread) with its container status (`running` | `stopped`):
 
 ```bash
-claw -g ops "Deploy to production just finished. Check for errors in the last 10 minutes."
+ncl sessions list --agent_group_id <group-id>
 ```
 
-### Pipe git diff for code review
+### dropped-messages
+
+Read-only log of messages the router dropped, aggregated per sender and chat with a `reason` (`no_agent_wired`, `no_agent_engaged`, `unknown_sender_strict`, `unknown_sender_request_approval`). Your first stop when a message got no reply:
 
 ```bash
-git diff main..HEAD | claw --pipe -g dev "Review this diff for issues"
+ncl dropped-messages list
 ```
 
-### Daily summary via cron
+### approvals
+
+Read-only view of in-flight approval cards waiting for an admin response:
 
 ```bash
-claw "Summarize today's standups" >> daily-brief.txt
+ncl approvals list --status pending
 ```
 
-### Chain with other tools
+### destinations and user-dms
+
+Destinations are per-agent send ACLs — each row lets an agent address a channel or another agent by a local name. `user-dms` is the read-only DM-route cache the host uses to cold-DM users.
 
 ```bash
-claw "What are the open P0 bugs?" | mail -s "P0 Bug Report" team@example.com
+ncl destinations list --agent_group_id <group-id>
+ncl destinations add --agent-group-id <group-id> --local-name ops-channel --target-type channel --target-id <mg-id>
+ncl user-dms list
 ```
-
-## Troubleshooting
-
-<AccordionGroup>
-  <Accordion title="'neither container nor docker found'">
-    Install Docker Desktop or Apple Container (macOS 15+), or pass `--runtime` explicitly.
-  </Accordion>
-
-  <Accordion title="'no secrets found in .env'">
-    The script reads `.env` from your NanoClaw directory. Verify it exists and contains at least one of: `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`.
-  </Accordion>
-
-  <Accordion title="Container times out">
-    The default timeout is 300 seconds. For longer tasks, pass `--timeout 600` (or higher). If the container consistently hangs, rebuild the image with `./container/build.sh`.
-  </Accordion>
-
-  <Accordion title="'group not found'">
-    Run `claw --list-groups` to see registered groups. Group lookup does fuzzy partial matching on name and folder — if your query matches multiple groups, you get an error listing the ambiguous matches.
-  </Accordion>
-
-  <Accordion title="Container crashes mid-stream">
-    Containers run with `--rm` so they're automatically removed. If the agent crashes before emitting the output sentinel, `claw` falls back to printing raw stdout. Use `-v` to inspect output. Rebuild the image if crashes are consistent.
-  </Accordion>
-
-  <Accordion title="Override the NanoClaw directory">
-    If `claw` can't find your database or `.env`, set the `NANOCLAW_DIR` environment variable:
-
-    ```bash
-    export NANOCLAW_DIR=/path/to/your/nanoclaw
-    ```
-  </Accordion>
-</AccordionGroup>
-
-## Next steps
-
-<CardGroup cols={2}>
-  <Card title="Scheduled tasks" icon="clock" href="/guides/scheduled-tasks">
-    Automate recurring agent tasks with the built-in scheduler
-  </Card>
-
-  <Card title="Container runtime" icon="box" href="/concepts/container-lifecycle">
-    Learn how agent containers are configured and managed
-  </Card>
-</CardGroup>

--- a/operate/ncl-cli.mdx
+++ b/operate/ncl-cli.mdx
@@ -26,7 +26,7 @@ The general shape is:
 ncl <resource> <verb> [target] [--key value ...] [--json]
 ```
 
-Positional words join into the command name, and a trailing positional becomes the target ID — `ncl groups get abc123` and `ncl groups get --id abc123` are the same call. Flags map to columns; hyphens and underscores are interchangeable (`--agent-group-id` = `--agent_group_id`). Run `ncl help` to list every resource, and `ncl <resource> help` for its verbs, columns, and enums.
+Positional words join into the command name. A trailing positional becomes the target ID only if the ID contains no dashes — the dispatcher trims a single dash-segment, so `ncl groups get abc123` works, but a real NanoClaw ID (a UUID, four hyphens) does not resolve. In practice, always pass `--id <uuid>`. Flags map to columns; hyphens and underscores are interchangeable (`--agent-group-id` = `--agent_group_id`). Run `ncl help` to list every resource, and `ncl <resource> help` for its verbs, columns, and enums.
 
 ## Output and errors
 
@@ -37,6 +37,9 @@ If the host isn't running, `ncl` can't reach the socket and tells you so:
 ```text
 ncl: cannot reach NanoClaw host (connect ENOENT .../data/ncl.sock).
 Is the host running? Start it with: pnpm run dev
+Or, if installed as a service:
+  macOS:  launchctl kickstart -k gui/$(id -u)/com.nanoclaw-v2-<slug>
+  Linux:  systemctl --user restart nanoclaw-v2-<slug>
 ```
 
 ## Agents can run ncl too
@@ -50,7 +53,7 @@ The same command surface is exposed to agents inside containers. What an agent m
 Regardless of scope, mutating verbs (`create`, `update`, `delete`, `grant`, `restart`, ...) are approval-gated for agents: the agent gets `approval-pending` and an admin receives a card showing the exact command. From the host socket, the same verbs run immediately — the socket file permissions are the auth boundary. Change the scope with:
 
 ```bash
-ncl groups config update <group-id> --cli-scope disabled
+ncl groups config update --id <group-id> --cli-scope disabled
 ```
 
 ## Working with resources
@@ -63,7 +66,7 @@ Agent groups: the agent identities with their own folder, history, and container
 
 ```bash
 ncl groups create --name "Research" --folder research
-ncl groups restart <group-id> --rebuild
+ncl groups restart --id <group-id> --rebuild
 ```
 
 `restart` kills and respawns the group's containers (`--rebuild` rebuilds the image first — required after package changes; `--message <text>` leaves an on-wake instruction). `delete` cascades through sessions, wirings, roles, memberships, and destinations in one transaction.
@@ -71,10 +74,10 @@ ncl groups restart <group-id> --rebuild
 Config subcommands edit the group's `container_configs` row — changes apply on the next `restart`:
 
 ```bash
-ncl groups config get <group-id>
-ncl groups config update <group-id> --model claude-sonnet-4-5 --effort high
-ncl groups config add-mcp-server <group-id> --name fetch --command npx --args '["mcp-fetch"]'
-ncl groups config add-package <group-id> --apt ffmpeg
+ncl groups config get --id <group-id>
+ncl groups config update --id <group-id> --model claude-sonnet-4-5 --effort high
+ncl groups config add-mcp-server --id <group-id> --name fetch --command npx --args '["mcp-fetch"]'
+ncl groups config add-package --id <group-id> --apt ffmpeg
 ```
 
 `config update` accepts `--provider`, `--model`, `--effort`, `--image-tag`, `--assistant-name`, `--max-messages-per-prompt`, and `--cli-scope`.
@@ -86,7 +89,7 @@ A messaging group is one chat on one platform (unique `channel_type` + `platform
 ```bash
 ncl messaging-groups list --channel_type telegram
 ncl wirings create --messaging-group-id <mg-id> --agent-group-id <group-id> --engage-mode mention-sticky
-ncl wirings update <wiring-id> --session-mode per-thread
+ncl wirings update --id <wiring-id> --session-mode per-thread
 ```
 
 Wiring columns: `engage_mode` (`mention` | `mention-sticky` | `pattern`), `engage_pattern`, `sender_scope` (`all` | `known`), `ignored_message_policy` (`drop` | `accumulate`), `session_mode` (`shared` | `per-thread` | `agent-shared`).
@@ -105,7 +108,7 @@ ncl members add --user tg:6037840640 --group <group-id>
 
 ### sessions
 
-Read-only view of the runtime units — one row per (agent group, messaging group, thread) with its container status (`running` | `stopped`):
+Read-only view of the runtime units — one row per (agent group, messaging group, thread) with its container status (`running` | `stopped`; `idle` is reserved and currently unused):
 
 ```bash
 ncl sessions list --agent_group_id <group-id>

--- a/operate/troubleshooting.mdx
+++ b/operate/troubleshooting.mdx
@@ -18,7 +18,7 @@ tail -f logs/nanoclaw.log          # full routing chain: inbound, spawn/exit, de
 tail -n 50 logs/nanoclaw.error.log # delivery failures, crash-loop backoff, warnings
 ```
 
-Set `LOG_LEVEL=debug` (see [Configuration](/operate/configuration#applying-changes)) to also see resolved mount configurations, the container spawn command, and streamed container stderr tagged with `container=<group folder>`. Containers run with `--rm`, so the host log is the only place container output survives.
+Set `LOG_LEVEL=debug` (see [Configuration](/operate/configuration#applying-changes)) to also see resolved mount configurations and streamed container stderr tagged with `container=<group folder>`. Containers run with `--rm`, so the host log is the only place container output survives.
 
 Then get the system state from the [ncl CLI](/operate/ncl-cli):
 
@@ -60,14 +60,14 @@ Trace the message through the pipeline, in order:
     ```bash
     ncl dropped-messages list
     ```
-    Each row aggregates drops per sender and chat, with a `reason`:
+    Each row aggregates drops per chat, with a `reason`:
 
     | Reason | Meaning | Fix |
     |---|---|---|
     | `no_agent_wired` | No wiring exists for that chat | Create one: `ncl wirings create --messaging-group-id <id> --agent-group-id <id>` |
     | `no_agent_engaged` | A wiring exists but its engage rules didn't fire | Check `engage_mode`: `mention` needs an @mention (or a DM); `pattern` matches `engage_pattern` against each message |
     | `unknown_sender_strict` | Sender not recognized, strict policy | Add the sender, or relax the policy — see [Hardening](/operate/hardening#restrict-who-can-talk-to-your-agents) |
-    | `unknown_sender_request_approval` | Sender not recognized; an approval card was sent | Approve or reject the pending card: `ncl approvals list --status pending` |
+    | `unknown_sender_request_approval` | Sender not recognized; an Allow/Deny card was sent to an approver's DM | The approver answers the card in their DM; `ncl dropped-messages list` shows the recorded drop either way |
   </Step>
   <Step title="Did a container spawn?">
     ```bash
@@ -84,11 +84,11 @@ Trace the message through the pipeline, in order:
 
 ## Container won't spawn
 
-All three of these abort the spawn and show up in `logs/nanoclaw.log`:
+The first two of these abort the spawn; a rejected mount only degrades it (the container starts without that mount). All three appear in `logs/nanoclaw.error.log`:
 
 - **`OneCLI gateway not applied — refusing to spawn container without credentials`** — the host can't wire the credential vault, so it refuses to launch the agent. The message stays pending and the sweep retries every minute; fix the gateway (is OneCLI running on `127.0.0.1:10254`?) and the spawn recovers on its own. See [Credentials](/operate/credentials).
-- **Egress lockdown errors** — with lockdown enabled, the spawn fails fast rather than run with open egress: `the "<network>" internal network could not be created` or `the OneCLI gateway "<container>" could not be attached`. Check `docker network inspect` for the egress network and see [Hardening](/operate/hardening#lock-down-network-egress).
-- **`Additional mount REJECTED`** — a mount from your group's container config failed allowlist validation. The log line includes the `requestedPath` and `reason`; the container still starts, just without that mount. Fix the allowlist — see [Hardening](/operate/hardening#gate-additional-mounts).
+- **Egress lockdown errors** — with lockdown enabled, the spawn fails fast rather than run with open egress: `the "<network>" internal network could not be created` or `the OneCLI gateway "<container>" could not be attached to "<network>"`. Check `docker network inspect` for the egress network and see [Hardening](/operate/hardening#lock-down-network-egress).
+- **`Additional mount REJECTED`** — a mount from your group's container config failed allowlist validation. The log line includes the `requestedPath` and `reason`. Fix the allowlist — see [Hardening](/operate/hardening#gate-additional-mounts).
 
 ## Replies are slow
 

--- a/operate/troubleshooting.mdx
+++ b/operate/troubleshooting.mdx
@@ -1,625 +1,142 @@
 ---
-title: Troubleshooting
-description: Troubleshooting guide for common NanoClaw issues including container errors, channel failures, and service problems
-keywords: ["troubleshooting", "debugging", "common issues"]
+title: "Troubleshooting"
+description: "Diagnose NanoClaw v2 failures: host startup stops, container spawn errors, dropped messages, silent agents, and stuck sessions."
+keywords: ["troubleshooting", "debugging", "dropped messages", "container spawn", "upgrade tripwire", "host sweep", "LOG_LEVEL"]
 tag: "UPDATED"
 ---
 
-This guide covers common issues you may encounter when running NanoClaw and how to resolve them.
+{/* verified-against: .claude/skills/debug/SKILL.md, src/container-runtime.ts, src/container-runner.ts, src/host-sweep.ts, src/upgrade-state.ts, src/log.ts, src/cli/resources/dropped-messages.ts, src/cli/resources/sessions.ts, src/egress-lockdown.ts, src/modules/mount-security/index.ts, src/webhook-server.ts, src/circuit-breaker.ts, setup/service.ts @ dc34ceb */}
 
-## Quick status check
+## Start here
 
-Run these commands to get a quick overview of system health:
+The fastest path is the built-in debug skill: open Claude Code in your NanoClaw folder and run `/debug`. It knows the two-DB session architecture, the log locations, and how to query the session databases directly.
+
+If you're diagnosing by hand, check the logs first. The service writes stdout to `logs/nanoclaw.log` and stderr (warnings and errors) to `logs/nanoclaw.error.log`:
 
 ```bash
-# 1. Is the service running?
-launchctl list | grep nanoclaw
-# Expected: PID  0  com.nanoclaw (PID = running, "-" = not running, non-zero exit = crashed)
-
-# 2. Any running containers?
-docker ps --format '{{.Names}} {{.Status}}' 2>/dev/null | grep nanoclaw
-
-# 3. Any stopped/orphaned containers?
-docker ps -a --format '{{.Names}} {{.Status}}' 2>/dev/null | grep nanoclaw
-
-# 4. Recent errors in service log?
-grep -E 'ERROR|WARN' logs/nanoclaw.log | tail -20
-
-# 5. Are channels connected? (look for last connection event)
-grep -E 'Connected|Connection closed|connection.*close' logs/nanoclaw.log | tail -5
-
-# 6. Are groups loaded?
-grep 'groupCount' logs/nanoclaw.log | tail -3
+tail -f logs/nanoclaw.log          # full routing chain: inbound, spawn/exit, delivery
+tail -n 50 logs/nanoclaw.error.log # delivery failures, crash-loop backoff, warnings
 ```
 
-## Agent not responding
+Set `LOG_LEVEL=debug` (see [Configuration](/operate/configuration#applying-changes)) to also see resolved mount configurations, the container spawn command, and streamed container stderr tagged with `container=<group folder>`. Containers run with `--rm`, so the host log is the only place container output survives.
 
-### Symptoms
-Messages sent to the agent receive no response.
+Then get the system state from the [ncl CLI](/operate/ncl-cli):
 
-### Diagnosis
+```bash
+ncl sessions list           # container_status: running | stopped
+ncl dropped-messages list   # messages the router or access gate refused
+ncl wirings list            # which chats route to which agents, and how they engage
+```
+
+## Host won't start
+
+**"NanoClaw stopped: update did not go through the supported path"** — the upgrade tripwire fired. The code version doesn't match the marker in `data/upgrade-state.json`, which usually means you ran a raw `git pull` instead of `/update-nanoclaw`. See [Upgrading](/operate/upgrading) for the recovery path.
+
+**"Circuit breaker: delaying startup due to repeated crashes"** in the log — the host crashed repeatedly and is backing off (up to 15 minutes after six consecutive crashes). It will retry on its own; find the original crash in `logs/nanoclaw.error.log` (look for `FATAL Uncaught exception`) and fix that instead of restarting in a loop.
+
+## "FATAL: Container runtime failed to start"
+
+On startup the host runs `docker info`. If it fails, NanoClaw prints this banner and exits:
+
+```text
+╔════════════════════════════════════════════════════════════════╗
+║  FATAL: Container runtime failed to start                      ║
+║                                                                ║
+║  Agents cannot run without a container runtime. To fix:        ║
+║  1. Ensure Docker is installed and running                     ║
+║  2. Run: docker info                                           ║
+║  3. Restart NanoClaw                                           ║
+╚════════════════════════════════════════════════════════════════╝
+```
+
+Do exactly what it says: start Docker (Docker Desktop on macOS, `sudo systemctl start docker` on Linux), confirm `docker info` succeeds, then restart NanoClaw.
+
+## Agent never replies
+
+Trace the message through the pipeline, in order:
 
 <Steps>
-  <Step title="Check if messages are being received">
+  <Step title="Did the router accept it?">
     ```bash
-    grep 'New messages' logs/nanoclaw.log | tail -10
+    ncl dropped-messages list
     ```
-    
-    If no messages appear, the issue is with channel connectivity.
+    Each row aggregates drops per sender and chat, with a `reason`:
+
+    | Reason | Meaning | Fix |
+    |---|---|---|
+    | `no_agent_wired` | No wiring exists for that chat | Create one: `ncl wirings create --messaging-group-id <id> --agent-group-id <id>` |
+    | `no_agent_engaged` | A wiring exists but its engage rules didn't fire | Check `engage_mode`: `mention` needs an @mention (or a DM); `pattern` matches `engage_pattern` against each message |
+    | `unknown_sender_strict` | Sender not recognized, strict policy | Add the sender, or relax the policy — see [Hardening](/operate/hardening#restrict-who-can-talk-to-your-agents) |
+    | `unknown_sender_request_approval` | Sender not recognized; an approval card was sent | Approve or reject the pending card: `ncl approvals list --status pending` |
   </Step>
-  
-  <Step title="Check if containers are being spawned">
+  <Step title="Did a container spawn?">
     ```bash
-    grep -E 'Processing messages|Spawning container' logs/nanoclaw.log | tail -10
+    ncl sessions list                      # container_status should be "running"
+    grep 'Spawning container' logs/nanoclaw.log | tail -5
+    docker ps --format '{{.Names}} {{.Status}}' | grep nanoclaw
     ```
-    
-    If messages are received but no containers spawn, check trigger patterns.
+    `stopped` is normal between messages — the sweep restarts the container when due messages arrive. If nothing spawns at all, see [Container won't spawn](#container-wont-spawn) below.
   </Step>
-  
-  <Step title="Check for active containers">
-    ```bash
-    docker ps --filter name=nanoclaw-
-    ```
-    
-    If containers are stuck running, they may have hit an infinite loop.
-  </Step>
-  
-  <Step title="Check container logs">
-    ```bash
-    docker logs nanoclaw-{group}-{timestamp}
-    ```
-    
-    Look for errors in the agent execution.
+  <Step title="Did the agent produce a reply?">
+    Inspect the session DBs (`inbound.db` / `outbound.db` under `data/v2-sessions/<group>/<session>/`). The `/debug` skill walks you through the exact queries. A `Container exited` line with a non-zero `code` in the host log, plus the streamed stderr above it, is where the failure usually shows.
   </Step>
 </Steps>
 
-### Solutions
+## Container won't spawn
 
-<Accordion title="Trigger word not matching">
-  Verify the trigger word in your message matches the configured trigger:
-  
-  ```bash
-  sqlite3 store/messages.db "SELECT name, trigger_pattern FROM registered_groups;"
-  ```
-  
-  The trigger is case-insensitive and must appear at the start of the message.
-</Accordion>
+All three of these abort the spawn and show up in `logs/nanoclaw.log`:
 
-<Accordion title="Container runtime not available">
-  Ensure Docker is running:
-  
-  ```bash
-  docker info
-  ```
-  
-  If Docker is not running, start it:
-  - macOS: Open Docker Desktop
-  - Linux: `sudo systemctl start docker`
-</Accordion>
+- **`OneCLI gateway not applied — refusing to spawn container without credentials`** — the host can't wire the credential vault, so it refuses to launch the agent. The message stays pending and the sweep retries every minute; fix the gateway (is OneCLI running on `127.0.0.1:10254`?) and the spawn recovers on its own. See [Credentials](/operate/credentials).
+- **Egress lockdown errors** — with lockdown enabled, the spawn fails fast rather than run with open egress: `the "<network>" internal network could not be created` or `the OneCLI gateway "<container>" could not be attached`. Check `docker network inspect` for the egress network and see [Hardening](/operate/hardening#lock-down-network-egress).
+- **`Additional mount REJECTED`** — a mount from your group's container config failed allowlist validation. The log line includes the `requestedPath` and `reason`; the container still starts, just without that mount. Fix the allowlist — see [Hardening](/operate/hardening#gate-additional-mounts).
 
-<Accordion title="Queue at concurrency limit">
-  Check if the queue is blocked:
-  
-  ```bash
-  grep 'concurrency limit' logs/nanoclaw.log | tail -5
-  ```
-  
-  Stop stuck containers:
-  
-  ```bash
-  docker stop -t 1 $(docker ps -q --filter name=nanoclaw-)
-  ```
-</Accordion>
+## Replies are slow
 
-## Container timeout
+- **Cold start**: the first reply after a container spawn takes 30–60 seconds while the sandbox warms up. Setup tells you this during its ping test; it's normal.
+- **Scheduled or retried messages wait for the sweep**: the host sweep runs every 60 seconds, so a due message for a stopped container can sit up to a minute before the wake fires (`Waking container for due messages` in the log).
+- **Retries back off**: a message reset after a crash retries with exponential backoff (5s, 10s, 20s, ...). After five tries you'll see `Message marked as failed after max retries` — that message is dead; resend it.
 
-### Symptoms
-- Logs show `Container timeout` or `timed out`
-- Exit code 137 (SIGKILL) in container logs
-- Messages are lost after timeout
+## Container killed mid-task
 
-### Diagnosis
+The host sweep kills containers it considers stuck, then resets their in-flight messages to pending:
+
+- **`Killing container past absolute ceiling`** — the container's heartbeat file went silent for over 30 minutes. The ceiling stretches automatically when the agent declares a longer Bash timeout, so long-running commands aren't killed as long as they declare their timeout.
+- **`Killing container — message claimed then silent`** — the container claimed a message and showed no sign of life for over 60 seconds since the claim (also extended by a declared Bash timeout).
+
+Both paths are self-healing: `Reset stale message with backoff` follows in the log and the work retries in a fresh container. If the same message keeps killing containers, look at the streamed container stderr (`LOG_LEVEL=debug`) to see what the agent was doing when it died.
+
+## Webhook channel is silent
+
+Webhook-based adapters (Slack, Teams, and similar) register routes on a shared local HTTP server. Confirm it's up and routed:
 
 ```bash
-# Check for recent timeouts
-grep -E 'Container timeout|timed out' logs/nanoclaw.log | tail -10
-
-# Check container log files
-ls -lt groups/*/logs/container-*.log | head -10
-
-# Read the most recent container log
-cat groups/{group}/logs/container-{timestamp}.log
+grep 'Webhook server started' logs/nanoclaw.log   # shows port + registered adapters
+curl -i http://localhost:3000/webhook/slack       # 404 "Unknown adapter" = not registered
 ```
 
-### Solutions
+The server listens on `WEBHOOK_PORT` (default `3000`). If another process already holds that port, the listen fails and the host crashes with `FATAL Uncaught exception` — change `WEBHOOK_PORT` in `.env`. Channel-specific failures (tokens, tunnel/public URL, platform-side config) are covered on each channel page: [Slack](/channels/slack), [Teams](/channels/teams), [Channels overview](/channels/overview).
 
-<Accordion title="Increase timeout for specific group">
-  Modify the group's `containerConfig` in the database:
-  
-  ```bash
-  sqlite3 store/messages.db
-  ```
-  
-  ```sql
-  UPDATE registered_groups 
-  SET container_config = json_set(
-    COALESCE(container_config, '{}'),
-    '$.timeout',
-    3600000  -- 1 hour in milliseconds
-  )
-  WHERE name = 'Family Chat';
-  ```
-</Accordion>
+## Credential request stuck
 
-<Accordion title="Check for infinite loops">
-  Review the container log to see if the agent is stuck:
-  
-  ```bash
-  cat groups/{group}/logs/container-{timestamp}.log
-  ```
-  
-  Look for repeated patterns or lack of progress. If the agent is stuck, consider:
-  - Simplifying the prompt
-  - Adding constraints to the task
-  - Reviewing recent changes to `CLAUDE.md`
-</Accordion>
-
-<Accordion title="Adjust idle timeout">
-  The idle timeout (for graceful shutdown between messages) is currently equal to the hard timeout. This is a known issue. To fix:
-  
-  Edit `src/config.ts` and set:
-  ```typescript
-  export const IDLE_TIMEOUT = 5 * 60 * 1000; // 5 minutes
-  export const CONTAINER_TIMEOUT = 30 * 60 * 1000; // 30 minutes
-  ```
-  
-  Then rebuild:
-  ```bash
-  npm run build && launchctl kickstart -k gui/$(id -u)/com.nanoclaw
-  ```
-</Accordion>
-
-## Service stops after SSH logout (Linux)
-
-### Symptoms
-- NanoClaw works while SSH is connected but stops silently after disconnecting
-- `systemctl --user status nanoclaw` shows inactive after reconnecting
-- No error logs or crash — the service simply disappears
-- `systemctl --user enable nanoclaw` appears to succeed but the service still stops
-
-### Cause
-
-By default, systemd sets `Linger=no` for users. When your last SSH session closes, systemd terminates all user-level processes — including the NanoClaw service. This is especially common on cloud VMs (EC2, GCP, Oracle Cloud).
-
-### Solution
-
-The setup script automatically enables linger for non-root users. If you're still experiencing this issue (e.g., you set up NanoClaw before this fix), run:
+If an agent's API call hangs and then fails, a credential approval card may be waiting. The gateway holds the request open until an admin taps Approve or Reject; with no eligible approver it auto-denies, and unanswered cards expire. Check what's pending:
 
 ```bash
-loginctl enable-linger
+ncl approvals list --status pending
 ```
 
-Verify it's enabled:
+The full approval flow — who gets the card, expiry, what happens after a host restart — is in [Credentials](/operate/credentials#approving-credential-use).
+
+## Resetting a session
+
+To wipe a misbehaving session's conversation state, remove its folder — the host re-provisions both session DBs on the next message:
 
 ```bash
-loginctl show-user $USER | grep Linger
-# Expected: Linger=yes
-```
-
-<Note>
-  If `loginctl enable-linger` fails with a permission error, your system may require polkit authorization. Contact your system administrator or run the command with `sudo`.
-</Note>
-
-## Known issues
-
-### Cursor rollback on error
-
-The message cursor (`lastAgentTimestamp`) is now rolled back on container errors, provided no output was already sent to the user. If the agent fails after sending partial output, the cursor is not rolled back to prevent duplicate messages.
-
-If you need to manually reset the cursor, update it in `router_state`:
-
-```sql
--- The cursor is stored as a JSON object mapping JIDs to timestamps
-SELECT value FROM router_state WHERE key = 'last_agent_timestamp';
-```
-
-### IDLE_TIMEOUT and CONTAINER_TIMEOUT
-
-The hard timeout is calculated as `Math.max(configTimeout, IDLE_TIMEOUT + 30_000)`, ensuring a 30-second gap for graceful `_close` sentinel shutdown before the hard kill fires. With default settings (both 30 minutes), the hard timeout is 30 minutes 30 seconds.
-
-If containers are consistently hitting the hard timeout, consider lowering `IDLE_TIMEOUT` in `src/config.ts` to a shorter value (e.g., 5 minutes) so idle containers exit more promptly.
-
-### Kubernetes image garbage collection deletes nanoclaw-agent image
-
-**Symptoms:** `Container exited with code 125: pull access denied for nanoclaw-agent` — the container image disappears after a few hours, even though you just built it.
-
-**Cause:** If your container runtime has Kubernetes enabled (Rancher Desktop enables it by default), the kubelet runs image garbage collection when disk usage exceeds 85%. NanoClaw containers are ephemeral (run and exit), so `nanoclaw-agent:latest` is never protected by a running container. The kubelet sees it as unused and deletes it — often overnight when no messages are being processed.
-
-**Fix:** Disable Kubernetes if you don't need it:
-
-```bash
-# Rancher Desktop
-rdctl set --kubernetes-enabled=false
-
-# Then rebuild the container image
-./container/build.sh
-```
-
-**Diagnosis:**
-
-```bash
-# Check k3s log for image GC activity (Rancher Desktop)
-grep -i "nanoclaw" ~/Library/Logs/rancher-desktop/k3s.log
-# Look for: "Removing image to free bytes" with the nanoclaw-agent image ID
-
-# Check NanoClaw logs for image status
-grep -E "image found|image NOT found|image missing" logs/nanoclaw.log
-```
-
-If you need Kubernetes enabled, set `CONTAINER_IMAGE` to an image stored in a registry that the kubelet won't garbage-collect, or raise the kubelet's GC thresholds.
-
-### Resume branches from stale tree position
-
-**Issue:** When agent teams spawns subagent CLI processes, they write to the same session JSONL. On subsequent `query()` resumes, the CLI reads the JSONL but may pick a stale branch tip, causing responses to land on a branch the host never receives.
-
-**Fix:** Already fixed. The agent runner now passes `resumeSessionAt` with the last assistant message UUID to explicitly anchor each resume.
-
-## Container 401 errors
-
-### Symptoms
-- Container logs show `401 Unauthorized` or `authentication_error` on API calls
-- Agent starts but fails immediately when trying to respond
-- Errors recur every few hours even after restarting
-
-### Cause
-
-Short-lived OAuth tokens copied from the system keychain or `~/.claude/.credentials.json` expire within hours. These tokens share the same `sk-ant-oat01-` prefix as long-lived tokens, so the mistake isn't obvious. When they expire, every container launch fails with a 401.
-
-### Solution
-
-<Tabs>
-  <Tab title="OneCLI Agent Vault (v1.2.35+)">
-    Update the secret registered with OneCLI:
-
-    ```bash
-    # Replace with a long-lived OAuth token or API key
-    onecli secrets create --name Anthropic --type anthropic --value YOUR_KEY --host-pattern api.anthropic.com
-    ```
-
-    You can also use a long-lived OAuth token from `claude setup-token`:
-    ```bash
-    onecli secrets create --name Claude --type oauth --value YOUR_TOKEN --host-pattern api.anthropic.com
-    ```
-  </Tab>
-
-  <Tab title="Credential Proxy (legacy)">
-    Use one of these credential types in `.env`:
-
-    - **Long-lived OAuth token**: Run `claude setup-token` and add the resulting `CLAUDE_CODE_OAUTH_TOKEN` to `.env`
-    - **API key**: Get a key from [console.anthropic.com](https://console.anthropic.com) and add `ANTHROPIC_API_KEY` to `.env`
-  </Tab>
-</Tabs>
-
-After updating credentials, restart the service:
-
-<CodeGroup>
-```bash macOS
-launchctl kickstart -k gui/$(id -u)/com.nanoclaw
-```
-
-```bash Linux
-systemctl --user restart nanoclaw
-```
-</CodeGroup>
-
-<Warning>
-Never copy tokens from `~/.claude/.credentials.json` into `.env`. These are short-lived keychain tokens that expire within hours. Use `claude setup-token` to generate a long-lived token instead.
-</Warning>
-
-## WhatsApp authentication issues
-
-### Symptoms
-- Logs show "QR" or "authentication required"
-- No messages are being received
-- Connection repeatedly drops
-
-### Diagnosis
-
-```bash
-# Check for QR code requests
-grep 'QR\|authentication required\|qr' logs/nanoclaw.log | tail -5
-
-# Check auth files exist
-ls -la store/auth/
-```
-
-### Solution
-
-Re-authenticate with WhatsApp:
-
-```bash
-claude
-/add-whatsapp
-```
-
-Scan the QR code with your phone, then restart the service:
-
-<CodeGroup>
-```bash macOS
-launchctl kickstart -k gui/$(id -u)/com.nanoclaw
-```
-
-```bash Linux
-systemctl --user restart nanoclaw
-```
-</CodeGroup>
-
-## Container mount issues
-
-### Symptoms
-- Agent cannot access expected files or directories
-- Logs show "Mount validated" or "Mount REJECTED"
-- Permission errors in container logs
-
-### Diagnosis
-
-```bash
-# Check mount validation logs
-grep -E 'Mount validated|Mount.*REJECTED|mount' logs/nanoclaw.log | tail -10
-
-# Verify the mount allowlist is readable
-cat ~/.config/nanoclaw/mount-allowlist.json
-
-# Check group's container_config in DB
-sqlite3 store/messages.db "SELECT name, container_config FROM registered_groups;"
-```
-
-### Solutions
-
-<Accordion title="Add path to mount allowlist">
-  Edit `~/.config/nanoclaw/mount-allowlist.json`:
-  
-  ```json
-  {
-    "allowedRoots": [
-      {
-        "path": "/Users/you/Documents/project",
-        "allowReadWrite": true,
-        "description": "Project files"
-      }
-    ],
-    "blockedPatterns": [".ssh", ".gnupg", ".aws", ".env", "credentials"],
-    "nonMainReadOnly": true
-  }
-  ```
-  
-  Then restart the service. If the mount allowlist file did not exist at startup, NanoClaw will detect it once created without requiring a restart.
-</Accordion>
-
-<Accordion title="Reset mount allowlist to defaults">
-  If you need to regenerate the default mount allowlist (for example, after a misconfiguration), re-run setup with the `--force` flag:
-
-  ```bash
-  claude /setup --force
-  ```
-
-  Without `--force`, setup skips the mount allowlist if it already exists to preserve your customizations.
-</Accordion>
-
-<Accordion title="Check for symlinks">
-  The mount security system resolves symlinks before validation. If you're mounting a symlink, ensure the resolved path is in the allowlist:
-  
-  ```bash
-  readlink -f /path/to/symlink
-  ```
-</Accordion>
-
-<Accordion title="Verify file permissions">
-  Containers run as the host user (or uid 1000 on some systems). Ensure the host user can read the mounted directories:
-  
-  ```bash
-  ls -la /path/to/mount
-  ```
-</Accordion>
-
-<Accordion title="Test mount manually">
-  Run a test container to verify mounts:
-  
-  ```bash
-  docker run -i --rm \
-    -v /path/to/host:/workspace/test:ro \
-    nanoclaw-agent:latest \
-    ls -la /workspace/test
-  ```
-</Accordion>
-
-## IPC issues
-
-### Symptoms
-- Messages sent via IPC don't appear in the chat
-- Tasks don't get scheduled
-- IPC files accumulate in `data/ipc/{group}/`
-
-### Diagnosis
-
-```bash
-# Check for failed IPC operations
-ls -la data/ipc/errors/
-cat data/ipc/errors/main-message-*.json
-
-# Monitor IPC activity
-grep 'IPC' logs/nanoclaw.log | tail -20
-
-# Verify IPC directory permissions
-ls -la data/ipc/main/
-ls -la data/ipc/family-chat/
-```
-
-### Solutions
-
-<Accordion title="Check IPC authorization">
-  Non-main groups can only send messages to their own chat. Verify the `chatJid` in the IPC file matches the group's registered JID:
-  
-  ```bash
-  sqlite3 store/messages.db "SELECT jid, name, folder FROM registered_groups;"
-  ```
-</Accordion>
-
-<Accordion title="Verify JSON format">
-  IPC files must be valid JSON. Check for syntax errors:
-  
-  ```bash
-  cat data/ipc/errors/{group}-message-*.json | jq .
-  ```
-</Accordion>
-
-<Accordion title="Test IPC manually">
-  Write a test message:
-  
-  ```bash
-  echo '{"type":"message","chatJid":"me","text":"test"}' > \
-    data/ipc/main/messages/test.json
-  
-  # Watch logs for processing
-  tail -f logs/nanoclaw.log | grep IPC
-  ```
-</Accordion>
-
-## Session artifact auto-pruning
-
-NanoClaw automatically cleans up stale session artifacts on startup and then every 24 hours. This prevents disk usage from growing unbounded as sessions accumulate.
-
-**Retention policy:**
-
-| Artifact | Retention | Notes |
-|----------|-----------|-------|
-| Session JSONLs and tool results | 7 days | Active sessions (from DB) are never deleted |
-| Debug logs | 3 days | Active sessions skipped |
-| Todo files | 3 days | Active sessions skipped |
-| Telemetry | 7 days | Active sessions skipped |
-| Group logs | 7 days | — |
-
-The cleanup script reads active session IDs from SQLite and never deletes files belonging to active sessions. It runs 30 seconds after startup to avoid competing with initialization, then repeats on a 24-hour interval.
-
-You can run the cleanup manually with `--dry-run` to preview what would be deleted:
-
-```bash
-bash scripts/cleanup-sessions.sh --dry-run
-```
-
-## Stale session auto-recovery
-
-NanoClaw automatically detects and recovers from stale or corrupt sessions. When a container fails because the session transcript file (`.jsonl`) is missing — due to a crash mid-write, manual deletion, or disk-full condition — NanoClaw clears the broken session ID and lets the existing backoff mechanism in the group queue retry with a fresh session.
-
-Stale sessions are detected by matching the error output against known patterns (`no conversation found`, `ENOENT` on `.jsonl` files, or `session not found`). Only these specific signals trigger session clearing — transient errors (network, API) fall through to the normal retry path.
-
-You can identify stale session recovery in logs by looking for:
-
-```
-Stale session detected — clearing for next retry
-```
-
-No manual intervention is required.
-
-### Manual recovery
-
-If auto-recovery doesn't trigger (e.g., the error message doesn't match the expected patterns), you can manually clear a stale session:
-
-```bash
-sqlite3 store/messages.db "DELETE FROM sessions WHERE group_folder = '{group-folder}';"
-```
-
-Then restart the service or wait for the next retry.
-
-## Session branching issues
-
-### Symptoms
-- Agent responses don't appear in the conversation
-- Session transcript shows multiple branches
-- Concurrent CLI processes in session debug logs
-
-### Diagnosis
-
-```bash
-# Check for concurrent CLI processes
-ls -la data/sessions/{group}/.claude/debug/
-
-# Count unique SDK processes (each .txt file = one CLI subprocess)
-# Multiple files = concurrent queries
-
-# Check parentUuid branching in transcript
-python3 -c "
-import json, sys
-lines = open('data/sessions/{group}/.claude/projects/-workspace-group/{session}.jsonl').read().strip().split('\n')
-for i, line in enumerate(lines):
-  try:
-    d = json.loads(line)
-    if d.get('type') == 'user' and d.get('message'):
-      parent = d.get('parentUuid', 'ROOT')[:8]
-      content = str(d['message'].get('content', ''))[:60]
-      print(f'L{i+1} parent={parent} {content}')
-  except: pass
-"
-```
-
-### Solution
-
-This issue was fixed by passing `resumeSessionAt` with the last assistant message UUID. If you're still experiencing it, ensure you're running the latest version of the agent runner.
-
-## Service management
-
-### Restart the service
-
-```bash
-launchctl kickstart -k gui/$(id -u)/com.nanoclaw
-```
-
-### View live logs
-
-```bash
-tail -f logs/nanoclaw.log
-```
-
-### Stop the service
-
-<Warning>
-Stopping the service does NOT kill running containers. They will continue running as orphaned processes.
-</Warning>
-
-```bash
-launchctl bootout gui/$(id -u)/com.nanoclaw
-```
-
-### Start the service
-
-```bash
-launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.nanoclaw.plist
-```
-
-### Rebuild after code changes
-
-```bash
-npm run build && launchctl kickstart -k gui/$(id -u)/com.nanoclaw
+ncl sessions list                              # find the session and its agent group
+rm -rf data/v2-sessions/<group>/<session>/
 ```
 
 ## Getting help
 
-If you're still experiencing issues:
-
-1. **Ask Claude Code directly:** Run `claude` and describe the problem. Claude can read logs, check database state, and diagnose issues.
-
-2. **Run the debug skill:** `claude` → `/debug` for guided troubleshooting.
-
-3. **Check the Discord:** [Join the community](https://discord.gg/VDdww8qS42) for help from other users.
-
-4. **Review recent changes:** If the issue started after a customization, review what changed:
-   ```bash
-   git diff
-   git log --oneline -10
-   ```
-
-## Related pages
-
-- [Security model](/concepts/security) - Authorization and isolation
-- [IPC system](/concepts/architecture) - Inter-process communication
-- [Container runtime](/concepts/container-lifecycle) - Container execution details
+- Run `/debug` in Claude Code — it can read the logs and query the session DBs for you.
+- [Join the Discord](https://discord.gg/VDdww8qS42) for help from other users.
+- [Open an issue](https://github.com/nanocoai/nanoclaw/issues) if you've found a bug.

--- a/operate/upgrading.mdx
+++ b/operate/upgrading.mdx
@@ -1,0 +1,71 @@
+---
+title: "Upgrading"
+description: "Update NanoClaw and its skills with /update-nanoclaw and /update-skills — preview, backup, merge, validate, and restart."
+tag: "NEW"
+keywords: ["upgrade", "update", "update-nanoclaw", "update-skills", "migrate-nanoclaw", "upstream", "merge", "rollback"]
+---
+
+{/* verified-against: .claude/skills/update-nanoclaw/SKILL.md, .claude/skills/update-skills/SKILL.md, .claude/skills/migrate-nanoclaw/SKILL.md, scripts/upgrade-state.ts, src/upgrade-state.ts @ dc34ceb */}
+
+Don't update with a raw `git pull`. NanoClaw records each sanctioned upgrade in `data/upgrade-state.json`, and a startup tripwire refuses to boot if the running code's version doesn't match that marker. The supported path is the `/update-nanoclaw` skill, which handles the merge, validation, and the marker stamp for you.
+
+## Updating NanoClaw
+
+Run `/update-nanoclaw` in a Claude Code session at your project root. The skill works in stages, and nothing is committed until you've seen a preview:
+
+1. **Self-refresh.** It fetches upstream and refreshes its own skill folder first, so the newest update process runs the update.
+2. **Preflight.** Stops if the working tree is dirty — commit or stash first. Adds the `upstream` remote if it's missing.
+3. **Safety net.** Creates a backup branch and tag (`backup/pre-update-<hash>-<timestamp>`) before touching anything.
+4. **Preview.** Shows upstream commits since your last sync and buckets the changed files: skills, host source (`src/`), container (`container/`, triggers a rebuild), and build config (lockfile changes trigger a dependency install). You then pick a path: full merge (default), selective cherry-pick, rebase, or abort.
+5. **Conflict preview.** Dry-runs the merge (`git merge --no-commit --no-ff`, then abort) so you see which files would conflict before committing to anything.
+6. **Merge and resolve.** Applies your chosen path. On conflicts it opens only the conflicted files, resolves the markers, and keeps your local customizations intact.
+7. **Validation.** Runs `pnpm run build` and `pnpm test`. If `container/` files changed, it also rebuilds the container image with `./container/build.sh`.
+8. **Breaking changes.** Scans the new `CHANGELOG.md` entries for `[BREAKING]` lines and offers to run each referenced migration skill.
+9. **Marker stamp.** On success, stamps the upgrade marker (`pnpm exec tsx scripts/upgrade-state.ts set "" update-nanoclaw`) so the tripwire passes on next start.
+10. **Summary.** Prints the backup tag, conflicts resolved, and the restart command for your platform.
+
+To roll back, reset to the backup tag the skill printed:
+
+```bash
+git reset --hard pre-update-<hash>-<timestamp>
+```
+
+## What happens to installed channels
+
+Channel and provider adapters are files copied into your tree from the long-lived `channels` and `providers` branches — they aren't part of the `main` merge, so the update itself doesn't refresh them. Instead, after the merge, `/update-nanoclaw` detects which channels and providers you have wired into the barrels (`src/channels/index.ts`, `src/providers/index.ts`) and offers to re-run each one's `/add-<name>` skill.
+
+Re-applying is safe and idempotent: it re-fetches the latest adapter files from upstream and overwrites only that skill's own code. Credentials in `.env`, barrel wiring, and database state are untouched. The flip side: if you edited an adapter file directly, re-applying overwrites your edits — commit first so the changes are recoverable, or skip that channel and update it manually.
+
+## Updating skills
+
+To refresh skills without a full upstream update, run `/update-skills`. Its flow:
+
+1. **Preflight.** Clean working tree, upstream remote confirmed, then `git fetch origin channels providers --prune`.
+2. **Detection.** Reads the channel and provider barrels to list which code-carrying skills are installed. Operational skills (ones that copy no code into the tree) have nothing to refresh.
+3. **Selection.** You pick which skills to re-apply.
+4. **Re-apply.** Invokes each selected skill's own `/add-<name>` apply, which fetches the latest files and overwrites the copied-in code.
+5. **Validation.** `pnpm run build` and `pnpm test` — each channel skill ships a registration test that asserts the barrel still registers the adapter.
+
+Restart the service afterwards to pick up the refreshed code.
+
+## Heavily customized forks
+
+If you've diverged far from upstream — many local commits, deep changes to core files — merging gets painful. `/migrate-nanoclaw` takes a different approach: it extracts your customizations into a replayable guide, checks out clean upstream in a worktree, and reapplies them on the new base, so there's nothing to merge. `/update-nanoclaw` suggests it automatically when it detects large drift. See the note in [Migrate from v1 or OpenClaw](/migrate-from-v1) for how it differs from the v1 migration path.
+
+## When not to update
+
+- **Dirty working tree** — the skill stops; commit or stash first. The same applies before `/update-skills`.
+- **Locally modified adapters or upstream skills** — re-applying a channel skill overwrites its files; make sure your edits are committed so you can recover them.
+- **Just want to see what changed** — pick the abort option in the preview step. It shows the changelog and changes nothing.
+- **Large drift** — prefer `/migrate-nanoclaw` over a conflict-heavy merge.
+
+## After an upgrade
+
+The skill validates the build and tests itself, but a few things are worth checking by hand:
+
+- **Restart the service.** Unit and label names are per-install; the skill prints the exact command (derived from `setup/lib/install-slug.sh`) for macOS, Linux, or a manual `pnpm run dev`.
+- **Container rebuild.** If `container/` changed, the image was rebuilt — running agent containers keep the old image until their session ends; new sessions use the new one.
+- **Send a test message** on each channel you use, and check `logs/nanoclaw.log` for errors.
+- **Tripwire trips on start?** The marker wasn't stamped (validation failed, or the update bypassed the skill). Fix the underlying issue, then stamp manually: `pnpm exec tsx scripts/upgrade-state.ts set`.
+
+If something is off, start with [Troubleshooting](/operate/troubleshooting).

--- a/operate/upgrading.mdx
+++ b/operate/upgrading.mdx
@@ -15,7 +15,7 @@ Run `/update-nanoclaw` in a Claude Code session at your project root. The skill 
 
 1. **Self-refresh.** It fetches upstream and refreshes its own skill folder first, so the newest update process runs the update.
 2. **Preflight.** Stops if the working tree is dirty — commit or stash first. Adds the `upstream` remote if it's missing.
-3. **Safety net.** Creates a backup branch and tag (`backup/pre-update-<hash>-<timestamp>`) before touching anything.
+3. **Safety net.** Creates a backup branch (`backup/pre-update-<hash>-<timestamp>`) and tag (`pre-update-<hash>-<timestamp>`) before touching anything.
 4. **Preview.** Shows upstream commits since your last sync and buckets the changed files: skills, host source (`src/`), container (`container/`, triggers a rebuild), and build config (lockfile changes trigger a dependency install). You then pick a path: full merge (default), selective cherry-pick, rebase, or abort.
 5. **Conflict preview.** Dry-runs the merge (`git merge --no-commit --no-ff`, then abort) so you see which files would conflict before committing to anything.
 6. **Merge and resolve.** Applies your chosen path. On conflicts it opens only the conflicted files, resolves the markers, and keeps your local customizations intact.
@@ -44,7 +44,7 @@ To refresh skills without a full upstream update, run `/update-skills`. Its flow
 2. **Detection.** Reads the channel and provider barrels to list which code-carrying skills are installed. Operational skills (ones that copy no code into the tree) have nothing to refresh.
 3. **Selection.** You pick which skills to re-apply.
 4. **Re-apply.** Invokes each selected skill's own `/add-<name>` apply, which fetches the latest files and overwrites the copied-in code.
-5. **Validation.** `pnpm run build` and `pnpm test` — each channel skill ships a registration test that asserts the barrel still registers the adapter.
+5. **Validation.** `pnpm run build` and `pnpm test` — each channel and provider skill ships a registration test that asserts the barrel still registers the adapter.
 
 Restart the service afterwards to pick up the refreshed code.
 


### PR DESCRIPTION
PR 4 of 9 (spec: docs/superpowers/specs/2026-06-10-docs-portal-v2-refactor-design.md). All pages verified against nanocoai/nanoclaw@dc34ceb (v2.1.4); every page carries a verified-against comment.

## Pages
- **operate/configuration** (NEW): the two config layers — and the load-bearing discovery that only 5 vars are read from .env; the rest are process-env-only and the service launchers don't load .env (tables split by source, with real instructions for each)
- **operate/ncl-cli** (rewritten): the actual 11-resource command surface from src/cli/, cli_scope semantics, approval gating. Examples use --id (positional UUIDs hit a dispatch parsing limitation)
- **operate/credentials** (NEW): Agent Vault mechanics (HTTPS_PROXY interception, stub credentials, in-flight injection), three Anthropic auth paths, approval cards, remote OneCLI, /use-native-credential-proxy
- **operate/hardening** (rewritten, replaces docker-sandboxes seed): egress lockdown (previously undocumented), mount allowlist validation rules, sender policies, command gate. v1 micro-VM content dropped — zero code presence
- **operate/upgrading** (NEW): the real /update-nanoclaw staged flow incl. the upgrade-state tripwire that refuses to boot after raw git pull; adapter re-application; /update-skills
- **operate/troubleshooting** (rewritten): symptom-organized, every error string verbatim from source, the four real drop reasons, kill-condition timings

## Upstream findings (documented honestly, candidates for upstream issues)
- MAX_CONCURRENT_CONTAINERS is parsed but enforced nowhere — marked as no-effect
- manage-mounts SKILL.md ships a readOnly key the validator ignores (we document allowReadWrite)
- scripts/cleanup-sessions.sh still reads v1 paths — omitted from troubleshooting
- debug SKILL.md claims spawn-command logging that doesn't exist

Validation: mint validate ✅ · mint broken-links ✅