### PR TITLE
docs: rewrite Extend group — skills model, tools, providers, self-mod, authoring

### DIFF
--- a/channels/overview.mdx
+++ b/channels/overview.mdx
@@ -38,7 +38,7 @@ Each install skill follows the same pattern (see `/add-telegram` for the canonic
 1. **Fetch the `channels` branch** — `git fetch origin channels`
 2. **Copy the adapter** — `git show origin/channels:src/channels/<name>.ts > src/channels/<name>.ts`, along with its tests, helpers, and any setup steps
 3. **Wire the barrel** — append `import './<name>.js';` to `src/channels/index.ts` so the adapter self-registers at startup
-4. **Install the platform package, pinned** — e.g. `pnpm install @chat-adapter/telegram@4.27.0`
+4. **Install the platform package, pinned** — e.g. `pnpm install @chat-adapter/telegram@<exact-version>` (each skill pins its own version)
 5. **Build and validate** — `pnpm run build` plus the channel's registration test, which asserts the adapter actually lands in the registry
 6. **Collect credentials** — bot tokens, QR pairing, linked devices, whatever the platform needs, into `.env`
 

--- a/docs.json
+++ b/docs.json
@@ -98,9 +98,9 @@
     { "source": "/api/message-routing", "destination": "/reference/adapter-interface" },
     { "source": "/api/group-management", "destination": "/reference/ncl-cli" },
     { "source": "/api/task-scheduling", "destination": "/reference/mcp-tools" },
-    { "source": "/api/skills/creating-skills", "destination": "/extend/overview" },
-    { "source": "/api/skills/skill-structure", "destination": "/extend/overview" },
-    { "source": "/api/skills/examples", "destination": "/extend/overview" }
+    { "source": "/api/skills/creating-skills", "destination": "/extend/writing-skills" },
+    { "source": "/api/skills/skill-structure", "destination": "/extend/writing-skills" },
+    { "source": "/api/skills/examples", "destination": "/extend/writing-skills" }
   ],
   "search": {
     "prompt": "Search NanoClaw docs..."
@@ -154,7 +154,7 @@
           {
             "group": "Extend",
             "icon": "puzzle-piece",
-            "pages": ["extend/overview", "extend/tools", "extend/providers"]
+            "pages": ["extend/overview", "extend/tools", "extend/providers", "extend/self-modification", "extend/writing-skills"]
           },
           {
             "group": "Understand",

--- a/extend/overview.mdx
+++ b/extend/overview.mdx
@@ -1,364 +1,90 @@
 ---
-title: Skills system
-description: How NanoClaw uses git branches and a plugin marketplace to add integrations without bloating the codebase
+title: "Skills: how NanoClaw extends itself"
+description: "What a NanoClaw skill is in v2 — SKILL.md workflows that Claude Code executes in your checkout, fetching code additively from registry branches. Never a git merge."
 tag: "UPDATED"
-keywords: ["skills", "git branches", "plugins", "marketplace"]
+keywords: ["skills", "extend", "SKILL.md", "registry branches", "channels branch", "providers branch", "REMOVE.md", "container skills", "additive fetch"]
 ---
 
-<Warning>
-This page describes the v1 skill model (one `skill/*` branch per feature, merged into your fork). v2 consolidated channel adapters onto a single `channels` branch and alternative providers onto a `providers` branch — `/add-<name>` skills now copy from the relevant branch rather than merging a dedicated skill branch. A v2-focused rewrite is pending. See [Integrations overview](/channels/overview) for the current model.
-</Warning>
+{/* verified-against: CONTRIBUTING.md, docs/skills-model.md, .claude/skills/{add-telegram,add-codex,add-gmail-tool,manage-mounts}/SKILL.md, .claude/skills/{add-telegram,add-gmail-tool}/REMOVE.md, container/skills/, src/container-runner.ts @ dc34ceb (v2.1.4) */}
 
-NanoClaw's skills system lets you add integrations and features by merging git branches into your fork. This keeps the base codebase minimal while enabling powerful customization — all using standard git operations.
+A NanoClaw skill is a **SKILL.md instruction workflow** in `.claude/skills/` that Claude Code executes in your checkout. When you run `/add-telegram` or `/manage-mounts`, Claude reads the skill's instructions and performs them — copying files, appending an import, installing a dependency, running a test. There is no plugin engine, no manifest.yaml, and no skill state file. The skill *is* the markdown.
 
-## Philosophy: Skills over features
+<Note>
+This URL previously documented a different model: skills as `skill/*` git branches that you merged into your fork and removed with `git revert`. That model was designed for v1 and **never shipped in v2** — no `skill/*` branches exist on the repo, and no skill performs a `git merge`. If a skill's instructions say `git merge`, it isn't built for v2. This page describes how skills actually work as of v2.1.4.
+</Note>
 
-From the NanoClaw README:
+This is how the trunk stays small: it ships channel and provider *infrastructure* but no specific adapters. Your fork only ever contains the code for the features you installed — the rest stays out of your context window and your upgrade path.
 
-> **Skills over features.** Instead of adding features (e.g. support for Telegram) to the codebase, contributors submit claude code skills like `/add-telegram` that transform your fork. You end up with clean code that does exactly what you need.
+## How a code-carrying skill installs
 
-This approach means:
-
-- The base NanoClaw codebase stays in one head (~127k tokens at v2.0.0 — still fits Claude's context window for repo-wide reasoning)
-- Each installation is customized to your exact needs
-- No configuration sprawl or unused features
-- The code remains understandable and modifiable
-
-## How skills work
-
-Skills are distributed as **git branches** on the upstream repository. Applying a skill is a `git merge`. Updating core is a `git merge`. Everything is standard git.
-
-### Repository structure
-
-The upstream repo (`nanocoai/nanoclaw`) maintains skill branches for features that extend core functionality:
-
-| Branch | Description |
-|--------|-------------|
-| `main` | Core NanoClaw — no channel or skill code |
-| `skill/ollama-tool` | Ollama MCP server for local models |
-| `skill/compact` | `/compact` session command |
-| `skill/channel-formatting` | Channel-aware text formatting |
-| `skill/apple-container` | Apple Container runtime (macOS) |
-| ... | And more |
-
-Each skill branch contains **all** the code changes for that skill: new files, modified source files, updated `package.json` dependencies, `.env.example` additions — everything.
-
-### Channel fork architecture
-
-Channels (WhatsApp, Telegram, Discord, Slack, Gmail) live in **separate fork repositories**, not as skill branches on upstream. Each channel fork is a complete NanoClaw installation with the channel code already merged in.
-
-| Fork repo | Channel | Library |
-|-----------|---------|---------|
-| `nanocoai/nanoclaw-whatsapp` | WhatsApp | @whiskeysockets/baileys |
-| `nanocoai/nanoclaw-telegram` | Telegram | grammy |
-| `nanocoai/nanoclaw-discord` | Discord | discord.js |
-| `nanocoai/nanoclaw-slack` | Slack | @slack/bolt (Socket Mode) |
-| `nanocoai/nanoclaw-gmail` | Gmail | googleapis |
-
-Channels self-register at startup using the channel registry (`src/channels/registry.ts`). Each channel module calls `registerChannel()` with a factory function — the host process discovers available channels dynamically via `getRegisteredChannelNames()`.
-
-**Channel-specific skills** also live on the channel fork, not upstream:
-
-| Skill | Channel fork | What it does |
-|-------|-------------|--------------|
-| `/add-voice-transcription` | nanoclaw-whatsapp | Whisper API voice transcription |
-| `/use-local-whisper` | nanoclaw-whatsapp | Local whisper.cpp transcription |
-| `/add-image-vision` | nanoclaw-whatsapp | Image attachment processing |
-| `/add-reactions` | nanoclaw-whatsapp | Emoji reaction support |
-| `/add-pdf-reader` | nanoclaw-whatsapp | PDF text extraction |
-| `/add-telegram-swarm` | nanoclaw-telegram | Agent swarm for Telegram |
-
-<Info>
-The channel fork architecture keeps the upstream `main` branch minimal. Core NanoClaw has no channel code at all — you add exactly the channels you need by merging from the appropriate fork.
-</Info>
-
-### Four categories of skills
-
-**Feature skills** (branch-based, installed on demand):
-- `/add-discord`, `/add-telegram`, `/add-slack`, `/add-gmail`, etc.
-- Each has a `SKILL.md` with setup instructions and a corresponding `skill/*` branch with code
-- Discovered through Claude Code's plugin marketplace
-
-**Utility skills** (self-contained tools with code files):
-- Ship code files alongside the `SKILL.md` (e.g., scripts in a `scripts/` subfolder)
-- No branch merge needed — the code is self-contained in the skill directory
-- Example: `/claw` (Python CLI in `scripts/claw`)
-- Live in `.claude/skills/<name>/` on `main`
-
-**Operational skills** (on `main`, always available):
-- `/setup`, `/debug`, `/update-nanoclaw`, `/customize`, `/update-skills`, `/init-onecli`, `/migrate-nanoclaw`, `/migrate-from-openclaw`, `/get-qodo-rules`, `/qodo-pr-resolver`, `/x-integration`
-- Instruction-only `SKILL.md` files — no code changes, just workflows
-- Live in `.claude/skills/` on `main`
-
-**Container skills** (synced into every container):
-- `/agent-browser`, `/capabilities`, `/slack-formatting`, `/status`
-- Live in `container/skills/` and are synced to each group's `.claude/skills/` directory
-- Available to the agent running inside the container
-- Some are restricted to the main channel (e.g., `/capabilities` and `/status` check for the `/workspace/project` mount)
-
-## Applying a skill
-
-### Via Claude Code (recommended)
-
-Run the skill command in Claude Code. For example, `/add-discord` triggers Claude to:
+Channel and provider adapters live on two long-lived **registry branches** (`channels` and `providers`) that upstream keeps in sync with `main`. The install skill fetches files from the branch and copies them in — it never merges the branch. Using `/add-telegram` as the canonical example:
 
 <Steps>
-  <Step title="Merge the channel or skill">
-    For a channel fork:
-    ```bash
-    git remote add discord https://github.com/nanocoai/nanoclaw-discord.git
-    git fetch discord main
-    git merge discord/main
-    ```
-
-    For an upstream skill branch:
-    ```bash
-    git fetch upstream skill/ollama-tool
-    git merge upstream/skill/ollama-tool
-    ```
+  <Step title="Fetch the registry branch">
+    `git fetch origin channels`
   </Step>
-
-  <Step title="Interactive setup">
-    Walks you through creating the bot, getting tokens, configuring environment variables, and registering chats.
+  <Step title="Copy the files in">
+    `git show origin/channels:src/channels/telegram.ts > src/channels/telegram.ts` — repeated for the adapter's helpers, its tests, and its setup step. The tests travel with the code on the branch.
   </Step>
-
-  <Step title="Verify">
-    Runs build and tests to confirm everything works.
+  <Step title="Wire the barrel">
+    Append `import './telegram.js';` to `src/channels/index.ts` so the adapter self-registers at startup. This one-line append is the only edit to existing code.
+  </Step>
+  <Step title="Install the pinned dependency">
+    `pnpm install @chat-adapter/telegram@4.27.0`
+  </Step>
+  <Step title="Build and run the registration test">
+    `pnpm run build`, then the copied registration test — it imports the real channel barrel and asserts the registry contains `telegram`. If the import line is deleted, the barrel fails to evaluate, or the dependency is missing, this test goes red.
   </Step>
 </Steps>
 
-### Manually
+Three properties hold across every install skill:
 
-<Tabs>
-  <Tab title="Channel (from fork repo)">
-    ```bash
-    git remote add discord https://github.com/nanocoai/nanoclaw-discord.git
-    git fetch discord main
-    git merge discord/main
-    ```
-  </Tab>
-  <Tab title="Skill (from upstream branch)">
-    ```bash
-    git fetch upstream skill/ollama-tool
-    git merge upstream/skill/ollama-tool
-    ```
-  </Tab>
-</Tabs>
+- **Additive fetch, never a merge.** Merging a registry branch into a customized install is exactly the conflict fight this model exists to avoid. The skill copies in only the files it needs.
+- **Idempotent.** Each skill starts with a pre-flight check and every step is safe to re-run. Re-running a half-applied install completes it instead of breaking it.
+- **Reversible via REMOVE.md.** Skills that leave anything behind ship a `REMOVE.md` alongside the `SKILL.md` that reverses every change — delete the copied files, remove the barrel import, uninstall the package, rebuild. No `git revert` involved.
 
-### Applying multiple channels
+## The four categories of host skills
 
-```bash
-git merge discord/main
-git merge telegram/main
-git merge upstream/skill/ollama-tool
-```
+These are the skills you invoke as slash commands in Claude Code from your NanoClaw checkout. The [skills catalog](/reference/skills-catalog) lists all of them; here's what each category does, with one worked example apiece.
 
-Git handles the composition. If multiple merges modify the same lines, it's a real conflict — Claude resolves it automatically.
-
-## Skill discovery
-
-Skills are available through Claude Code's **plugin marketplace**. NanoClaw's `.claude/settings.json` registers the official marketplace:
-
-```json
-{
-  "extraKnownMarketplaces": {
-    "nanoclaw-skills": {
-      "source": {
-        "source": "github",
-        "repo": "nanocoai/nanoclaw-skills"
-      }
-    }
-  }
-}
-```
-
-During `/setup`, the marketplace plugin is installed automatically:
-
-```bash
-claude plugin install nanoclaw-skills@nanoclaw-skills --scope project
-```
-
-Skills are **hot-loaded** after installation — no restart needed. This means `/setup` can install the marketplace plugin, then immediately run any feature skill, all in one session.
-
-## Skill dependencies
-
-Some skills depend on others. For example, `skill/telegram-swarm` requires `skill/telegram`. Dependent skill branches are branched from their parent, not from `main`.
-
-This means `skill/telegram-swarm` includes all of Telegram's changes plus its own additions. When you merge `skill/telegram-swarm`, you get both — no need to merge Telegram separately.
-
-Dependencies are implicit in git history — no separate dependency file is needed.
-
-## Available integration skills
-
-### Channels (from fork repos)
-
-| Channel | Command | Fork repo | Library |
-|---------|---------|-----------|---------|
-| WhatsApp | `/add-whatsapp` | `nanoclaw-whatsapp` | @whiskeysockets/baileys |
-| Telegram | `/add-telegram` | `nanoclaw-telegram` | grammy |
-| Discord | `/add-discord` | `nanoclaw-discord` | discord.js |
-| Slack | `/add-slack` | `nanoclaw-slack` | @slack/bolt (Socket Mode) |
-| Gmail | `/add-gmail` | `nanoclaw-gmail` | googleapis |
-
-### Upstream skills (from skill branches)
-
-- **`/add-compact`** — Manual context compaction skill
-- **`/add-ollama-tool`** — Ollama MCP server for local models
-- **`/add-parallel`** — Parallel AI MCP servers for web research
-- **`/channel-formatting`** — Channel-aware Markdown-to-native text conversion for outbound messages (WhatsApp, Telegram, Slack, Signal)
-- **`/convert-to-apple-container`** — Switch from Docker to Apple Container on macOS
-- **`/add-emacs`** — Emacs channel with interactive chat buffer and org-mode integration (local HTTP bridge, no bot token needed)
-- **`/add-macos-statusbar`** — macOS menu bar status indicator with start/stop/restart controls
-- **`/add-karpathy-llm-wiki`** — Persistent wiki knowledge base per group, based on Karpathy's LLM Wiki pattern
-- **`/use-native-credential-proxy`** — Replace OneCLI Agent Vault with built-in `.env`-based credential proxy
-
-### Channel-specific skills (from channel fork branches)
-
-- **`/add-voice-transcription`** — Voice message transcription (on `nanoclaw-whatsapp`)
-- **`/add-image-vision`** — Image attachment processing (on `nanoclaw-whatsapp`)
-- **`/add-reactions`** — Emoji reaction support (on `nanoclaw-whatsapp`)
-- **`/add-pdf-reader`** — PDF text extraction (on `nanoclaw-whatsapp`)
-- **`/add-telegram-swarm`** — Agent swarm support (on `nanoclaw-telegram`)
-
-## Updating
-
-### Updating core
-
-```bash
-git fetch upstream main
-git merge upstream/main
-git push origin main
-```
-
-Skill and channel changes are already in your git history, so `git merge upstream/main` just works. No skill replay step needed.
-
-### Updating channels
-
-Channel forks track upstream, so pulling from a channel fork also brings in the latest core changes:
-
-```bash
-git fetch discord main
-git merge discord/main
-```
-
-### Breaking change detection
-
-After a successful merge, `/update-nanoclaw` scans the changelog diff for `[BREAKING]` entries. If any are found, Claude shows each breaking change and offers to run the referenced migration skills (e.g., `/init-onecli` for Docker users, `/convert-to-apple-container` for Apple Container users). Some breaking changes are runtime-specific — the migration instructions differentiate between Docker and Apple Container environments. You can select which migrations to run or skip them entirely.
-
-### Checking for skill updates
-
-Run `/update-skills` or let `/update-nanoclaw` check after a core update. For each previously-merged skill branch or channel fork that has new commits, Claude offers to merge the updates.
+| Category | Example | What installing looks like |
+| --- | --- | --- |
+| **Channel installs** | `/add-telegram` | The flow above: copy the adapter from the `channels` branch, append the barrel import, pin the dependency, run the registration test. See [Channels overview](/channels/overview). |
+| **Provider installs** | `/add-codex` | Same pattern against the `providers` branch, but multi-point: a provider spans the host tree *and* the container's agent-runner tree, so the skill copies into both and runs a registration test per tree. See [Providers](/extend/providers). |
+| **Tool installs** | `/add-gmail-tool` | Wires an MCP server into selected agent groups with vault-managed credentials: the container only ever sees `onecli-managed` placeholder stubs, and the OneCLI gateway injects real OAuth tokens in flight. See [Tools](/extend/tools). |
+| **Operational skills** | `/manage-mounts` | Pure instruction workflows — no code copied, nothing fetched. The SKILL.md walks Claude through a task, like editing the mount allowlist through the setup CLI and restarting the service. |
 
 <Note>
-  This requires no state files — it uses git history to determine which skills were previously merged and whether they have new commits.
+Upstream's CONTRIBUTING.md folds these into a slightly different taxonomy (channel/provider, utility, operational, container), but the install mechanics are what matter: registry-branch fetch for channels and providers, self-contained files for tools, instructions only for operational skills.
 </Note>
 
-## Removing a skill
+## Container skills: the fifth thing
 
-```bash
-# Find the merge commit
-git log --merges --oneline | grep discord
+Everything above runs on the **host**, in your checkout. Container skills (`container/skills/`) are different: they're mounted read-only at `/app/skills` into every agent container at spawn, and the agent inside the container loads them at runtime. You never invoke them yourself — they teach the agent how to browse the web (`agent-browser`), format Slack messages (`slack-formatting`), or even change its own NanoClaw install on request (`self-customize` — see [Self-modification](/extend/self-modification)).
 
-# Revert it
-git revert -m 1 <merge-commit>
-```
+Which container skills a group gets is controlled by the `skills` column in its container config — `"all"` or a pinned list. See [Container config](/reference/container-config#skills).
 
-This creates a new commit that undoes the skill's changes. If you've modified the skill's code since merging, the revert might conflict — Claude resolves it.
+## Contributing a skill upstream
 
-<Warning>
-  If you later want to re-apply a reverted skill, you must revert the revert first (git treats reverted changes as "already applied and undone"). Claude handles this automatically.
-</Warning>
+You don't push to `channels` or `providers` directly. You PR your adapter against `main` — a self-registering module, one appended barrel import, a registration test, a SKILL.md with the fetch-and-copy steps, and a REMOVE.md that reverses every change — and maintainers land the code on the registry branch from your work. Full flow in [Contributing](/concepts/contributing).
 
-## Community marketplaces
+## Updating skills
 
-Anyone can maintain their own fork with skill branches and their own marketplace repo. This enables a community-driven skill ecosystem.
-
-A community contributor:
-
-1. Maintains a fork with `skill/*` branches
-2. Creates a marketplace repo with a `.claude-plugin/marketplace.json`
-3. Opens a PR to add their marketplace to NanoClaw's `.claude/settings.json`
-
-Users can also add marketplaces manually:
-
-```bash
-/plugin marketplace add alice/nanoclaw-skills
-```
-
-## CI: Keeping skill branches current
-
-A GitHub Action runs on every push to `main`:
-
-1. Lists all `skill/*` branches
-2. Merges `main` into each skill branch (merge-forward, not rebase)
-3. Runs build and tests on the merged result
-4. Pushes the updated skill branch if tests pass
-5. Opens a GitHub issue for any skill that fails
-
-<Note>
-  Merge-forward (not rebase) preserves history for users who already merged the skill. No force-push needed.
-</Note>
-
-## Contributing a skill
-
-### As a contributor
-
-1. Fork `nanocoai/nanoclaw`
-2. Branch from `main` and make your code changes
-3. Open a regular PR
-
-That's it. The maintainers create a `skill/<name>` branch from your PR and add the `SKILL.md` to the marketplace.
-
-### As a maintainer
-
-When a skill PR is approved:
-
-1. Create a `skill/<name>` branch from the PR's commits
-2. Add the skill's `SKILL.md` to the marketplace repo (`nanocoai/nanoclaw-skills`)
-3. The contributor is added to `CONTRIBUTORS.md`
-
-## Skills vs configuration files
-
-NanoClaw deliberately avoids configuration files. From the README:
-
-> **Customization = code changes.** No configuration sprawl. Want different behavior? Modify the code. The codebase is small enough that it's safe to make changes.
-
-Skills extend this philosophy: instead of a config file with `integrations: [telegram, discord, slack]`, you merge skill branches that modify the source code directly. You end up with code that does exactly what you need, nothing more.
-
-## Best practices
-
-<Tip>
-  **Apply skills one at a time.** Test each integration before adding the next one. This makes troubleshooting easier.
-</Tip>
-
-<Tip>
-  **Keep your fork up to date.** Run `/update-nanoclaw` periodically to pull upstream changes, then optionally run `/update-skills` to pick up skill improvements.
-</Tip>
-
-<Tip>
-  **Commit before applying a skill.** Since skills are git merges, having a clean working tree makes it easy to revert if needed.
-</Tip>
-
-<Warning>
-  Skills modify your source code via git merge. Always ensure your working tree is clean before applying a new skill.
-</Warning>
+Run `/update-skills` (or let `/update-nanoclaw` trigger it after a core update) to re-fetch installed adapters from their registry branches — see [Upgrading](/operate/upgrading).
 
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Add Telegram" icon="paper-plane" href="/channels/telegram">
-    Add Telegram support to your installation
+  <Card title="Skills catalog" icon="list" href="/reference/skills-catalog">
+    Every skill that ships with NanoClaw, by category
   </Card>
-
-  <Card title="Add Discord" icon="comments" href="/channels/discord">
-    Add Discord support to your installation
+  <Card title="Tools" icon="wrench" href="/extend/tools">
+    Add MCP tools and capabilities to your agents
   </Card>
-
-  <Card title="Add Slack" icon="hashtag" href="/channels/slack">
-    Add Slack support to your installation
+  <Card title="Providers" icon="microchip" href="/extend/providers">
+    Swap the agent runtime: Codex, OpenCode, Ollama
   </Card>
-
-  <Card title="Add Gmail" icon="envelope" href="/extend/tools">
-    Add Gmail integration to your installation
+  <Card title="Write your own skill" icon="pen-ruler" href="/extend/writing-skills">
+    Authoring guidelines: mostly adds, a test per integration point, a REMOVE.md
   </Card>
 </CardGroup>

--- a/extend/overview.mdx
+++ b/extend/overview.mdx
@@ -10,7 +10,7 @@ keywords: ["skills", "extend", "SKILL.md", "registry branches", "channels branch
 A NanoClaw skill is a **SKILL.md instruction workflow** in `.claude/skills/` that Claude Code executes in your checkout. When you run `/add-telegram` or `/manage-mounts`, Claude reads the skill's instructions and performs them — copying files, appending an import, installing a dependency, running a test. There is no plugin engine, no manifest.yaml, and no skill state file. The skill *is* the markdown.
 
 <Note>
-This URL previously documented a different model: skills as `skill/*` git branches that you merged into your fork and removed with `git revert`. That model was designed for v1 and **never shipped in v2** — no `skill/*` branches exist on the repo, and no skill performs a `git merge`. If a skill's instructions say `git merge`, it isn't built for v2. This page describes how skills actually work as of v2.1.4.
+This URL previously documented a different model: skills as `skill/*` git branches that you merged into your fork and removed with `git revert`. That model was designed for v1 and **never shipped in v2** — skills are not distributed as `skill/*` branches you merge, and no skill installs by merging a branch. If a skill's install instructions say `git merge`, it isn't built for v2. This page describes how skills actually work as of v2.1.4.
 </Note>
 
 This is how the trunk stays small: it ships channel and provider *infrastructure* but no specific adapters. Your fork only ever contains the code for the features you installed — the rest stays out of your context window and your upgrade path.
@@ -26,11 +26,11 @@ Channel and provider adapters live on two long-lived **registry branches** (`cha
   <Step title="Copy the files in">
     `git show origin/channels:src/channels/telegram.ts > src/channels/telegram.ts` — repeated for the adapter's helpers, its tests, and its setup step. The tests travel with the code on the branch.
   </Step>
-  <Step title="Wire the barrel">
-    Append `import './telegram.js';` to `src/channels/index.ts` so the adapter self-registers at startup. This one-line append is the only edit to existing code.
+  <Step title="Wire the barrel and the setup step">
+    Append `import './telegram.js';` to `src/channels/index.ts` so the adapter self-registers at startup, and add the `pair-telegram` entry to the `STEPS` map in `setup/index.ts`. These one-line appends are the only edits to existing code.
   </Step>
-  <Step title="Install the pinned dependency">
-    `pnpm install @chat-adapter/telegram@4.27.0`
+  <Step title="Install the dependency">
+    `pnpm install @chat-adapter/telegram` — the skill installs the pinned adapter version.
   </Step>
   <Step title="Build and run the registration test">
     `pnpm run build`, then the copied registration test — it imports the real channel barrel and asserts the registry contains `telegram`. If the import line is deleted, the barrel fails to evaluate, or the dependency is missing, this test goes red.

--- a/extend/providers.mdx
+++ b/extend/providers.mdx
@@ -1,147 +1,106 @@
 ---
-title: Ollama integration
-description: Use local LLMs alongside Claude via the Ollama MCP server
+title: "Agent providers"
+description: "Swap the agent brain per group — Claude Code by default, OpenCode or Codex via provider skills, or a local Ollama model with no provider code at all."
 tag: "UPDATED"
-keywords: ["ollama", "local models", "llm", "mcp", "self-hosted"]
+keywords: ["providers", "agent provider", "claude", "opencode", "codex", "ollama", "local models", "agent_provider", "model", "effort"]
 ---
 
-<Warning>
-In v2, Ollama moved from a core integration to a skill on the `providers` branch. Install via `/add-ollama-provider` (run Ollama as a full provider for an agent group) or `/add-ollama-tool` (keep Claude as the agent, expose Ollama as a tool). The MCP setup described below reflects v1 mechanics; a v2 rewrite is pending. See [Integrations overview](/channels/overview#providers) for the v2 provider model.
-</Warning>
+{/* verified-against: container/agent-runner/src/providers/{types,factory,claude,provider-registry}.ts, container/agent-runner/src/{config,index}.ts, src/container-runner.ts, src/container-config.ts, src/providers/{claude,provider-container-registry}.ts, src/cli/resources/{groups,sessions}.ts, .claude/skills/{add-opencode,add-codex,add-ollama-provider}/SKILL.md, docs/ollama.md, providers branch @ dc34ceb (v2.1.4) */}
 
-NanoClaw can delegate tasks to local models running on [Ollama](https://ollama.com), while Claude remains the orchestrator. This lets you offload cheaper tasks (summarization, translation, general queries) to local models and reduce API costs.
-
-## How it works
-
-The `/add-ollama-tool` skill adds a stdio-based MCP server inside the agent container. The MCP server exposes these tools:
-
-| Tool | Description | Requires |
-|------|-------------|----------|
-| `ollama_list_models` | Lists all locally installed Ollama models | — |
-| `ollama_generate` | Sends a prompt to a specified model and returns the response | — |
-| `ollama_pull_model` | Pulls (downloads) a model from the Ollama registry | `OLLAMA_ADMIN_TOOLS=true` |
-| `ollama_delete_model` | Deletes a locally installed model to free disk space | `OLLAMA_ADMIN_TOOLS=true` |
-| `ollama_show_model` | Shows model details: parameters, template, architecture info | `OLLAMA_ADMIN_TOOLS=true` |
-| `ollama_list_running` | Lists models currently loaded in memory with resource usage | `OLLAMA_ADMIN_TOOLS=true` |
-
-The container agent reaches Ollama on the host via `host.docker.internal:11434`. Claude decides when to use local models based on task complexity — you don't need to configure routing rules.
-
-```mermaid
-graph TB
-    subgraph "Agent Container"
-        CL[Claude<br/>orchestrator]
-        MCP[Ollama MCP Server<br/>stdio transport]
-    end
-
-    subgraph "Host"
-        OL[Ollama<br/>llama3.2, gemma3, etc.]
-    end
-
-    CL -->|tool call| MCP
-    MCP -->|host.docker.internal:11434| OL
-
-    style CL fill:#6ee7b7,color:#1e1e1e
-    style MCP fill:#93c5fd,color:#1e1e1e
-    style OL fill:#fde68a,color:#1e1e1e
-```
-
-## Prerequisites
-
-Install Ollama and pull at least one model:
-
-```bash
-# Install Ollama (macOS/Linux)
-curl -fsSL https://ollama.com/install.sh | sh
-
-# Pull a model
-ollama pull llama3.2        # Good general purpose (2GB)
-ollama pull gemma3:1b       # Small and fast (1GB)
-ollama pull qwen3-coder:30b # Best for code tasks (18GB)
-```
-
-Verify Ollama is running:
-
-```bash
-ollama list
-```
-
-## Installation
-
-Apply the skill in Claude Code:
-
-```
-/add-ollama-tool
-```
-
-Or manually:
-
-```bash
-git fetch upstream skill/ollama-tool
-git merge upstream/skill/ollama-tool
-```
-
-This adds:
-- `container/agent-runner/src/ollama-mcp-stdio.ts` — MCP server that bridges to Ollama
-- `scripts/ollama-watch.sh` — macOS notification watcher for Ollama status
-- Ollama MCP configuration and `[OLLAMA]` log surfacing in the agent runner
-- `OLLAMA_ADMIN_TOOLS` config option for model management tools
-
-After merging, rebuild the container:
-
-```bash
-./container/build.sh
-```
-
-## Configuration
-
-Set `OLLAMA_HOST` in `.env` if Ollama runs on a non-default address:
-
-```bash
-# Default (usually correct — no need to set)
-OLLAMA_HOST=http://host.docker.internal:11434
-```
-
-The MCP server automatically falls back to `localhost` if `host.docker.internal` fails.
-
-To enable admin tools (pull, delete, show, list running), add:
-
-```bash
-OLLAMA_ADMIN_TOOLS=true
-```
+A **provider** is the agent CLI that runs inside a group's container — the thing that actually plans, calls tools, and writes replies. By default that's Claude Code via the Claude Agent SDK. The provider is pluggable: the agent runner selects an implementation from an open registry at startup, and the trunk ships only `claude` (plus a `mock` provider for tests).
 
 <Note>
-Ollama must be running on the host before starting NanoClaw. The MCP server writes status to `/workspace/ipc/ollama_status.json` so the host process can surface connection issues in logs.
+Don't confuse providers with [tools](/extend/tools). A tool skill like `/add-ollama-tool` keeps Claude as the agent's brain and gives it a local model to call; a provider skill **replaces** the brain for an entire group.
 </Note>
 
-## Usage
+## How the provider is resolved
 
-Once installed, Claude can use local models transparently. For example:
+At spawn time the host resolves the provider name with a fixed precedence ([`src/container-runner.ts`](https://github.com/qwibitai/nanoclaw/blob/main/src/container-runner.ts)):
 
-> "Summarize this document using a local model"
+1. `sessions.agent_provider` — per-session override
+2. `container_configs.provider` — the group's [container config](/reference/container-config#provider)
+3. `'claude'`
 
-Claude will call `ollama_list_models` to see available models, then `ollama_generate` with the appropriate prompt. You can also be explicit about which model to use:
+The result is lowercased. The host then asks its provider registry whether that provider contributes extra mounts or env vars (OpenCode's XDG dirs, Codex's per-session `~/.codex`, `OPENCODE_*`/`OPENAI_*` passthrough); `claude` and `mock` contribute nothing. Inside the container, the runner reads `provider` from `container.json` — materialized fresh from the database at every spawn — and instantiates it from the in-container registry, passing the group's `model` and `effort` through unchanged.
 
-> "Use llama3.2 to translate this to Spanish"
+Every code path that creates a session on trunk writes `agent_provider = null`, and `ncl sessions` is read-only (`list`/`get`) — so the per-session override exists in the resolver, but nothing ships that sets it. In practice you switch providers per group.
 
-## Third-party model endpoints
+## Claude (default)
 
-Independently of Ollama, NanoClaw supports any Anthropic API-compatible endpoint. Set these in `.env`:
+The Claude provider wraps the Claude Agent SDK. Its `model` accepts an alias (`sonnet`, `opus`, `haiku`) or a full model ID, and `effort` is one of `low`, `medium`, `high`, `xhigh`, `max` — both optional, both falling back to the SDK default. It's also the most capable provider: native slash-command handling, and transcript rotation that archives oversized session histories before a cold resume can wedge the container.
 
-```bash
-ANTHROPIC_BASE_URL=https://your-api-endpoint.com
-ANTHROPIC_AUTH_TOKEN=your-token-here
+To point it at any Anthropic-compatible endpoint, set `ANTHROPIC_BASE_URL` in `.env` — the real token stays in the vault and is injected on the wire. See [Credentials](/operate/credentials#anthropic-credentials).
+
+## Two ways to run a different brain
+
+The three provider skills split into two mechanisms:
+
+- **Real provider implementations** — OpenCode and Codex are TypeScript providers that live on the `providers` [registry branch](/extend/overview#how-a-code-carrying-skill-installs). `/add-opencode` and `/add-codex` copy the files in, wire them into the host and container barrels, and rebuild the image.
+- **No provider code at all** — Ollama speaks the Anthropic API natively (`/v1/messages`), so `/add-ollama-provider` keeps the Claude provider and just redirects it: env overrides plus a model setting.
+
+### OpenCode (`/add-opencode`)
+
+Copies `opencode.ts` (host and container sides) from the `providers` branch, appends one import line to each provider barrel, adds `@opencode-ai/sdk` to the agent runner, installs the `opencode-ai` CLI in the Dockerfile, and copies registration/Dockerfile guard tests so the wiring stays verified. The provider spawns `opencode serve` per query and routes models through OpenCode's own config — OpenRouter, DeepSeek, OpenAI, Google, Anthropic, OpenCode Zen.
+
+Configure via host `.env`: `OPENCODE_PROVIDER`, `OPENCODE_MODEL` (in `provider/model` form), optional `OPENCODE_SMALL_MODEL`, and `ANTHROPIC_BASE_URL` pointed at the upstream provider's API base for non-Anthropic providers. API keys go in the [OneCLI vault](/operate/credentials) with a matching host pattern — never in `.env`. SDK and CLI versions are pinned together at 1.4.17; `latest` silently breaks session IDs.
+
+### Codex (`/add-codex`)
+
+Copies `codex.ts` and `codex-app-server.ts` from the `providers` branch, wires the same barrels and guards, and installs the `@openai/codex` CLI in the Dockerfile (no SDK dependency — Codex is a binary). The provider runs `codex app-server` as a child process and speaks JSON-RPC over stdio, which gives it native session resume, streaming events, MCP tools, and automatic compaction (at 40K cumulative input tokens, via `thread/compact/start`).
+
+Auth: run `codex login` on the host to use a ChatGPT subscription (the host copies `auth.json` into a per-session `~/.codex` mount), or set `OPENAI_API_KEY` + `CODEX_MODEL` in `.env`. An experimental third path points `OPENAI_BASE_URL` at any OpenAI-compatible endpoint — Groq, Together, self-hosted vLLM.
+
+### Ollama (`/add-ollama-provider`)
+
+No files copied, no rebuild of provider code. The skill first checks that `ContainerConfig` supports the `env` and `blockedHosts` fields (patching `src/container-config.ts` and `src/container-runner.ts` if not), then writes the group's container config:
+
+```json
+{
+  "env": {
+    "ANTHROPIC_BASE_URL": "http://host.docker.internal:11434",
+    "ANTHROPIC_API_KEY": "ollama",
+    "NO_PROXY": "host.docker.internal",
+    "no_proxy": "host.docker.internal"
+  },
+  "blockedHosts": ["api.anthropic.com"]
+}
 ```
 
-This allows you to use:
-- Open-source models on [Together AI](https://together.ai), [Fireworks](https://fireworks.ai), etc.
-- Custom model deployments with Anthropic-compatible APIs
+`ANTHROPIC_BASE_URL` redirects the SDK to Ollama, the placeholder key satisfies it (Ollama ignores it), `NO_PROXY` bypasses the OneCLI credential gateway for the host hostname, and `blockedHosts` resolves `api.anthropic.com` to `0.0.0.0` so config drift can't silently bill your account. The model is set in the group's shared `settings.json` (`data/v2-sessions/<group-id>/.claude-shared/settings.json`) — Claude Code reads its model from there, not from env. Pick models that handle tool calls reliably; the upstream notes recommend Gemma 4 or Qwen 3 Coder over small 3B models.
 
-<Warning>
-When using custom endpoints, the secret injection layer (OneCLI Agent Vault in v1.2.35+, or the credential proxy in earlier versions) still intercepts container API requests. Ensure the endpoint is reachable from the host.
-</Warning>
+## What changes on a non-Claude provider
 
-## Related pages
+Verified against the provider sources on the `providers` branch:
 
-- [Skills system](/extend/overview) — How skills work
-- [Configuration](/api/configuration) — Environment variables reference
-- [Container runtime](/concepts/container-lifecycle) — How agent containers work
+- **Slash commands aren't native.** OpenCode and Codex declare `supportsNativeSlashCommands = false`, so the poll loop formats slash commands as ordinary chat text instead of executing them.
+- **No mid-turn input.** Both queue follow-up messages and drain them between turns; the Claude provider streams them into the live turn.
+- **CLAUDE.md imports are emulated.** Codex's app-server doesn't expand `@-import` directives or auto-load `CLAUDE.local.md`, so the provider resolves both itself to reconstruct the composed system prompt.
+- **No transcript rotation.** Only the Claude provider implements `maybeRotateContinuation` — the guard against unresumable, oversized session transcripts.
+
+## Switching a group
+
+Set the provider (and optionally model/effort) on the group's container config, then restart:
+
+```bash
+ncl groups config update --id <group-id> --provider opencode --model deepseek/deepseek-chat
+ncl groups restart --id <group-id>
+```
+
+Config changes are saved immediately but only take effect on the next container spawn — the restart forces it. Switching back is `--provider claude` (or clearing the field; the fallback is `claude` either way), and each provider skill ships a `REMOVE.md` to back the code out entirely.
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Skills catalog" icon="list" href="/reference/skills-catalog#provider-installs">
+    The three provider-install skills at a glance
+  </Card>
+  <Card title="Container config" icon="box" href="/reference/container-config#provider">
+    The provider, model, and effort fields in full
+  </Card>
+  <Card title="Credentials" icon="key" href="/operate/credentials">
+    How provider API keys stay out of containers
+  </Card>
+  <Card title="Give agents tools" icon="screwdriver-wrench" href="/extend/tools">
+    Keep Claude as the brain and add capabilities instead
+  </Card>
+</CardGroup>

--- a/extend/providers.mdx
+++ b/extend/providers.mdx
@@ -5,7 +5,7 @@ tag: "UPDATED"
 keywords: ["providers", "agent provider", "claude", "opencode", "codex", "ollama", "local models", "agent_provider", "model", "effort"]
 ---
 
-{/* verified-against: container/agent-runner/src/providers/{types,factory,claude,provider-registry}.ts, container/agent-runner/src/{config,index}.ts, src/container-runner.ts, src/container-config.ts, src/providers/{claude,provider-container-registry}.ts, src/cli/resources/{groups,sessions}.ts, .claude/skills/{add-opencode,add-codex,add-ollama-provider}/SKILL.md, docs/ollama.md, providers branch @ dc34ceb (v2.1.4) */}
+{/* verified-against: container/agent-runner/src/providers/{types,factory,claude,provider-registry}.ts, container/agent-runner/src/{config,index}.ts, src/container-runner.ts, src/container-config.ts, src/providers/{claude,provider-container-registry}.ts, src/cli/resources/{groups,sessions}.ts, .claude/skills/{add-opencode,add-codex,add-ollama-provider}/SKILL.md, docs/ollama.md @ trunk dc34ceb (v2.1.4); opencode.ts, codex.ts, codex-app-server.ts @ providers branch 5e76b9d */}
 
 A **provider** is the agent CLI that runs inside a group's container — the thing that actually plans, calls tools, and writes replies. By default that's Claude Code via the Claude Agent SDK. The provider is pluggable: the agent runner selects an implementation from an open registry at startup, and the trunk ships only `claude` (plus a `mock` provider for tests).
 
@@ -21,7 +21,7 @@ At spawn time the host resolves the provider name with a fixed precedence ([`src
 2. `container_configs.provider` — the group's [container config](/reference/container-config#provider)
 3. `'claude'`
 
-The result is lowercased. The host then asks its provider registry whether that provider contributes extra mounts or env vars (OpenCode's XDG dirs, Codex's per-session `~/.codex`, `OPENCODE_*`/`OPENAI_*` passthrough); `claude` and `mock` contribute nothing. Inside the container, the runner reads `provider` from `container.json` — materialized fresh from the database at every spawn — and instantiates it from the in-container registry, passing the group's `model` and `effort` through unchanged.
+The result is lowercased. The host then asks its provider registry whether that provider contributes extra mounts or env vars (OpenCode's XDG dirs, Codex's per-session `~/.codex`, `OPENCODE_*`/`OPENAI_*` passthrough). `mock` contributes nothing, and `claude` contributes only when setup has wired a custom Anthropic-compatible endpoint — `ANTHROPIC_BASE_URL` from `.env` plus a placeholder auth token for the vault gateway to overwrite. Inside the container, the runner reads `provider` from `container.json` — materialized fresh from the database at every spawn — and instantiates it from the in-container registry, passing the group's `model` and `effort` through unchanged.
 
 Every code path that creates a session on trunk writes `agent_provider = null`, and `ncl sessions` is read-only (`list`/`get`) — so the per-session override exists in the resolver, but nothing ships that sets it. In practice you switch providers per group.
 
@@ -40,13 +40,13 @@ The three provider skills split into two mechanisms:
 
 ### OpenCode (`/add-opencode`)
 
-Copies `opencode.ts` (host and container sides) from the `providers` branch, appends one import line to each provider barrel, adds `@opencode-ai/sdk` to the agent runner, installs the `opencode-ai` CLI in the Dockerfile, and copies registration/Dockerfile guard tests so the wiring stays verified. The provider spawns `opencode serve` per query and routes models through OpenCode's own config — OpenRouter, DeepSeek, OpenAI, Google, Anthropic, OpenCode Zen.
+Copies `opencode.ts` (host and container sides) from the `providers` branch, appends one import line to each provider barrel, adds `@opencode-ai/sdk` to the agent runner, installs the `opencode-ai` CLI in the Dockerfile, and copies registration/Dockerfile guard tests so the wiring stays verified. The provider keeps a shared `opencode serve` runtime — spawned once, reused across queries, and torn down on abort or when the config changes — and routes models through OpenCode's own config: OpenRouter, DeepSeek, OpenAI, Google, Anthropic, OpenCode Zen.
 
 Configure via host `.env`: `OPENCODE_PROVIDER`, `OPENCODE_MODEL` (in `provider/model` form), optional `OPENCODE_SMALL_MODEL`, and `ANTHROPIC_BASE_URL` pointed at the upstream provider's API base for non-Anthropic providers. API keys go in the [OneCLI vault](/operate/credentials) with a matching host pattern — never in `.env`. SDK and CLI versions are pinned together at 1.4.17; `latest` silently breaks session IDs.
 
 ### Codex (`/add-codex`)
 
-Copies `codex.ts` and `codex-app-server.ts` from the `providers` branch, wires the same barrels and guards, and installs the `@openai/codex` CLI in the Dockerfile (no SDK dependency — Codex is a binary). The provider runs `codex app-server` as a child process and speaks JSON-RPC over stdio, which gives it native session resume, streaming events, MCP tools, and automatic compaction (at 40K cumulative input tokens, via `thread/compact/start`).
+Copies `codex.ts` and `codex-app-server.ts` from the `providers` branch, wires the same barrels and guards, and installs the `@openai/codex` CLI in the Dockerfile (no SDK dependency — Codex is a binary). The provider spawns one `codex app-server` child process per query and speaks JSON-RPC over stdio, which gives it native session resume, streaming events, and MCP tools.
 
 Auth: run `codex login` on the host to use a ChatGPT subscription (the host copies `auth.json` into a per-session `~/.codex` mount), or set `OPENAI_API_KEY` + `CODEX_MODEL` in `.env`. An experimental third path points `OPENAI_BASE_URL` at any OpenAI-compatible endpoint — Groq, Together, self-hosted vLLM.
 
@@ -86,7 +86,7 @@ ncl groups config update --id <group-id> --provider opencode --model deepseek/de
 ncl groups restart --id <group-id>
 ```
 
-Config changes are saved immediately but only take effect on the next container spawn — the restart forces it. Switching back is `--provider claude` (or clearing the field; the fallback is `claude` either way), and each provider skill ships a `REMOVE.md` to back the code out entirely.
+Config changes are saved immediately but only take effect on the next container spawn — the restart forces it. Switching back is `--provider claude` (or clearing the field; the fallback is `claude` either way). To back the code out entirely, OpenCode and Codex each ship a `REMOVE.md`; Ollama needs no removal — its SKILL.md's "Reverting to Claude" steps are just deleting the `env` and `blockedHosts` keys from the container config and the `model` setting from the shared settings file.
 
 ## Next steps
 

--- a/extend/self-modification.mdx
+++ b/extend/self-modification.mdx
@@ -20,7 +20,7 @@ Agents can change their own environment — but every change that touches the co
 
 ## Free edits: the agent's own memory
 
-The group folder is mounted read-write at `/workspace/agent/`, so the agent can edit `CLAUDE.local.md` — its persistent per-group memory and instructions — without asking anyone. This is where "remember that I prefer short answers" lands. The [self-customize skill](#how-agents-learn-this) mounted into every container teaches exactly this: workspace files and `CLAUDE.local.md` are direct edits, everything else has a workflow.
+The group folder is mounted read-write at `/workspace/agent/`, so the agent can edit `CLAUDE.local.md` — its persistent per-group memory and instructions — without asking anyone. This is where "remember that I prefer short answers" lands. The [self-customize container skill](/reference/skills-catalog#container-skills) teaches exactly this: workspace files and `CLAUDE.local.md` are direct edits, everything else has a workflow.
 
 The boundary is enforced by nested read-only mounts on top of the read-write group dir:
 
@@ -38,7 +38,7 @@ The request is fire-and-forget. On approval, the host does the whole follow-up i
 2. Rebuilds the per-agent image
 3. Kills the container and queues an on-wake message telling the fresh agent to verify the packages and report back to the user
 
-Packages installed this way persist across all future sessions — unlike a `pnpm install` in the workspace, which the self-customize skill recommends for one-off tasks precisely because it *doesn't* require approval or persist.
+Packages installed this way are baked into the image and available in every future session — unlike a `pnpm install` in the per-session workspace, which needs no approval but doesn't persist into the image or other sessions. The self-customize skill recommends exactly that for one-off tasks, and prototyping in the workspace before promoting a dependency to a container-level install.
 
 ## `add_mcp_server`: new tools
 
@@ -50,7 +50,7 @@ Two things this path can't do: it doesn't accept the `instructions` field that [
 
 Both operations use the same approvals plumbing as [credential requests](/operate/credentials#approving-credential-use). You get a DM card — "Install Packages Request" or "Add MCP Request" — naming the agent, the package list or server command, and the agent's stated reason, with Approve / Reject buttons.
 
-- **Who gets it:** admins of the requesting agent group first, then global admins, then owners — the first one with a reachable DM. No eligible approver means the request fails immediately and the agent is told why.
+- **Who gets it:** admins of the requesting agent group first, then global admins, then owners — the first one with a reachable DM, preferring approvers on the same channel type as the originating session, then falling back to list order on any channel. No eligible approver means the request fails immediately and the agent is told why.
 - **On approve:** the host executes the full change (config update, rebuild if needed, restart) and the agent gets a system message prompting it to verify and report.
 - **On reject:** the agent sees "Your `install_packages` request was rejected by admin."
 

--- a/extend/self-modification.mdx
+++ b/extend/self-modification.mdx
@@ -1,0 +1,91 @@
+---
+title: "Agent self-modification"
+description: "What agents can change about themselves — editing their own memory freely, and requesting packages or MCP servers through admin approval."
+tag: "NEW"
+keywords: ["self-modification", "install_packages", "add_mcp_server", "CLAUDE.local.md", "approval", "self-customize", "rebuild", "agent memory"]
+---
+
+{/* verified-against: src/modules/self-mod/{index,request,apply}.ts, src/modules/approvals/primitive.ts, container/agent-runner/src/mcp-tools/self-mod.ts, container/agent-runner/src/mcp-tools/self-mod.instructions.md, container/skills/self-customize/SKILL.md, src/container-runner.ts, src/claude-md-compose.ts @ dc34ceb (v2.1.4) */}
+
+Agents can change their own environment — but every change that touches the container goes through you. The self-mod module exposes exactly two operations, `install_packages` and `add_mcp_server`, and **both are always approval-gated**: the agent submits a request, an admin gets a card, and nothing changes until someone taps Approve. The one thing an agent can change freely is its own memory file.
+
+## What an agent can change
+
+| Surface | Approval | What happens |
+| --- | --- | --- |
+| `CLAUDE.local.md` and workspace files | None — direct edit | Persists immediately; it's a plain file on the host |
+| apt / npm packages | Admin card | Container config updated, image rebuilt, container restarted |
+| MCP servers | Admin card | Container config updated, container restarted (no rebuild) |
+| Its own source code, composed `CLAUDE.md`, `container.json` | Not possible | Mounted read-only |
+
+## Free edits: the agent's own memory
+
+The group folder is mounted read-write at `/workspace/agent/`, so the agent can edit `CLAUDE.local.md` — its persistent per-group memory and instructions — without asking anyone. This is where "remember that I prefer short answers" lands. The [self-customize skill](#how-agents-learn-this) mounted into every container teaches exactly this: workspace files and `CLAUDE.local.md` are direct edits, everything else has a workflow.
+
+The boundary is enforced by nested read-only mounts on top of the read-write group dir:
+
+- the composed `CLAUDE.md` is read-only and regenerated from scratch every spawn — edits would be lost anyway, so writes are blocked and the agent is told to use `CLAUDE.local.md`
+- `container.json` (the materialized [container config](/reference/container-config)) is read-only — config changes only land through the approval paths below
+- the agent-runner source at `/app/src` is read-only — code changes go through a builder agent, not in-place edits
+
+## `install_packages`: apt and npm packages
+
+The agent calls the [`install_packages` MCP tool](/reference/mcp-tools#install_packages) with `apt` and/or `npm` package lists and an optional `reason`. Constraints, validated in the container *and* re-validated on the host (the payload travels verbatim to a shell exec, so both layers matter): at least one package, max 20 per request, strict name patterns — no version specs, flags, or shell characters.
+
+The request is fire-and-forget. On approval, the host does the whole follow-up in one step:
+
+1. Appends the packages to the group's `packages_apt` / `packages_npm` config (deduplicated)
+2. Rebuilds the per-agent image
+3. Kills the container and queues an on-wake message telling the fresh agent to verify the packages and report back to the user
+
+Packages installed this way persist across all future sessions — unlike a `pnpm install` in the workspace, which the self-customize skill recommends for one-off tasks precisely because it *doesn't* require approval or persist.
+
+## `add_mcp_server`: new tools
+
+The agent calls [`add_mcp_server`](/reference/mcp-tools#add_mcp_server) with a `name` and `command` (plus optional `args` and `env`) for an MCP server it already knows how to invoke. On approval, the host adds the server to the group's `mcp_servers` config and restarts the container — no image rebuild, since bun runs TypeScript directly and the new server is wired on the next start.
+
+Two things this path can't do: it doesn't accept the `instructions` field that [`mcp_servers` entries support](/reference/container-config#mcp_servers), and it doesn't handle credentials — agents are instructed to use the `"onecli-managed"` placeholder for any credential env vars and let the [OneCLI Agent Vault](/operate/credentials) inject real values in flight, never to ask you for keys.
+
+## The approval flow, from your seat
+
+Both operations use the same approvals plumbing as [credential requests](/operate/credentials#approving-credential-use). You get a DM card — "Install Packages Request" or "Add MCP Request" — naming the agent, the package list or server command, and the agent's stated reason, with Approve / Reject buttons.
+
+- **Who gets it:** admins of the requesting agent group first, then global admins, then owners — the first one with a reachable DM. No eligible approver means the request fails immediately and the agent is told why.
+- **On approve:** the host executes the full change (config update, rebuild if needed, restart) and the agent gets a system message prompting it to verify and report.
+- **On reject:** the agent sees "Your `install_packages` request was rejected by admin."
+
+Pending requests are visible with `ncl approvals list --status pending`; decisions happen on the card, not in the CLI.
+
+<Note>
+Self-mod is an optional module. Without it installed, the agent's tools still submit requests, but the host drops them — no card is ever delivered and nothing changes.
+</Note>
+
+## Reviewing and reverting changes
+
+Everything an agent changed through approval lands in the group's container config, so review is one command:
+
+```bash
+ncl groups config get --id <group-id>   # shows packages_apt, packages_npm, mcp_servers
+```
+
+To undo:
+
+```bash
+# Remove a package, then rebuild
+ncl groups config remove-package --id <group-id> --apt <pkg>
+ncl groups restart --id <group-id> --rebuild
+
+# Remove an MCP server, then restart (no rebuild needed)
+ncl groups config remove-mcp-server --id <group-id> --name <server>
+ncl groups restart --id <group-id>
+```
+
+`CLAUDE.local.md` edits have no approval trail — it's a plain file at `groups/<folder>/CLAUDE.local.md` on the host, and the groups directory is not a git repository. To review, read the file; to revert, edit it (or restore from your own backups).
+
+## Where the guardrails sit
+
+An agent asking to expand its own capabilities is exactly what a prompt-injected agent would ask for — that's why both operations are approval-gated and package names are sanitized at two layers. The [security model](/concepts/security) covers self-modification in the context of the other approval gates.
+
+<Note>
+Don't confuse agent self-modification with the operator-side `/customize` skill, which you run in Claude Code against your NanoClaw checkout to change channels, wirings, and core behavior. That's covered in [Customize NanoClaw](/guides/customize-an-agent).
+</Note>

--- a/extend/tools.mdx
+++ b/extend/tools.mdx
@@ -1,489 +1,96 @@
 ---
-title: Gmail integration (v1 only)
-description: The /add-gmail skill shipped on v1. v2 does not include a Gmail adapter — use /add-resend for outbound email.
-hidden: true
+title: "Give agents tools"
+description: "Two ways to add MCP tools to NanoClaw agents — install a tool skill like /add-gmail-tool, or register any MCP server yourself via the container config."
+tag: "UPDATED"
+keywords: ["tools", "mcp", "gmail", "google calendar", "ollama", "atomic chat", "agent-browser", "web access", "add-mcp-server", "tool skills"]
 ---
 
-<Warning>
-**Gmail is not a v2 channel.** v2 ships with no `src/channels/gmail.ts` and no `/add-gmail` skill on the `channels` branch. This page describes the v1 integration for users still running v1.
+{/* verified-against: .claude/skills/{add-gmail-tool,add-gcal-tool,add-ollama-tool,add-atomic-chat-tool}/SKILL.md, container/skills/agent-browser/SKILL.md, src/db/container-configs.ts, src/container-runner.ts @ dc34ceb (v2.1.4) */}
 
-For v2:
-- **Outbound email** — `/add-resend` (transactional sends via Resend)
-- **Google Chat** — `/add-gchat`
+Agents get tools two ways:
 
-See the [integrations overview](/channels/overview) for the current v2 channel list.
-</Warning>
+1. **Install a tool skill** — `/add-gmail-tool`, `/add-gcal-tool`, `/add-ollama-tool`, and friends. Each is a [SKILL.md workflow](/extend/overview) that wires an MCP server into the agent groups you choose, with credentials handled by the [OneCLI Agent Vault](/operate/credentials) where the service needs them.
+2. **Bring your own MCP server** — register any stdio MCP server in a group's [container config](/reference/container-config#mcp_servers) with one `ncl` command. No skill required.
 
-Add Gmail to NanoClaw as a tool (read, send, search, draft) or as a full channel that monitors your inbox and triggers the agent on new emails.
-
-## Overview
-
-The Gmail integration uses [@gongrzhe/server-gmail-autoauth-mcp](https://github.com/gongrzhe/server-gmail-autoauth-mcp) as an MCP server, providing Gmail tools to your agent. It can operate in two modes:
-
-### Tool-only mode
-
-The agent gets Gmail tools but doesn't monitor the inbox:
-
-- `mcp__gmail__send_email` - Send emails
-- `mcp__gmail__read_email` - Read specific emails by ID
-- `mcp__gmail__search_emails` - Search with Gmail query syntax
-- `mcp__gmail__create_draft` - Create draft emails
-- `mcp__gmail__list_labels` - List Gmail labels
-
-### Channel mode
-
-Everything from tool-only mode, plus:
-
-- Polls inbox for new emails (every 60 seconds)
-- Triggers agent on matching emails
-- Notifies via your main channel (e.g., WhatsApp)
-- Filters: Primary inbox only by default (excludes Promotions, Social, etc.)
-
-## Adding Gmail
-
-Use the `/add-gmail` skill:
-
-<Steps>
-  <Step title="Run the skill">
-    ```bash
-    claude
-    /add-gmail
-    ```
-  </Step>
-  
-  <Step title="Choose mode">
-    - **Tool-only** - Agent can use Gmail tools when triggered from other channels
-    - **Channel mode** - Agent monitors inbox and triggers on new emails
-  </Step>
-  
-  <Step title="Apply code changes">
-    The skill applies different changes depending on mode:
-    
-    **Tool-only:**
-    - Mounts `~/.gmail-mcp` in container
-    - Adds Gmail MCP server to agent runner
-    
-    **Channel mode:**
-    - All of the above, plus:
-    - Adds `src/channels/gmail.ts` (GmailChannel implementation)
-    - Adds `src/channels/gmail.test.ts` (unit tests)
-    - Merges Gmail channel into `src/index.ts`
-    - Installs `googleapis` NPM package
-  </Step>
-  
-  <Step title="Set up OAuth">
-    Create GCP OAuth credentials and authorize Gmail access
-  </Step>
-  
-  <Step title="Build container">
-    Rebuild the agent container to include Gmail MCP server
-  </Step>
-  
-  <Step title="Test">
-    Verify Gmail tools work via your main channel
-  </Step>
-</Steps>
-
-## GCP OAuth setup
-
-Gmail integration requires Google Cloud OAuth credentials.
-
-<Steps>
-  <Step title="Create GCP project">
-    1. Open [console.cloud.google.com](https://console.cloud.google.com)
-    2. Create a new project or select existing
-  </Step>
-  
-  <Step title="Enable Gmail API">
-    1. Go to **APIs & Services** → **Library**
-    2. Search "Gmail API"
-    3. Click **Enable**
-  </Step>
-  
-  <Step title="Create OAuth credentials">
-    1. Go to **APIs & Services** → **Credentials**
-    2. Click **+ CREATE CREDENTIALS** → **OAuth client ID**
-    3. If prompted for consent screen:
-       - Choose **External**
-       - Fill in app name and email
-       - Save
-    4. Application type: **Desktop app**
-    5. Name: anything (e.g., "NanoClaw Gmail")
-  </Step>
-  
-  <Step title="Download credentials">
-    1. Click **DOWNLOAD JSON**
-    2. Save as `gcp-oauth.keys.json`
-  </Step>
-  
-  <Step title="Move to config directory">
-    ```bash
-    mkdir -p ~/.gmail-mcp
-    cp /path/to/gcp-oauth.keys.json ~/.gmail-mcp/gcp-oauth.keys.json
-    ```
-  </Step>
-</Steps>
-
-## Authorization
-
-After placing the OAuth credentials file, authorize Gmail access:
-
-```bash
-npx -y @gongrzhe/server-gmail-autoauth-mcp auth
-```
-
-A browser window will open:
-
-1. Sign in to your Google account
-2. If you see "app isn't verified" warning:
-   - Click **Advanced**
-   - Click **Go to [app name] (unsafe)**
-   - This is normal for personal OAuth apps
-3. Grant the requested permissions
-
-Credentials are saved to `~/.gmail-mcp/credentials.json`.
+Two things are already there before you add anything: the built-in `nanoclaw` MCP server (messaging, scheduling, sub-agents — see [Agent MCP tools](/reference/mcp-tools)), and web access via the `agent-browser` container skill (below).
 
 <Note>
-  The MCP server automatically refreshes OAuth tokens. You only need to authorize once unless you revoke access.
+**Landed here looking for the Gmail channel?** Gmail was a channel in v1 — it polled your inbox and triggered the agent on new emails. In v2 it's an MCP **tool**: `/add-gmail-tool` gives the agent the ability to read, search, and send email, but inbound email does not trigger the agent. An inbound Gmail channel hasn't been ported to v2's channel architecture.
 </Note>
 
-## Build and restart
+## Gmail
 
-After authorization:
+`/add-gmail-tool` wires the [`@gongrzhe/server-gmail-autoauth-mcp`](https://github.com/GongRzhe/Gmail-MCP-Server) stdio server into the groups you pick. The agent sees the tools as `mcp__gmail__<name>` (from `gmail-mcp@1.1.11`):
 
-<Steps>
-  <Step title="Clear stale agent runners">
-    ```bash
-    rm -r data/sessions/*/agent-runner-src 2>/dev/null || true
-    ```
-    
-    This ensures new group agents get the updated runner with Gmail support.
-  </Step>
-  
-  <Step title="Rebuild container">
-    ```bash
-    cd container && ./build.sh
-    ```
-  </Step>
-  
-  <Step title="Rebuild and restart">
-    ```bash
-    npm run build
-    launchctl kickstart -k gui/$(id -u)/com.nanoclaw  # macOS
-    # or: systemctl --user restart nanoclaw (Linux)
-    ```
-  </Step>
-</Steps>
+| Area | Tools |
+| --- | --- |
+| Search & read | `search_emails`, `read_email`, `download_attachment` |
+| Send & draft | `send_email`, `draft_email` |
+| Modify & delete | `modify_email`, `delete_email`, `batch_modify_emails`, `batch_delete_emails` |
+| Labels | `list_email_labels`, `create_label`, `update_label`, `delete_label`, `get_or_create_label` |
+| Filters | `list_filters`, `get_filter`, `create_filter`, `create_filter_from_template`, `delete_filter` |
 
-## Testing Gmail tools
+OAuth follows v2's credential invariant — containers never hold raw tokens. You connect Gmail once in the OneCLI web UI; the skill writes **stub files** (`~/.gmail-mcp/`) whose values are the `"onecli-managed"` placeholder. The MCP server starts happily against the stubs, and the vault's gateway rewrites `Authorization: Bearer onecli-managed` to the real OAuth token in flight to `gmail.googleapis.com`. Full mechanics in [Credentials](/operate/credentials#credential-stubs).
 
-Send a message in your main channel:
+The skill installs the MCP server into the container image, registers it per group with `ncl groups config add-mcp-server`, and mounts the stub directory. To test: ask the agent to *"list my gmail labels"* — the first call takes a moment while the server starts and the vault does the token exchange.
 
-```
-@Andy check my recent emails
-```
+## Google Calendar
 
-or
+`/add-gcal-tool` is a direct sibling of the Gmail skill — same stub-credential pattern, separate install and removal. It wires [`@cocal/google-calendar-mcp`](https://github.com/cocal-com/google-calendar-mcp) (chosen for multi-calendar and multi-account support), surfaced as `mcp__calendar__<name>`: list/search/create/update/delete events, list calendars, free/busy queries, and current time.
 
-```
-@Andy list my Gmail labels
-```
+## Local models as tools
 
-The agent should use the Gmail MCP tools to respond.
+Two skills let Claude offload work to local models. In both cases **Claude stays the orchestrator** — it decides when to delegate, calls the local model as a tool, and uses the result.
 
-### Check MCP server
+| Skill | What it adds |
+| --- | --- |
+| `/add-ollama-tool` | `ollama_list_models` and `ollama_generate` against the host's [Ollama](https://ollama.com) daemon. Set `OLLAMA_ADMIN_TOOLS=true` to also expose model management (`pull`, `delete`, `show`, `list_running`). Keyless — the only config is the daemon URL. |
+| `/add-atomic-chat-tool` | `atomic_chat_list_models` and `atomic_chat_generate` against the [Atomic Chat](https://github.com/AtomicBot-ai/Atomic-Chat) desktop app's OpenAI-compatible API on port 1337. |
 
-Test the MCP server directly:
+<Note>
+Don't confuse `/add-ollama-tool` with `/add-ollama-provider`. The tool skill keeps Claude as the agent's brain and gives it a local model to call; the provider skill **replaces** the agent's brain with a local Ollama model for an entire group. See [Providers](/extend/providers).
+</Note>
+
+## Web access
+
+Every agent can already browse the web. The `agent-browser` container skill ships in `container/skills/`, which is mounted read-only into every container — and the container config's `skills` field defaults to `"all"`, so it's available without any setup.
+
+It teaches the agent the `agent-browser` CLI: navigate to URLs, snapshot pages as accessibility trees with element refs, click and fill forms, extract text and attributes, take screenshots, save PDFs, run JavaScript, and persist login state across sessions. The agent uses it on its own whenever a browser helps — research, reading articles, interacting with web apps — not just when you ask explicitly.
+
+Which container skills a group gets is controlled per group — see [Container config](/reference/container-config#skills).
+
+## Bring your own MCP server
+
+Any stdio MCP server can be added to a group without a skill. Register it in the group's container config:
 
 ```bash
-npx -y @gongrzhe/server-gmail-autoauth-mcp
+ncl groups config add-mcp-server \
+  --id <group-id> \
+  --name github \
+  --command npx \
+  --args '["-y", "@modelcontextprotocol/server-github"]' \
+  --env '{}'
 ```
 
-If working, you'll see the MCP server protocol handshake. Press Ctrl+C to exit.
+`--args` and `--env` are optional JSON. The server is merged with the built-in `nanoclaw` server at runner startup, and the agent's allow-pattern (`mcp__github__*`) is derived automatically from the server name. The change lands in the central database and takes effect on the group's next container spawn — restart the group (`ncl groups restart --id <group-id>`) to pick it up immediately.
 
-## Channel mode setup
+Run from inside an agent's container, `ncl` write commands are approval-gated; from a host operator shell they execute immediately. Remove with `ncl groups config remove-mcp-server --id <group-id> --name github`. The optional `instructions` field (composed into the group's CLAUDE.md) can't be set through `ncl` as of v2.1.4 — see [Container config](/reference/container-config#mcp_servers).
 
-If you chose channel mode, the agent monitors your inbox for new emails.
-
-### Default filter
-
-By default, only emails in the **Primary** inbox trigger the agent:
-
-```typescript
-const query = 'is:unread category:primary';
-```
-
-This excludes:
-
-- Promotions
-- Social
-- Updates
-- Forums
-
-### Custom filters
-
-Edit `src/channels/gmail.ts` to customize the filter:
-
-```typescript
-// Only from specific sender
-const query = 'is:unread from:boss@company.com';
-
-// Only with specific label
-const query = 'is:unread label:important';
-
-// Only matching keywords
-const query = 'is:unread (urgent OR asap)';
-```
-
-See [Gmail search operators](https://support.google.com/mail/answer/7190) for full query syntax.
-
-### Email notifications
-
-When an email triggers the agent, it notifies via your main channel:
-
-```
-[Email from: sender@example.com]
-Subject: Meeting tomorrow
-
-Body preview (first 500 chars)...
-```
-
-The agent sees this notification but **does not reply to the email** unless you explicitly ask it to.
-
-### CLAUDE.md instructions
-
-The skill adds these instructions to `groups/main/CLAUDE.md`:
-
-```markdown
-## Email Notifications
-
-When you receive an email notification (messages starting with `[Email from ...`),
-inform the user about it but do NOT reply to the email unless specifically asked.
-You have Gmail tools available—use them only when the user explicitly asks you to
-reply, forward, or take action on an email.
-```
-
-This prevents the agent from auto-replying to every email.
-
-## JID format
-
-In channel mode, emails use the `gmail:` prefix:
-
-- **Email:** `gmail:<message-id>`
-
-Example: `gmail:18d4a2f8e6c9b1a3`
-
-## Implementation details
-
-### Tool-only mode
-
-The agent runner includes the Gmail MCP server:
-
-```typescript
-const mcpServers = {
-  gmail: {
-    command: 'npx',
-    args: ['-y', '@gongrzhe/server-gmail-autoauth-mcp'],
-  },
-};
-```
-
-The `~/.gmail-mcp` directory is mounted read-write into the container:
-
-```typescript
-const volumes = [
-  `${os.homedir()}/.gmail-mcp:/home/node/.gmail-mcp:rw`,
-];
-```
-
-### Channel mode
-
-The Gmail channel polls for unread emails every 60 seconds:
-
-```typescript
-export class GmailChannel implements Channel {
-  name = 'gmail';
-  
-  async connect(): Promise<void> {
-    this.auth = await this.authorize();
-    this.gmail = google.gmail({ version: 'v1', auth: this.auth });
-    
-    // Poll every 60 seconds
-    setInterval(() => this.checkInbox(), 60000);
-  }
-  
-  private async checkInbox() {
-    const res = await this.gmail.users.messages.list({
-      userId: 'me',
-      q: 'is:unread category:primary',
-    });
-    
-    for (const message of res.data.messages || []) {
-      const msg = await this.gmail.users.messages.get({
-        userId: 'me',
-        id: message.id!,
-      });
-      
-      // Notify via main channel
-      this.opts.onMessage(`gmail:${message.id}`, {
-        id: message.id!,
-        chat_jid: `gmail:${message.id}`,
-        sender: this.getHeader(msg, 'From'),
-        sender_name: this.getHeader(msg, 'From'),
-        content: this.formatEmailNotification(msg),
-        timestamp: new Date().toISOString(),
-        is_from_me: false,
-        is_bot_message: false,
-      });
-      
-      // Mark as read
-      await this.gmail.users.messages.modify({
-        userId: 'me',
-        id: message.id!,
-        requestBody: { removeLabelIds: ['UNREAD'] },
-      });
-    }
-  }
-}
-```
-
-## Troubleshooting
-
-<AccordionGroup>
-  <Accordion title="OAuth token expired">
-    Re-authorize:
-    
-    ```bash
-    rm ~/.gmail-mcp/credentials.json
-    npx -y @gongrzhe/server-gmail-autoauth-mcp
-    ```
-    
-    Then rebuild and restart.
-  </Accordion>
-  
-  <Accordion title="Container can't access Gmail">
-    Verify the mount in `src/container-runner.ts`:
-    
-    ```typescript
-    `${os.homedir()}/.gmail-mcp:/home/node/.gmail-mcp:rw`
-    ```
-    
-    Check container logs:
-    
-    ```bash
-    cat groups/main/logs/container-*.log | tail -50
-    ```
-  </Accordion>
-  
-  <Accordion title="Emails not being detected (channel mode)">
-    Check the filter query in `src/channels/gmail.ts`. The default is:
-    
-    ```typescript
-    q: 'is:unread category:primary'
-    ```
-    
-    Check logs for Gmail polling errors:
-    
-    ```bash
-    tail -f logs/nanoclaw.log | grep -i gmail
-    ```
-  </Accordion>
-  
-  <Accordion title="Gmail connection not working">
-    Test the MCP server directly:
-    
-    ```bash
-    npx -y @gongrzhe/server-gmail-autoauth-mcp
-    ```
-    
-    Should show MCP protocol handshake. If it errors, check:
-    
-    - `~/.gmail-mcp/gcp-oauth.keys.json` exists
-    - `~/.gmail-mcp/credentials.json` exists (run auth if missing)
-  </Accordion>
-</AccordionGroup>
-
-## Available Gmail tools
-
-The MCP server provides these tools to your agent:
-
-| Tool | Description |
-|------|-------------|
-| `mcp__gmail__send_email` | Send an email (to, subject, body) |
-| `mcp__gmail__read_email` | Read a specific email by message ID |
-| `mcp__gmail__search_emails` | Search emails using Gmail query syntax |
-| `mcp__gmail__create_draft` | Create a draft email |
-| `mcp__gmail__list_labels` | List all Gmail labels |
-
-### Example usage
-
-Ask your agent:
-
-```
-@Andy search my emails for "project alpha" from last week
-```
-
-```
-@Andy send an email to team@company.com with subject "Weekly update" and body "Here's the update..."
-```
-
-```
-@Andy create a draft reply to the email from John about the meeting
-```
-
-## Removing Gmail
-
-To remove the Gmail skill and revert to a Gmail-free setup:
-
-<Steps>
-  <Step title="Find the merge commit">
-    ```bash
-    git log --merges --oneline | grep gmail
-    ```
-
-    Look for a commit like `abc1234 Merge remote-tracking branch 'upstream/skill/gmail'`.
-  </Step>
-
-  <Step title="Revert the merge">
-    ```bash
-    git revert -m 1 <merge-commit>
-    ```
-
-    This creates a new commit that undoes all of Gmail's code changes.
-  </Step>
-
-  <Step title="Rebuild and restart">
-    ```bash
-    npm install
-    npm run build
-    ```
-
-    <CodeGroup>
-    ```bash macOS
-    launchctl kickstart -k gui/$(id -u)/com.nanoclaw
-    ```
-
-    ```bash Linux
-    systemctl --user restart nanoclaw
-    ```
-    </CodeGroup>
-  </Step>
-</Steps>
-
-See [removing a skill](/extend/overview#removing-a-skill) for details.
+If your server needs a credential, don't put a raw key in `--env` — connect the service in the OneCLI vault and let the gateway inject it, or use the stub pattern the Gmail skill demonstrates. See [Credentials](/operate/credentials).
 
 ## Next steps
 
 <CardGroup cols={2}>
-  <Card title="Skills system" icon="puzzle-piece" href="/extend/overview">
-    Learn more about how skills work
+  <Card title="Skills catalog" icon="list" href="/reference/skills-catalog#tool-installs">
+    All ten tool-install skills, including dashboard, memory, and Vercel
   </Card>
-  
-  <Card title="Add Telegram" icon="telegram" href="/channels/telegram">
-    Add Telegram support to your installation
+  <Card title="Agent MCP tools" icon="screwdriver-wrench" href="/reference/mcp-tools">
+    The built-in nanoclaw server every agent already has
   </Card>
-  
-  <Card title="Add Discord" icon="discord" href="/channels/discord">
-    Add Discord support to your installation
+  <Card title="Credentials" icon="key" href="/operate/credentials">
+    How the vault keeps raw tokens out of containers
+  </Card>
+  <Card title="Container config" icon="box" href="/reference/container-config">
+    The full mcp_servers, skills, and mounts reference
   </Card>
 </CardGroup>

--- a/extend/writing-skills.mdx
+++ b/extend/writing-skills.mdx
@@ -23,7 +23,7 @@ Instructions here...
 ```
 
 - `name` — lowercase, alphanumeric plus hyphens, max 64 characters. This becomes the slash command (`/my-skill`).
-- `description` — required, and load-bearing: **it's how Claude decides whether to invoke the skill**. Write what it does *and* when to use it. `manage-mounts` even lists its trigger phrases: `Triggers on "mounts", "mount allowlist", "agent access to directories"`.
+- `description` — required, and load-bearing: **it's how Claude decides whether to invoke the skill**. Write what it does *and* when to use it. `manage-mounts` even lists its trigger phrases: `Triggers on "mounts", "mount allowlist", "agent access to directories", "container mounts"`.
 
 The body is prose an agent can run. Real skills converge on the same shape: a pre-flight check, numbered steps, then a build-and-validate step at the end. Keep it under 500 lines — move detail to separate reference files in the skill directory — and put code in separate files, never inline in the markdown.
 
@@ -33,11 +33,11 @@ Apply must be **idempotent**: upgrades re-run it (`/update-skills` works by re-r
 
 **Pre-flight check.** Start with an explicit "is this already applied?" gate. From `add-telegram`:
 
-> Skip to **Credentials** if all of these are already in place: `src/channels/telegram.ts` [...] exists, `src/channels/index.ts` contains `import './telegram.js';`, `@chat-adapter/telegram` is listed in `package.json` dependencies. Otherwise continue. Every step below is safe to re-run.
+> Skip to **Credentials** if all of these are already in place: `src/channels/telegram.ts` [...] exists, `src/channels/index.ts` contains `import './telegram.js';`, [...] `@chat-adapter/telegram` is listed in `package.json` dependencies. Otherwise continue. Every step below is safe to re-run.
 
 Each individual step also carries its own guard ("skip if already present") so a partial apply completes instead of duplicating lines.
 
-**Pinned versions.** Dependencies install at an exact version — `pnpm install @chat-adapter/telegram@4.27.0`, never `latest`. Same for Dockerfile-installed binaries: pin with an `ARG <X>_VERSION=` line.
+**Pinned versions.** Dependencies install at an exact version — `pnpm install @chat-adapter/telegram@<exact-version>`, never `latest`. Same for Dockerfile-installed binaries: pin with an `ARG <X>_VERSION=` line.
 
 **Present-tense DO steps only.** A skill is a standalone artifact with no memory of its own edits. No "earlier versions did X", no "no changes needed here" — those are flagged anti-patterns. So is a separate VERIFY.md: tests are the verification, and the final step is always `pnpm run build` plus running the skill's own tests.
 

--- a/extend/writing-skills.mdx
+++ b/extend/writing-skills.mdx
@@ -1,0 +1,119 @@
+---
+title: "Writing skills"
+description: "How to author a NanoClaw skill: SKILL.md anatomy, idempotent apply steps, REMOVE.md, registration tests, and the path from a private skill to an upstream PR."
+tag: "NEW"
+keywords: ["writing skills", "SKILL.md", "REMOVE.md", "skill authoring", "idempotency", "registration test", "skill-guidelines", "vitest", "integration points"]
+---
+
+{/* verified-against: docs/skill-guidelines.md, CONTRIBUTING.md, vitest.skills.config.ts, .claude/skills/{add-telegram,manage-mounts,update-skills,add-ollama-tool}/SKILL.md, .claude/skills/add-telegram/REMOVE.md @ dc34ceb (v2.1.4) */}
+
+A skill is a markdown file that Claude Code executes — there's no engine to integrate with, so writing one is mostly writing good instructions. The bar upstream holds skills to is [docs/skill-guidelines.md](https://github.com/nanocoai/nanoclaw/blob/main/docs/skill-guidelines.md), and it boils down to two principles: **minimal integration surface** (mostly add files; keep reach-ins into existing code to a line or two that calls your own code) and **a test for every functional integration point** (one that goes red if the wiring is deleted or drifts). This page covers the conventions; [the overview](/extend/overview) explains the model.
+
+## Anatomy of a SKILL.md
+
+Every skill is a directory under `.claude/skills/<name>/` with a `SKILL.md` in the [Claude Code skills format](https://code.claude.com/docs/en/skills):
+
+```markdown
+---
+name: my-skill
+description: What this skill does and when to use it.
+---
+
+Instructions here...
+```
+
+- `name` — lowercase, alphanumeric plus hyphens, max 64 characters. This becomes the slash command (`/my-skill`).
+- `description` — required, and load-bearing: **it's how Claude decides whether to invoke the skill**. Write what it does *and* when to use it. `manage-mounts` even lists its trigger phrases: `Triggers on "mounts", "mount allowlist", "agent access to directories"`.
+
+The body is prose an agent can run. Real skills converge on the same shape: a pre-flight check, numbered steps, then a build-and-validate step at the end. Keep it under 500 lines — move detail to separate reference files in the skill directory — and put code in separate files, never inline in the markdown.
+
+## Conventions that make a skill safe to re-run
+
+Apply must be **idempotent**: upgrades re-run it (`/update-skills` works by re-running each installed skill's own apply), and a skill that half-applies twice is a bug. Three conventions from the in-tree skills:
+
+**Pre-flight check.** Start with an explicit "is this already applied?" gate. From `add-telegram`:
+
+> Skip to **Credentials** if all of these are already in place: `src/channels/telegram.ts` [...] exists, `src/channels/index.ts` contains `import './telegram.js';`, `@chat-adapter/telegram` is listed in `package.json` dependencies. Otherwise continue. Every step below is safe to re-run.
+
+Each individual step also carries its own guard ("skip if already present") so a partial apply completes instead of duplicating lines.
+
+**Pinned versions.** Dependencies install at an exact version — `pnpm install @chat-adapter/telegram@4.27.0`, never `latest`. Same for Dockerfile-installed binaries: pin with an `ARG <X>_VERSION=` line.
+
+**Present-tense DO steps only.** A skill is a standalone artifact with no memory of its own edits. No "earlier versions did X", no "no changes needed here" — those are flagged anti-patterns. So is a separate VERIFY.md: tests are the verification, and the final step is always `pnpm run build` plus running the skill's own tests.
+
+## REMOVE.md
+
+`REMOVE.md` is required **exactly when apply leaves anything behind**. A pure instruction-only skill that copies nothing needs none. When it's required, it must reverse *every* change apply made — the most common review rejection is an incomplete one. `add-telegram`'s REMOVE.md is the template; it mirrors the apply step for step:
+
+1. Delete the barrel import line from `src/channels/index.ts` (delete, never comment out), then `rm` every copied file — adapter, helpers, setup step, *and tests*
+2. Delete the `STEPS` map entry from `setup/index.ts`
+3. Remove the skill's env vars from `.env` and re-sync to the container
+4. `pnpm uninstall` the dependency
+5. Rebuild and restart the service
+
+Each removal step is itself idempotent ("skip if already gone").
+
+## Testing your skill
+
+Every reach-in with a functional consequence gets a test that goes red if the wiring is deleted or drifts. Tests targeting host code use vitest; container code uses `bun:test` under `container/agent-runner/`. Tests **travel with the skill** — they ship in the skill's directory (or on the registry branch) and apply copies them into the project tree, so they run against the composed system via `pnpm test`. There's also a dedicated config, `vitest.skills.config.ts`, that picks up tests under `.claude/skills/**/tests/` — run it with `pnpm exec vitest run --config vitest.skills.config.ts`.
+
+The most common shape is the **registration test**: import the real barrel, assert the registry contains your entry. `add-telegram`'s `telegram-registration.test.ts` imports `src/channels/index.ts` and asserts `telegram` is registered — it goes red if the import line is deleted, if the barrel fails to evaluate, *or* if the adapter package isn't installed (the unmocked import throws), so it guards the dependency for free. Don't test your function directly instead: calling your own code bypasses the wiring and stays green when the barrel line is deleted.
+
+When the edit lives somewhere you can't invoke (a `main()` call, a container boot file), fall back to a **structural test**. `add-ollama-tool` ships one that parses the container's `index.ts` with the TypeScript compiler API and asserts the `mcpServers` object literal has an `ollama` entry pointing at the right module.
+
+Two rules apply across all of them: mock only genuinely external services (a fake HTTP server, stubbed creds), never the package you're guarding; and `pnpm run build` is an always-on leg, because typed drift slips past runtime tests. Finally, the robustness check from the guidelines: apply your skill with a small, cheap model. If it fumbles the instructions, the instructions are too vague — fix them, don't blame the model.
+
+## A minimal template
+
+A template for a small operational skill — instruction-only, so no REMOVE.md and no integration tests, just idempotent steps. Adapt the phases to your task:
+
+````markdown
+---
+name: rotate-agent-logs
+description: Archive and truncate NanoClaw agent logs. Triggers on "rotate logs",
+  "logs too big", "archive agent logs".
+---
+
+# Rotate Agent Logs
+
+## Pre-flight
+
+Check `ls data/logs/*.log` — if no log file exceeds 50MB, tell the user
+nothing needs rotating and stop. Every step below is safe to re-run.
+
+## 1. Archive
+
+For each oversized log, copy it to `data/logs/archive/<name>-<date>.log.gz`
+(create the directory if missing, skip files already archived today).
+
+## 2. Truncate and restart
+
+Truncate the rotated logs, then restart the service so file handles reopen:
+
+```bash
+source setup/lib/install-slug.sh
+launchctl kickstart -k gui/$(id -u)/$(launchd_label)  # macOS
+systemctl --user restart $(systemd_unit)              # Linux
+```
+
+## Verify
+
+Confirm the archive files exist and the live logs are small again. Report
+both paths to the user.
+````
+
+## Private skill or upstream contribution?
+
+**For your own install**, just create the directory: drop `.claude/skills/<name>/SKILL.md` into your checkout and Claude Code picks it up as `/<name>` — no registration, no build step. This is the right home for anything specific to your setup, and where every skill should start.
+
+**To contribute upstream**, your skill needs to be useful beyond your own setup and meet the guidelines bar above. Upstream recognizes four types — channel/provider skills (code on the registry branches), utility skills (code files in the skill directory), operational skills (instructions only), and container skills (`container/skills/`, loaded by the agent inside the container) — each with its own PR path. See [Contributing](/concepts/contributing) for the flow, and note that for channel and provider skills you PR against `main` and maintainers land the code on the registry branch from your work.
+
+<Warning>
+Skills are not sandboxed. Unlike agent containers, a skill runs in your Claude Code session on the host, with whatever permissions that session has — read untrusted skills before running them.
+</Warning>
+
+## Related pages
+
+- [Skills: how NanoClaw extends itself](/extend/overview) — the model: additive fetch, registry branches, the skill categories
+- [Contributing](/concepts/contributing) — repo layout, test configs, and the upstream PR flow
+- [Skills catalog](/reference/skills-catalog) — every skill that ships with NanoClaw, for more worked examples


### PR DESCRIPTION
PR 7 of 9 (spec: docs/superpowers/specs/2026-06-10-docs-portal-v2-refactor-design.md). Verified against nanocoai/nanoclaw trunk@dc34ceb (v2.1.4) + the channels/providers registry branches.

## Pages
- **extend/overview** (rewritten): the REAL v2 skills model, with an explicit correction Note — this URL used to document skills-as-git-branches, which v2 never shipped
- **extend/tools** (rewritten): Gmail-is-not-a-channel correction, all 19 mcp__gmail__* tools, gcal/ollama-tool/atomic-chat, agent-browser web access, BYO MCP server
- **extend/providers** (rewritten): the two mechanisms (OpenCode/Codex real provider code vs Ollama env-only), resolution order, verified capability differences
- **extend/self-modification** (NEW): the two approval-gated ops, free-edit boundaries, revert story
- **extend/writing-skills** (NEW): SKILL.md anatomy, idempotency/REMOVE.md/test conventions per skill-guidelines.md, authoring template

## Code-first catches
- OpenCode uses a shared runtime; Codex is spawn-per-query (skill docs had it backwards)
- A 40K-compaction claim existing only in SKILL.md prose was kept out (no code support)
- sessions.agent_provider is resolved but nothing on trunk sets it — documented honestly
- vitest.skills.config globs a tests/ layout no skill actually uses (upstream nit)
- All stray adapter version pins removed in favor of placeholders (upstream SKILL.md pins drift from installer pins)

Validation: mint validate ✅ · mint broken-links ✅