### PR TITLE
docs: Build-with-agents tutorials — first agent, customization, schedules, multi-agent

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -149,7 +149,7 @@
           {
             "group": "Build with agents",
             "icon": "wand-magic-sparkles",
-            "pages": ["guides/scheduled-tasks", "guides/multi-agent-swarm", "guides/customize-an-agent"]
+            "pages": ["guides/first-agent", "guides/customize-an-agent", "guides/scheduled-tasks", "guides/multi-agent-swarm"]
           },
           {
             "group": "Extend",

--- a/guides/customize-an-agent.mdx
+++ b/guides/customize-an-agent.mdx
@@ -54,7 +54,11 @@ You can edit the same file yourself — useful for longer instructions you'd rat
 ncl groups restart --id <agent-id>
 ```
 
-If you'd rather be guided than edit files, run `/customize` in Claude Code from your NanoClaw checkout. It's an interactive skill: it asks what you want to change, hands off to a dedicated skill when one exists (`/add-telegram`, `/manage-channels`, `/manage-mounts`, ...), and otherwise routes the change to the right surface — `CLAUDE.local.md` for persona, container config for runtime behavior, wirings for triggers.
+If you'd rather be guided than edit files, run `/customize` in Claude Code from your NanoClaw checkout. It's an interactive skill: it asks what you want to change, hands off to a dedicated skill when one exists (`/add-telegram`, `/manage-channels`, `/manage-mounts`, ...), and otherwise routes the change to the right surface — the agent group's memory file for persona, container config for runtime behavior, wirings for triggers.
+
+<Note>
+As of v2.1.4 the `/customize` skill's own text still points persona edits at the composed `groups/<folder>/CLAUDE.md`. Follow this tutorial instead: edit `CLAUDE.local.md` — anything written to the composed file is clobbered at the next spawn.
+</Note>
 
 </Step>
 <Step title="Swap the brain">
@@ -68,7 +72,7 @@ ncl groups config update --id <agent-id> --model sonnet --effort low
 - `--model` takes an alias (`sonnet`, `opus`, `haiku`) or a full model ID. Unset means the SDK default.
 - `--effort` is one of `low`, `medium`, `high`, `xhigh`, `max`.
 
-Config changes are saved but **do not take effect until you restart** — the values are read once at spawn:
+Config values are read at every spawn, so a running container keeps its old config — the change applies to the next container automatically. To force it now:
 
 ```bash
 ncl groups restart --id <agent-id>
@@ -105,7 +109,7 @@ It's nothing but a header and imports — the shared base plus per-skill fragmen
 
 ## What you changed
 
-Two surfaces, two mechanisms: personality went into a file the agent and you co-own (`CLAUDE.local.md`, applied at next spawn), the brain went into a DB row (`container_configs`, applied at next restart). The third surface — capabilities — works differently because it can change what the agent is able to *do*, so it goes through admin approval.
+Two surfaces, two mechanisms: personality went into a file the agent and you co-own (`CLAUDE.local.md`), the brain went into a DB row (`container_configs`). Both are read at container spawn — edits apply to the next container, and `ncl groups restart` forces one now. The third surface — capabilities — works differently because it can change what the agent is able to *do*, so it goes through admin approval.
 
 ## Next steps
 

--- a/guides/customize-an-agent.mdx
+++ b/guides/customize-an-agent.mdx
@@ -1,240 +1,114 @@
 ---
-title: Customize NanoClaw
-description: Change behavior by editing code, wiring agent groups, and installing skills — no config-file sprawl.
+title: "Customize an agent"
+description: "Hands-on tutorial: change an agent's personality through CLAUDE.local.md, swap its model and effort with ncl, and verify the changes landed."
 tag: "UPDATED"
-keywords: ["customize", "config", "trigger", "engage mode", "mount allowlist", "env vars", "buildTriggerPattern"]
+keywords: ["customize", "CLAUDE.local.md", "personality", "model", "effort", "ncl groups config update", "self-customize", "/customize"]
 ---
 
-NanoClaw doesn't rely on large configuration files. Instead, customizations fall into four lanes:
+{/* verified-against: src/claude-md-compose.ts, src/container-runner.ts, src/cli/resources/groups.ts, container/agent-runner/src/providers/types.ts, container/skills/self-customize/SKILL.md, .claude/skills/customize/SKILL.md @ dc34ceb (v2.1.4) */}
 
-1. **Code changes** — for behavior baked into the orchestrator (trigger pattern, polling, timeouts)
-2. **Wiring settings** — per-messaging-group config stored in the central DB (engage mode, sender scope, session mode)
-3. **Skills** — for features and integrations (install via `/add-<name>`, uninstall via `git revert`)
-4. **Mount allowlist** — for which host directories an agent can see
+This tutorial customizes the Scout agent from [your first agent](/guides/first-agent) — any agent group works, just swap the folder and `--id`. An agent has three customization surfaces:
 
-## Philosophy
+1. **Personality and rules** — `groups/<folder>/CLAUDE.local.md`, the agent's editable persistent memory
+2. **Brain** — model, reasoning effort, and other [container config](/reference/container-config) fields, edited with `ncl`
+3. **Capabilities** — packages and MCP servers, which go through the approval flow covered in [self-modification](/extend/self-modification)
 
-<Note>
-**From the README:**
-
-> NanoClaw doesn't use configuration files. To make changes, just tell Claude Code what you want... The codebase is small enough that Claude can safely modify it.
-</Note>
-
-The result: your fork does exactly what you asked for, and nothing else. No generic system to learn — just the code you want, readable by you and by Claude Code.
-
-## Change the trigger word
-
-The default is `@Andy`, derived from `ASSISTANT_NAME` in `src/config.ts`:
-
-```typescript
-// src/config.ts (verified v2)
-export const ASSISTANT_NAME = process.env.ASSISTANT_NAME || envConfig.ASSISTANT_NAME || 'Andy';
-
-export function buildTriggerPattern(trigger: string): RegExp {
-  return new RegExp(`^${escapeRegex(trigger.trim())}\\b`, 'i');
-}
-
-export const DEFAULT_TRIGGER = `@${ASSISTANT_NAME}`;
-export const TRIGGER_PATTERN = buildTriggerPattern(DEFAULT_TRIGGER);
-```
-
-To change it, update `.env`:
-
-```bash
-ASSISTANT_NAME=Bob
-```
-
-Or ask Claude Code:
-
-```
-@Andy change the trigger word to @Bob
-```
-
-Claude updates `.env`, restarts the service, and verifies the new pattern matches.
-
-## Environment variables
-
-`src/config.ts` reads `ASSISTANT_NAME`, `ASSISTANT_HAS_OWN_NUMBER`, `ONECLI_URL`, `ONECLI_API_KEY`, and `TZ` from `.env` (with `process.env` taking precedence). Everything else is `process.env` only.
-
-<Tabs>
-  <Tab title="OneCLI Agent Vault (default)">
-    ```bash
-    # .env
-    ASSISTANT_NAME=Andy
-    ASSISTANT_HAS_OWN_NUMBER=false
-    ONECLI_URL=http://127.0.0.1:10254
-    # ONECLI_API_KEY=...  # only if your OneCLI instance requires auth
-    TZ=America/Los_Angeles
-    ```
-
-    Credentials are managed by the OneCLI Agent Vault. No API keys live in `.env`.
-  </Tab>
-
-  <Tab title="Legacy credential proxy (opt-in)">
-    ```bash
-    # .env
-    ASSISTANT_NAME=Andy
-    ASSISTANT_HAS_OWN_NUMBER=false
-    ANTHROPIC_API_KEY=sk-ant-...
-    ```
-
-    Requires the `/use-native-credential-proxy` skill (lives at `skill/native-credential-proxy` on upstream). The skill restores the v1-style credential proxy — the host reads `ANTHROPIC_API_KEY` from `.env` and injects it into container traffic via a local proxy on port 3001. Containers never see the raw key.
-  </Tab>
-</Tabs>
-
-### Runtime-tunable settings (process.env only)
-
-| Variable | Default | What it controls |
-|---|---|---|
-| `CONTAINER_IMAGE` | `nanoclaw-agent:latest` | Which image to spawn |
-| `CONTAINER_TIMEOUT` | `1800000` (30 min) | Hard upper bound on a single container run |
-| `CONTAINER_MAX_OUTPUT_SIZE` | `10485760` (10 MB) | Truncation threshold for container stdout |
-| `MAX_MESSAGES_PER_PROMPT` | `10` | How many queued inbound messages join one Claude turn |
-| `IDLE_TIMEOUT` | `1800000` (30 min) | How long a container stays alive after the last response |
-| `MAX_CONCURRENT_CONTAINERS` | `5` | Global cap on active containers |
-
-Bump them like:
-
-```bash
-MAX_CONCURRENT_CONTAINERS=10 systemctl --user restart nanoclaw
-```
-
-Or persist in your systemd / launchd service definition.
-
-## Per-wiring behavior (engage mode, sender scope, session mode)
-
-Every messaging group × agent group wiring (stored in `messaging_group_agents`) has orthogonal settings:
-
-| Setting | Values | Meaning |
-|---|---|---|
-| `engage_mode` | `mention` (default) \| `pattern` \| `mention-sticky` | When the agent reacts: trigger-only, regex match, or trigger-and-then-sticky |
-| `engage_pattern` | regex string | Used when `engage_mode='pattern'`. Sentinel `.` means "match every message" |
-| `sender_scope` | `all` (default) \| `known` | Respond to anyone vs. only users in the agent group's member list |
-| `ignored_message_policy` | `drop` (default) \| `accumulate` | What happens to messages that didn't trigger — forgotten, or carried into the next prompt |
-| `session_mode` | `shared` (default) \| `per-thread` \| `agent-shared` | How sessions are carved: one per messaging group, one per thread, or one across multiple messaging groups |
-
-Change them with the `/manage-channels` skill — it reads/writes the wiring directly without requiring SQL.
-
-## Polling and delivery loops (source-verified)
-
-If you need to tune the delivery cadence, the constants live in `src/delivery.ts` and `src/host-sweep.ts`:
-
-```typescript
-// src/delivery.ts
-const ACTIVE_POLL_MS = 1000;    // running sessions checked every 1s
-const SWEEP_POLL_MS = 60_000;   // liveness/recovery sweep every 60s
-
-// src/host-sweep.ts
-const SWEEP_INTERVAL_MS = 60_000;
-export const CLAIM_STUCK_MS = 60 * 1000;
-export const ABSOLUTE_CEILING_MS = 30 * 60 * 1000;
-```
-
-Most users never change these. If you do, remember: tighter active-poll = more CPU for idle-but-active sessions; looser sweep = slower stuck-detection.
-
-## Memory and per-agent-group prompts
-
-Agent-group memory lives in `groups/<folder>/CLAUDE.md`. Edit it to change the agent's persona, style, or pinned context:
-
-```markdown
-# NanoClaw Assistant
-
-You are Andy, a helpful AI assistant.
-
-## Preferences
-
-- Keep responses concise
-- Use bullet points for lists
-- Always confirm before making changes
-```
-
-`CLAUDE.md` is composed at session start — a shared base plus the per-group fragment. Per-group changes don't affect other agent groups.
-
-## Mount allowlist
-
-Agents only see what you mount. The allowlist lives at `~/.config/nanoclaw/mount-allowlist.json` (outside the project root, never mounted into containers):
-
-```json
-{
-  "allowedRoots": [
-    {
-      "path": "/Users/you/Documents/vault",
-      "allowReadWrite": false,
-      "description": "Personal vault"
-    },
-    {
-      "path": "/Users/you/code/project",
-      "allowReadWrite": true,
-      "description": "Development project"
-    }
-  ],
-  "blockedPatterns": [],
-  "nonMainReadOnly": true
-}
-```
-
-Per-agent-group mount requests live in `groups/<folder>/container.json`. The host validates each request against the allowlist before mounting. See [Security model](/concepts/security) for the full picture.
-
-## The `/customize` skill
-
-For guided changes without memorizing file paths:
-
-```
-/customize
-```
-
-Claude Code asks what you want to change — trigger, behavior, integrations, mounts — and applies the diff after showing it to you.
-
-## Adding channels, providers, and features
-
-Channels and AI providers are skills, not core features. Install from the `channels` or `providers` branch:
-
-```
-/add-telegram       # channel
-/add-codex          # alternate provider (OpenAI)
-/add-ollama-provider  # alternate provider (local models)
-```
-
-See [Integrations overview](/channels/overview) for the full list.
-
-To remove a channel or provider, `git revert` the skill's commit — restores the previous state cleanly.
-
-## Customization workflow
+One file you will **not** edit: `groups/<folder>/CLAUDE.md`. The host regenerates it on every container spawn from a shared base plus skill and MCP fragments, and mounts it read-only into the container. Anything you write there gets clobbered. `CLAUDE.local.md` is the file that's yours (and the agent's).
 
 <Steps>
-  <Step title="Describe what you want">
-    Natural language — `@Andy I want the agent to respond to every message, not just mentions` — works fine.
-  </Step>
+<Step title="Personality, the conversational way">
 
-  <Step title="Claude suggests the change">
-    For wiring changes: `/manage-channels` + update `engage_mode`. For code changes: a diff against `src/config.ts` or elsewhere.
-  </Step>
-
-  <Step title="Review the diff">
-    Claude shows the exact lines before applying.
-  </Step>
-
-  <Step title="Test">
-    Run NanoClaw, verify the change works. If not: `/debug`.
-  </Step>
-</Steps>
-
-## Debugging customizations
+The simplest path is to just tell the agent:
 
 ```bash
-tail -f logs/nanoclaw.log
+pnpm run chat scout "scout, from now on answer in haiku and sign off as 'Scout'"
 ```
 
-Or ask the agent itself:
+The `self-customize` skill (on every agent by default) teaches the agent that `CLAUDE.local.md` edits are free — no approval needed — so it writes the rule into its own `groups/scout/CLAUDE.local.md` through the read-write workspace mount. The current conversation follows the rule immediately because you just said it; the file is what makes it stick for every future session.
 
+Check what it wrote:
+
+```bash
+cat groups/scout/CLAUDE.local.md
 ```
-@Andy why did my engage mode change not take effect?
-@Andy /debug
+
+</Step>
+<Step title="Personality, the direct way">
+
+You can edit the same file yourself — useful for longer instructions you'd rather paste than dictate:
+
+```markdown groups/scout/CLAUDE.local.md
+## Style
+
+- Answer in haiku
+- Sign off as "Scout"
+
+## Standing rules
+
+- Always confirm before deleting anything
 ```
 
-## Related
+**When does this take effect?** Instructions load when a container spawns, so a warm container mid-conversation won't pick up your edit. Either wait — containers exit after idling, and the next message spawns a fresh one — or force it now:
 
-- [Messaging](/channels/overview) — inbound routing and engage evaluation
-- [Scheduled tasks](/guides/scheduled-tasks) — task model and cron
-- [Security](/concepts/security) — sender policies, user roles
-- [Architecture](/concepts/architecture) — two-DB session model
+```bash
+ncl groups restart --id <agent-id>
+```
+
+If you'd rather be guided than edit files, run `/customize` in Claude Code from your NanoClaw checkout. It's an interactive skill: it asks what you want to change, hands off to a dedicated skill when one exists (`/add-telegram`, `/manage-channels`, `/manage-mounts`, ...), and otherwise routes the change to the right surface — `CLAUDE.local.md` for persona, container config for runtime behavior, wirings for triggers.
+
+</Step>
+<Step title="Swap the brain">
+
+Model and reasoning effort live in the agent group's container config, not in any file. Update them with `ncl`:
+
+```bash
+ncl groups config update --id <agent-id> --model sonnet --effort low
+```
+
+- `--model` takes an alias (`sonnet`, `opus`, `haiku`) or a full model ID. Unset means the SDK default.
+- `--effort` is one of `low`, `medium`, `high`, `xhigh`, `max`.
+
+Config changes are saved but **do not take effect until you restart** — the values are read once at spawn:
+
+```bash
+ncl groups restart --id <agent-id>
+```
+
+A cheap-and-fast Scout (`--model haiku --effort low`) is great for routing or lookup duty in a [multi-agent swarm](/guides/multi-agent-swarm); keep `opus` with higher effort for agents that do real work. The same command also takes `--assistant-name`, `--provider`, and more — see the [container config reference](/reference/container-config#fields).
+
+</Step>
+<Step title="Verify">
+
+Ask Scout something and confirm the haiku rule and the model change both took:
+
+```bash
+pnpm run chat scout "which model are you running on?"
+```
+
+You can also peek at the composed file to see why it's off-limits:
+
+```bash
+cat groups/scout/CLAUDE.md
+```
+
+```text
+<!-- Composed at spawn — do not edit. Edit CLAUDE.local.md for per-group content. -->
+@./.claude-shared.md
+@./.claude-fragments/module-self-mod.md
+...
+```
+
+It's nothing but a header and imports — the shared base plus per-skill fragments. Your text isn't in it because it doesn't need to be: Claude Code auto-loads `CLAUDE.local.md` alongside `CLAUDE.md` on every spawn.
+
+</Step>
+</Steps>
+
+## What you changed
+
+Two surfaces, two mechanisms: personality went into a file the agent and you co-own (`CLAUDE.local.md`, applied at next spawn), the brain went into a DB row (`container_configs`, applied at next restart). The third surface — capabilities — works differently because it can change what the agent is able to *do*, so it goes through admin approval.
+
+## Next steps
+
+- [Self-modification](/extend/self-modification) — let the agent install packages and MCP servers, with you as the approval gate
+- [Container config reference](/reference/container-config) — every field, including skills selection and extra mounts
+- [Multi-agent swarm](/guides/multi-agent-swarm) — put your customized agents to work together

--- a/guides/first-agent.mdx
+++ b/guides/first-agent.mdx
@@ -1,0 +1,136 @@
+---
+title: "Your first agent"
+description: "Hands-on tutorial: build an agent from parts with ncl — create the agent group, wire it to the CLI channel, talk to it, and inspect everything it created."
+tag: "NEW"
+keywords: ["tutorial", "first agent", "ncl groups create", "wirings", "messaging group", "cli channel", "pnpm run chat", "CLAUDE.local.md"]
+---
+
+{/* verified-against: src/cli/resources/{groups,wirings,messaging-groups,sessions}.ts, src/cli/crud.ts, src/router.ts, src/channels/cli.ts, scripts/chat.ts, scripts/init-cli-agent.ts, src/group-init.ts, src/container-runner.ts, setup/auto.ts @ dc34ceb (v2.1.4) */}
+
+If you followed the [quickstart](/quickstart), the setup wizard already built your first agent. This tutorial builds a **second** one by hand, so you see every part the wizard hides: an **agent group** (the identity), a **messaging group** (the chat), and a **wiring** (the routing rule connecting them). We'll use the [CLI channel](/channels/cli) — it ships on trunk and needs zero platform credentials.
+
+You need a working install with the host service running, [`ncl`](/operate/ncl-cli) on your PATH (or `pnpm ncl` from the checkout), and Docker up.
+
+<Steps>
+<Step title="Create the agent group">
+
+An agent group is just a row in the central DB plus a folder under `groups/` — but the folder doesn't exist yet, as you'll see.
+
+```bash
+ncl groups create --name "Scout" --folder scout
+```
+
+`ncl` prints the inserted row, including the generated UUID. Save it — every later command takes `--id`:
+
+```json
+{
+  "id": "3f2c9a1e-8b4d-4f6a-9c2e-d51b7a0e6f33",
+  "name": "Scout",
+  "folder": "scout",
+  "created_at": "2026-06-10T09:14:02.511Z"
+}
+```
+
+Now check the filesystem: `ls groups/` — there is **no `scout/` folder**. Creation only writes the DB row. The folder (and the container config, session state, and skills directory) is initialized lazily by `initGroupFilesystem()` the first time a container spawns for this group. An agent that has never been messaged costs nothing.
+
+</Step>
+<Step title="Find the CLI messaging group">
+
+A messaging group is one chat on one platform, identified by a unique (`channel_type`, `platform_id`) pair. The CLI channel hardcodes its platform ID to `local`, and setup leaves the "Local CLI" messaging group in place, so it should already exist:
+
+```bash
+ncl messaging-groups list --channel-type cli
+```
+
+Note the `id` of the row with `platform_id` = `local`. If the list is empty (CLI-less install), create it exactly as the setup script does — `unknown_sender_policy` must be `public` because the terminal's synthetic `cli:local` user holds no role:
+
+```bash
+ncl messaging-groups create --channel-type cli --platform-id local \
+  --name "Local CLI" --unknown-sender-policy public
+```
+
+</Step>
+<Step title="Wire them together">
+
+A wiring tells the router which agent handles messages from which chat, and when it engages:
+
+```bash
+ncl wirings create --messaging-group-id <mg-id> --agent-group-id <agent-id> \
+  --engage-mode pattern --engage-pattern '^[Ss]cout\b'
+```
+
+Two things matter here:
+
+- **`--engage-mode pattern` is required on CLI.** The default mode, `mention`, relies on platform-level @-mentions, which the CLI channel never produces — a `mention` wiring on CLI simply never fires.
+- **The pattern is a JavaScript regex** tested against the message text. `^[Ss]cout\b` engages Scout only when a message starts with its name. Don't use inline flags like `(?i)` — JS regexes reject them, and an invalid pattern fails *open* (the agent responds to everything).
+
+<Warning>
+Routing is fan-out: every wiring on a chat is evaluated independently. Your setup-created agent is wired to this same chat with pattern `.` (match everything), so a message starting with "scout" engages **both** agents and you'll get two replies. To give Scout exclusive ownership of its name, find the original wiring with `ncl wirings list` and narrow it: `ncl wirings update --id <original-wiring-id> --engage-pattern '^(?![Ss]cout\b)'`.
+</Warning>
+
+</Step>
+<Step title="Talk to it">
+
+```bash
+pnpm run chat scout hi, who are you and what can you do
+```
+
+The message hits `data/cli.sock`, the router matches your pattern, creates a session, and spawns a container. First contact is a cold start — expect **30–60 seconds** before the reply prints. Follow-ups to a warm container are much faster, and the session persists server-side, so context carries across invocations.
+
+If nothing comes back after the cold start, check what the router did with the message:
+
+```bash
+ncl dropped-messages list
+```
+
+A `no_agent_engaged` row means your pattern didn't match the text you sent.
+
+</Step>
+<Step title="Inspect what was created">
+
+That first message materialized everything that was lazy in step 1. The group folder now exists:
+
+```bash
+ls groups/scout/
+# CLAUDE.local.md
+```
+
+`CLAUDE.local.md` is the agent's persistent memory, auto-loaded on every spawn. Groups created via `ncl` start with it **empty** — edit it to give Scout a personality and standing instructions (see [customize an agent](/guides/customize-an-agent)).
+
+The session — the runtime unit mapping this (agent, chat) pair to a container — is visible too:
+
+```bash
+ncl sessions list --agent-group-id <agent-id>
+```
+
+Look for `status` = `active` and `container_status` = `running`. And the container itself, named `nanoclaw-v2-<folder>-<timestamp>`:
+
+```bash
+docker ps --filter name=nanoclaw-v2-scout
+```
+
+It stays warm for a while after the conversation, then exits; the host respawns it on the next message. To force a fresh one (with an image rebuild, e.g. after adding packages):
+
+```bash
+ncl groups restart --id <agent-id> --rebuild
+```
+
+</Step>
+</Steps>
+
+## What you built
+
+```mermaid
+graph LR
+    A["pnpm run chat<br/>(CLI channel, cli/local)"] --> B["Messaging group<br/>Local CLI"]
+    B -- "wiring: pattern ^[Ss]cout\b" --> C["Agent group<br/>Scout"]
+    C --> D["Session → container<br/>groups/scout/ + CLAUDE.local.md"]
+```
+
+One agent identity, one chat, one routing rule between them — and a session/container pair that only exists because you sent a message. Every channel in NanoClaw works through these same four pieces; only the adapter changes. See the [entity model](/concepts/entity-model) for the full picture.
+
+## Next steps
+
+- [Customize an agent](/guides/customize-an-agent) — memory, container config, models, packages
+- [Multi-agent swarm](/guides/multi-agent-swarm) — wire several agents that talk to each other
+- [Channels overview](/channels/overview) — wire Scout to WhatsApp, Telegram, Discord, and more

--- a/guides/first-agent.mdx
+++ b/guides/first-agent.mdx
@@ -83,7 +83,7 @@ If nothing comes back after the cold start, check what the router did with the m
 ncl dropped-messages list
 ```
 
-A `no_agent_engaged` row means your pattern didn't match the text you sent.
+A `no_agent_engaged` drop row only appears when no wiring on the chat matched at all — in this tutorial's setup a catch-all (or complementary) pattern always engages one agent, so if the table is empty, check whether the *other* agent answered instead: your message probably didn't start with "scout".
 
 </Step>
 <Step title="Inspect what was created">
@@ -92,10 +92,10 @@ That first message materialized everything that was lazy in step 1. The group fo
 
 ```bash
 ls groups/scout/
-# CLAUDE.local.md
+# CLAUDE.md  CLAUDE.local.md
 ```
 
-`CLAUDE.local.md` is the agent's persistent memory, auto-loaded on every spawn. Groups created via `ncl` start with it **empty** — edit it to give Scout a personality and standing instructions (see [customize an agent](/guides/customize-an-agent)).
+`CLAUDE.md` is the composed instructions file the host regenerates on every spawn — don't edit it. `CLAUDE.local.md` is the agent's editable persistent memory, auto-loaded on every spawn. Groups created via `ncl` start with it **empty** — edit it to give Scout a personality and standing instructions (see [customize an agent](/guides/customize-an-agent)).
 
 The session — the runtime unit mapping this (agent, chat) pair to a container — is visible too:
 

--- a/guides/multi-agent-swarm.mdx
+++ b/guides/multi-agent-swarm.mdx
@@ -1,319 +1,146 @@
 ---
-title: Agent Swarms
-description: Spin up teams of specialized Claude agents that collaborate on complex tasks in your chat
-keywords: ["agent swarms", "multi-agent", "collaboration"]
+title: "Build a multi-agent team"
+description: "Hands-on tutorial: have an agent spawn a helper with create_agent, watch the approval gate, message between them, and scale the pattern to a worker/manager/supervisor trio."
+tag: "UPDATED"
+keywords: ["multi-agent", "create_agent", "agent-to-agent", "agent destinations", "send_message", "sub-agents", "approval", "ncl destinations"]
 ---
 
+{/* verified-against: src/modules/agent-to-agent/{create-agent,agent-route,write-destinations,index}.ts, src/modules/agent-to-agent/db/agent-destinations.ts, src/modules/approvals/primitive.ts, container/agent-runner/src/mcp-tools/agents.ts + agents.instructions.md, container/agent-runner/src/destinations.ts, src/cli/resources/{destinations,groups,wirings}.ts, src/group-init.ts, src/db/messaging-groups.ts @ dc34ceb (v2.1.4) */}
 
-<Warning>
-This page describes the v1 "Agent Swarms" framing. v2 ships **agent-to-agent** primitives instead — `TeamCreate` / `TeamDelete` SDK tools plus the `src/modules/agent-to-agent/` host module for cross-agent message routing within an install. A v2 rewrite is pending. See [Integrations overview](/channels/overview) for current context.
-</Warning>
+The [introduction](/introduction) promises real teams: a worker per task, a manager that tracks what's in flight, a supervisor that pings you. This tutorial builds the smallest working version — one agent spawning and delegating to another — then scales the same three primitives into that trio. It continues from [your first agent](/guides/first-agent); you'll reuse Scout to see the approval gate.
 
-## Overview
+## The model in 60 seconds
 
-NanoClaw is the first personal AI assistant to support **Agent Swarms** - teams of specialized agents that collaborate on complex tasks. This feature is powered by Claude Code's experimental agent teams functionality.
+There is no swarm engine. Multi-agent in NanoClaw is the same three things everything else is:
 
-<Note>
-Agent Swarms is an experimental feature from Claude Code. NanoClaw enables it by default in all agent containers.
-</Note>
+- **Agent groups are fully isolated.** Each agent has its own container, workspace, and memory. Agents never share state — they can only message each other.
+- **Agent-to-agent messages are queue rows.** A message to another agent travels through the same SQLite inbox/outbox pipeline as a WhatsApp message; only `channel_type` differs (`agent` instead of a platform).
+- **Destinations are the permission edges.** A row in `agent_destinations` means "agent A may send to target B, and calls it `local-name`". No row, no delivery — the host rejects unauthorized sends. Channels and agents share one namespace, so messaging an agent is just `send_message` with `to` set to its name.
 
-## What are Agent Swarms?
-
-Agent Swarms allow a single Claude agent to orchestrate multiple sub-agents, each specialized for different tasks. The main agent coordinates the team, delegates work, and synthesizes results.
-
-### Use cases
-
-- **Research projects**: One agent searches the web, another analyzes data, a third writes the report
-- **Code reviews**: One agent checks style, another tests functionality, a third reviews security
-- **Content creation**: One agent researches topics, another drafts content, a third edits and refines
-- **Data processing**: Multiple agents process different data sources in parallel
-
-## How it works
-
-When you give NanoClaw a complex task, the main agent can spawn sub-agents automatically:
-
-```
-@Andy research AI developments this week, analyze trends, and write a detailed report
+```mermaid
+graph TD
+    You["Your DM (channel)"]
+    S["Supervisor"]
+    M["Manager"]
+    W1["Worker 1"]
+    W2["Worker 2"]
+    You <-->|wiring + destination| S
+    S <-->|destination: manager / parent| M
+    M <-->|destination: worker-1 / parent| W1
+    M <-->|destination: worker-2 / parent| W2
 ```
 
-The main agent might:
-1. Spawn a research agent to search and gather information
-2. Spawn an analysis agent to identify patterns and trends
-3. Spawn a writing agent to compile the final report
-4. Coordinate between them and synthesize the results
+Every arrow is one or two `agent_destinations` rows. Each direction is a separate row — A having an edge to B does not give B an edge back.
 
-## Enabling Agent Swarms
+<Steps>
+<Step title="Ask your agent to create a helper">
 
-Agent Swarms are enabled automatically in NanoClaw through the container configuration:
+Message the agent the setup wizard created (the one in your main chat):
 
-```typescript
-// From src/container-runner.ts — session settings
-env: {
-  // Enable agent swarms (subagent orchestration)
-  CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: '1',
-  // ... other settings
-}
+```text
+Create an agent called researcher. Its job: take a research question from you,
+dig in with web search, and report findings back to you with sources.
 ```
 
-This environment variable is set in each group's `.claude/settings.json`:
+The agent calls the `create_agent` MCP tool with a `name` and that role as `instructions`. The call is fire-and-forget — it returns immediately, and the host does the privileged work:
 
-```json
-{
-  "env": {
-    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
-    "CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD": "1",
-    "CLAUDE_CODE_DISABLE_AUTO_MEMORY": "0"
-  }
-}
-```
+1. Inserts an `agent_groups` row. The folder is the normalized name (`researcher`), with a numeric suffix if taken.
+2. Scaffolds `groups/researcher/` and seeds **`CLAUDE.local.md` with the `instructions` text** — that's the new agent's persistent role and personality, editable later like any agent's memory.
+3. Inserts **two destination rows**: the creator gets `researcher` → new agent, and the new agent gets `parent` → creator. The edge is bidirectional from birth, so replies need no extra wiring.
+4. Projects the new destination into the parent's running container immediately, then notifies it: `Agent "researcher" created. You can now message it with <message to="researcher">...</message>.`
 
-<Warning>
-This is an experimental Claude Code feature. Behavior may change in future releases.
-</Warning>
+No container starts yet — like any agent, researcher's container spawns on its first message.
 
-## Agent team architecture
+</Step>
+<Step title="The approval gate">
 
-Each sub-agent runs in its own Claude Code session with:
+Why did that just work without asking you? Authorization depends on the calling group's `cli_scope` in its [container config](/reference/container-config). The wizard's first agent is trusted (`cli_scope: global`), so it creates directly. Every other group — including Scout, since `ncl groups create` leaves the default `group` scope — is a potential prompt-injection victim, so the host queues an approval instead. Ask Scout to create an agent and an approval card lands in an admin DM:
 
-- Independent context and memory
-- Access to the same mounted filesystems as the parent
-- Ability to use all available tools (Bash, browser automation, etc.)
-- Communication channel back to the main orchestrator agent
+> **Create agent: researcher**
+>
+> Agent "Scout" wants to create a new sub-agent "researcher" (a new agent group with its own workspace and container). Approve?
+>
+> [ Approve ] [ Reject ]
 
-### Session isolation
-
-Sub-agents are isolated from each other but coordinated by the main agent:
-
-```
-┌─────────────────────────────────────┐
-│  Main Agent (orchestrator)          │
-│  - Delegates tasks to sub-agents    │
-│  - Coordinates results               │
-│  - Responds to user                  │
-└──────────┬──────────────────────────┘
-           │
-           ├─────────────┬─────────────┬──────────────
-           │             │             │
-    ┌──────▼──────┐ ┌───▼──────┐ ┌────▼─────────┐
-    │ Sub-Agent 1 │ │Sub-Agent2│ │ Sub-Agent 3  │
-    │ (Research)  │ │(Analysis)│ │  (Writing)   │
-    └─────────────┘ └──────────┘ └──────────────┘
-```
-
-## Example interactions
-
-### Research and analysis
-
-```
-@Andy analyze the top 10 posts on Hacker News today, categorize by topic, 
-and identify emerging trends
-```
-
-The agent might spawn:
-- A web scraping agent to fetch HN posts
-- Multiple analysis agents to categorize in parallel
-- A synthesis agent to compile trends
-
-### Multi-source data aggregation
-
-```
-@Andy compile a weekly report from:
-- Recent commits in the GitHub repo
-- Updates in the Slack #engineering channel  
-- Tickets closed in Linear
-```
-
-The agent might spawn:
-- A GitHub agent to analyze commit history
-- A Slack agent to summarize channel activity
-- A Linear agent to fetch closed tickets
-- A reporting agent to compile everything
-
-### Parallel document processing
-
-```
-@Andy summarize all the PDFs in the research folder and create 
-a comparison table
-```
-
-The agent might spawn:
-- Multiple document reading agents (one per PDF)
-- A synthesis agent to create the comparison table
-
-## Memory and context sharing
-
-All agents in a swarm have access to:
-
-- **Group memory**: The `CLAUDE.md` file in the group folder
-- **Mounted directories**: Same filesystem access as the main agent
-- **Additional memory directories**: Via `CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD`
-
-```typescript
-// From src/container-runner.ts — session settings
-env: {
-  // Load CLAUDE.md from additional mounted directories
-  CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD: '1',
-}
-```
-
-This allows sub-agents to read context from:
-- `/workspace/group/CLAUDE.md` (main group memory)
-- `/workspace/project/CLAUDE.md` (for main channel only)
-- `/workspace/global/CLAUDE.md` (read-only shared memory)
-
-## Coordination patterns
-
-The main agent coordinates sub-agents through various patterns:
-
-### Sequential workflow
-
-```
-Main agent:
-1. Spawn research agent → wait for results
-2. Spawn analysis agent with research results → wait
-3. Spawn writing agent with analysis → wait
-4. Return final report to user
-```
-
-### Parallel execution
-
-```
-Main agent:
-1. Spawn 3 research agents in parallel
-2. Wait for all to complete
-3. Synthesize results
-4. Return summary to user
-```
-
-### Hierarchical delegation
-
-```
-Main agent:
-1. Spawn coordinator agent for web research
-   → Coordinator spawns multiple scraper agents
-2. Spawn coordinator agent for data analysis  
-   → Coordinator spawns multiple analysis agents
-3. Synthesize both coordinators' results
-4. Return to user
-```
-
-## Performance considerations
-
-### Container limits
-
-Agent Swarms respect the global concurrent container limit:
-
-```typescript
-// From src/config.ts
-export const MAX_CONCURRENT_CONTAINERS = Math.max(
-  1,
-  parseInt(process.env.MAX_CONCURRENT_CONTAINERS || '5', 10) || 5,
-);
-```
-
-If you use Agent Swarms heavily, consider increasing this limit:
+The approver is picked in order: admins of that agent group → global admins → owners, preferring one reachable on the same channel the request came from. If no owner or admin with a reachable DM exists, the request fails and the agent is told why. To promote an agent you trust to create freely:
 
 ```bash
-export MAX_CONCURRENT_CONTAINERS=10
+ncl groups config update --id <agent-id> --cli-scope global
+ncl groups restart --id <agent-id>
 ```
 
-### Resource usage
+</Step>
+<Step title="Watch them talk">
 
-Each sub-agent:
-- Runs in its own Claude Code session (API calls)
-- May spawn its own container processes
-- Shares CPU/memory with other containers
+Now delegate through the parent:
 
-For complex swarms, monitor system resources:
+```text
+Ask researcher what changed in the EU AI Act this quarter, then summarize its answer for me.
+```
+
+What happens on the wire:
+
+- The parent sends `send_message({ to: "researcher", text: ... })` (or a `<message to="researcher">` block — same delivery). The host resolves `researcher` against the parent's destinations, checks the ACL, and copies the message into researcher's inbox. If researcher has never run, the host creates an `agent-shared` session for it and spawns its container.
+- Researcher sees `<message from="parent">…</message>` — destination names are local, so the child knows its creator only as `parent`. Its base instructions say to reply to the `from` destination, so it answers `to="parent"`.
+- **The return path is precise.** Every routed a2a message is stamped with the sender's `source_session_id`. When researcher replies, the router looks up which parent session started the exchange and delivers there — not to whichever parent session happens to be newest. Files survive the hop too: `send_file` attachments are copied from the sender's outbox into the receiver's inbox.
+
+The parent then summarizes in your chat. You can also message researcher directly by wiring it to a chat of its own, exactly like Scout in the [first agent tutorial](/guides/first-agent).
+
+</Step>
+<Step title="Scale to worker / manager / supervisor">
+
+The trio from the diagram is the same pattern with more edges. The conversational route: tell your trusted agent to create a `manager` (instructions: track tasks in flight, delegate, chase stragglers) and have the manager create its own workers — `create_agent` works from any agent, subject to the same scope/approval rule, and each creator gets its own edge to its children.
+
+Sibling and cross-level edges don't exist by default (workers can't reach the supervisor) — add them by hand. Each `ncl destinations add` is one direction:
 
 ```bash
-# Check running containers
-docker ps | grep nanoclaw
-
-# Monitor resource usage
-docker stats
+ncl destinations add --agent-group-id <worker-id> --local-name supervisor \
+  --target-type agent --target-id <supervisor-id>
+ncl destinations add --agent-group-id <supervisor-id> --local-name worker-1 \
+  --target-type agent --target-id <worker-id>
 ```
 
-## Debugging Agent Swarms
+`ncl destinations add`/`remove` project the change into running containers immediately — no restart needed.
 
-To see what's happening inside agent swarms:
+Two finishing touches:
 
-### Check container logs
+- **Supervisor pings you**: wire the supervisor to your DM (`ncl wirings create --messaging-group-id <your-dm-id> --agent-group-id <supervisor-id> ...`). Wiring auto-creates the channel destination, so the supervisor can message you proactively — and use `ask_user_question` to put actual buttons under a decision.
+- **One conversation per task**: wire a worker to a thread-capable channel (Discord, Slack) with `--session-mode per-thread` and every thread gets its own session — each task runs in a clean context instead of one ever-growing conversation. On server channels this is [forced anyway](/concepts/entity-model); the flag matters for DMs.
+
+</Step>
+<Step title="Observe the topology">
+
+Everything is rows, so the whole team is inspectable:
 
 ```bash
-# View logs for a specific group
-tail -f groups/{group-name}/logs/agent.log
+ncl groups list                                      # all agent identities
+ncl destinations list --agent-group-id <manager-id>  # who the manager may talk to, and as what
+ncl sessions list --agent-group-id <worker-id>       # live conversations and container status
+docker ps --filter name=nanoclaw-v2                  # the containers themselves
 ```
 
-### Ask the agent
+The destinations list reads as the manager's address book: `parent`, `worker-1`, `worker-2`, plus any channel it's wired to.
 
-```
-@Andy what sub-agents did you spawn for that task?
-@Andy show me the breakdown of how you delegated the work
-```
+</Step>
+</Steps>
 
-### Check session files
+## Limits
 
-Each sub-agent creates session files in `.claude/sessions/`:
+- **No loop protection.** There is no throttle, hop limit, or cycle detection on agent-to-agent messages — two agents told to "always reply" will ping-pong indefinitely, burning API calls. Give every agent's instructions an explicit stop condition ("report back once, then wait").
+- **No broadcast.** Each message targets one destination. Fan-out means one `<message>` block (or `send_message` call) per recipient — the parent orchestrates, the queue doesn't.
+- **Concurrency is capped.** Containers respect `MAX_CONCURRENT_CONTAINERS` (default 5). A wide team queues rather than crashing, but raise the cap if workers should genuinely run in parallel.
+- **Edits to destinations outside `ncl` don't propagate live.** A running container serves a projection of its destinations, refreshed on every wake and by `ncl destinations add`/`remove` — but direct DB writes leave it stale until the next wake.
+
+## Cleanup
 
 ```bash
-ls -la data/sessions/{group-folder}/.claude/sessions/
+ncl groups delete --id <agent-id>
 ```
 
-## Limitations
+This cascades through the central DB in one transaction: sessions, destination rows in **both directions** (its own and every edge pointing at it), pending approvals, wirings, memberships, and the container config. It does **not** kill a running container or delete `groups/<folder>/` and `data/v2-sessions/<group-id>/` — stop the container and remove those by hand if you want the workspace gone.
 
-<Warning>
-Agent Swarms has some current limitations:
+## Next steps
 
-- **Experimental**: The feature may change as Claude Code evolves
-- **Resource intensive**: Multiple agents consume more API calls and system resources
-- **No direct control**: You can't manually spawn specific sub-agents (orchestration is automatic)
-- **Coordination overhead**: The main agent needs to coordinate, which adds latency
-</Warning>
-
-## Best practices
-
-### When to use Agent Swarms
-
-✅ **Good use cases:**
-- Complex multi-step tasks with clear delegation opportunities
-- Parallel data processing across multiple sources
-- Tasks requiring different specialized skills
-- Research projects with distinct gathering/analysis/writing phases
-
-❌ **Avoid for:**
-- Simple single-step queries
-- Highly interactive conversations (stick to single agent)
-- Time-sensitive requests (coordination adds latency)
-- Tasks with strict resource constraints
-
-### Optimize swarm performance
-
-1. **Be explicit about delegation**: Help the agent understand when to spawn sub-agents
-   ```
-   @Andy research X using multiple agents in parallel, then synthesize results
-   ```
-
-2. **Provide clear sub-tasks**: Break down your request to guide delegation
-   ```
-   @Andy:
-   1. Fetch data from sources A, B, and C (parallel)
-   2. Analyze each dataset
-   3. Create comparison report
-   ```
-
-3. **Monitor resource usage**: Check if swarms are worth the overhead
-   ```
-   @Andy how many sub-agents did that task require?
-   ```
-
-## Related documentation
-
-- [Scheduled tasks](/guides/scheduled-tasks) - Run agent swarms on a schedule
-- [Customization](/guides/customize-an-agent) - Adjust container limits and behavior
-- [Web access](/extend/tools) - Sub-agents can use browser automation
-
-## External resources
-
-- [Claude Code Agent Teams documentation](https://code.claude.com/docs/en/agent-teams)
-- [Agent orchestration patterns](https://code.claude.com/docs/en/agent-teams#orchestrate-teams-of-claude-code-sessions)
+- [Scheduled tasks](/guides/scheduled-tasks) — have the manager run its review on a timer
+- [MCP tools reference](/reference/mcp-tools) — `create_agent`, `send_message`, `ask_user_question` parameters
+- [Entity model](/concepts/entity-model) — sessions, wirings, and session modes in depth

--- a/guides/multi-agent-swarm.mdx
+++ b/guides/multi-agent-swarm.mdx
@@ -45,7 +45,7 @@ dig in with web search, and report findings back to you with sources.
 The agent calls the `create_agent` MCP tool with a `name` and that role as `instructions`. The call is fire-and-forget — it returns immediately, and the host does the privileged work:
 
 1. Inserts an `agent_groups` row. The folder is the normalized name (`researcher`), with a numeric suffix if taken.
-2. Scaffolds `groups/researcher/` and seeds **`CLAUDE.local.md` with the `instructions` text** — that's the new agent's persistent role and personality, editable later like any agent's memory.
+2. Scaffolds `groups/researcher/` and seeds **`CLAUDE.local.md` with the `instructions` text** — that's the new agent's persistent role and personality, editable later like any agent's memory. A default `container_configs` row comes with it.
 3. Inserts **two destination rows**: the creator gets `researcher` → new agent, and the new agent gets `parent` → creator. The edge is bidirectional from birth, so replies need no extra wiring.
 4. Projects the new destination into the parent's running container immediately, then notifies it: `Agent "researcher" created. You can now message it with <message to="researcher">...</message>.`
 
@@ -104,7 +104,14 @@ ncl destinations add --agent-group-id <supervisor-id> --local-name worker-1 \
 
 Two finishing touches:
 
-- **Supervisor pings you**: wire the supervisor to your DM (`ncl wirings create --messaging-group-id <your-dm-id> --agent-group-id <supervisor-id> ...`). Wiring auto-creates the channel destination, so the supervisor can message you proactively — and use `ask_user_question` to put actual buttons under a decision.
+- **Supervisor pings you**: wire the supervisor to your DM (`ncl wirings create --messaging-group-id <your-dm-id> --agent-group-id <supervisor-id> ...`) so it receives your messages — and can reply, since an agent may always answer its origin chat. But `ncl wirings create` is a plain row insert: it does **not** create the channel destination (only the setup scripts' wiring path auto-creates one), so a *proactive* send addressed by name fails the ACL. Add the edge explicitly:
+
+  ```bash
+  ncl destinations add --agent-group-id <supervisor-id> --local-name owner-dm \
+    --target-type channel --target-id <your-dm-mg-id>
+  ```
+
+  Now the supervisor can message you unprompted — and use `ask_user_question` to put actual buttons under a decision.
 - **One conversation per task**: wire a worker to a thread-capable channel (Discord, Slack) with `--session-mode per-thread` and every thread gets its own session — each task runs in a clean context instead of one ever-growing conversation. On server channels this is [forced anyway](/concepts/entity-model); the flag matters for DMs.
 
 </Step>
@@ -128,7 +135,7 @@ The destinations list reads as the manager's address book: `parent`, `worker-1`,
 
 - **No loop protection.** There is no throttle, hop limit, or cycle detection on agent-to-agent messages — two agents told to "always reply" will ping-pong indefinitely, burning API calls. Give every agent's instructions an explicit stop condition ("report back once, then wait").
 - **No broadcast.** Each message targets one destination. Fan-out means one `<message>` block (or `send_message` call) per recipient — the parent orchestrates, the queue doesn't.
-- **Concurrency is capped.** Containers respect `MAX_CONCURRENT_CONTAINERS` (default 5). A wide team queues rather than crashing, but raise the cap if workers should genuinely run in parallel.
+- **No concurrency cap.** `MAX_CONCURRENT_CONTAINERS` (default 5) is parsed at startup but [not enforced anywhere as of v2.1.4](/reference/environment-variables) — a wide team really does run one container per active agent, so size the host accordingly.
 - **Edits to destinations outside `ncl` don't propagate live.** A running container serves a projection of its destinations, refreshed on every wake and by `ncl destinations add`/`remove` — but direct DB writes leave it stale until the next wake.
 
 ## Cleanup

--- a/guides/scheduled-tasks.mdx
+++ b/guides/scheduled-tasks.mdx
@@ -1,205 +1,121 @@
 ---
-title: Setting up scheduled tasks
-description: A scheduled task is a message with a timestamp — same inbox, same flow, same tools as any other message.
+title: "Schedule recurring work"
+description: "Hands-on tutorial: have your agent schedule a recurring task in chat, understand what fires it, manage the series, gate frequent runs with a script, and inspect it all from the host."
 tag: "UPDATED"
-keywords: ["scheduled tasks", "cron", "recurring", "process_after", "series_id", "scripts"]
+keywords: ["scheduled tasks", "schedule_task", "cron", "recurrence", "process_after", "series_id", "host sweep", "wakeAgent", "task script", "timezone"]
 ---
 
-## Overview
+{/* verified-against: container/agent-runner/src/mcp-tools/scheduling.ts, container/agent-runner/src/mcp-tools/scheduling.instructions.md, container/agent-runner/src/scheduling/task-script.ts, container/agent-runner/src/poll-loop.ts, container/agent-runner/src/timezone.ts, src/host-sweep.ts, src/modules/scheduling/{actions,db,recurrence}.ts, src/config.ts, src/container-runner.ts, src/cli/resources/ @ dc34ceb (v2.1.4) */}
 
-v2 has no separate task scheduler. A scheduled task is a row in `messages_in` with a `process_after` timestamp (and optionally a `recurrence` cron expression). The host sweep runs every 60 seconds, finds rows whose time has come, wakes the session's container, and the agent picks it up like any other inbound message.
+v2 has no scheduler service. A scheduled task is a row in the session's `messages_in` table with `kind='task'` and a `process_after` timestamp — same inbox, same flow as any chat message. The agent is the entire scheduling interface: you create, change, and cancel tasks by asking it in chat. This tutorial assumes a working install with a wired agent (see [your first agent](/guides/first-agent)).
 
-That means everything scheduled — daily briefings, weekly reports, per-hour polls, one-time reminders — goes through the same pipeline as a user message. You only learn one model.
+<Steps>
+<Step title="Schedule a task in chat">
 
-## Task types
+Ask your agent, in whatever chat it's wired to:
 
-<Tabs>
-  <Tab title="Recurring (cron)">
-    Use cron expressions for complex recurring schedules:
-
-    ```
-    0 9 * * *     — Daily at 9am
-    0 9 * * 1-5   — Weekdays at 9am
-    0 */6 * * *   — Every 6 hours
-    0 0 * * 0     — Sundays at midnight
-    0 8 1 * *     — First day of each month at 8am
-    ```
-
-    Each occurrence creates a new row in the session database sharing a `series_id`.
-  </Tab>
-
-  <Tab title="One-time">
-    Run a task at a specific future time:
-
-    ```
-    2026-03-01T10:00:00Z
-    ```
-
-    One-time tasks are marked `completed` after execution. No new rows are created.
-  </Tab>
-</Tabs>
-
-## Creating tasks
-
-Tasks are created through natural language requests to the agent:
-
-```
-@Andy send me a summary of my calendar every weekday at 9am
-@Andy check for new GitHub issues every hour and notify me
-@Andy remind me to review the budget tomorrow at 2pm
-@Andy compile AI news from Hacker News every Monday at 8am
+```text
+Scout, every weekday at 9am remind me to post my standup update
 ```
 
-### How it works
+Mechanically, the agent calls the `schedule_task` MCP tool with a `prompt`, a `processAfter` timestamp for the first run, and a cron `recurrence` (`0 9 * * 1-5`). The container can't write the host-owned inbound database, so the tool emits a system action through `messages_out`; the host applies it, inserting a `messages_in` row with `kind='task'`, status `pending`, your `process_after`, the cron expression, and `series_id` set to the task's own id. See the [session DB schema](/reference/db-schema#session-databases) for the columns.
 
-When you request a scheduled task, the agent:
+The agent confirms with the generated id (`task-<timestamp>-<random>`). For a one-shot task — "remind me tomorrow at 2pm to review the budget" — it simply omits `recurrence`.
 
-1. Parses your request to extract the schedule and prompt
-2. Calls the `schedule_task` MCP tool (writes to `outbound.db`)
-3. The host's delivery system creates the task in `inbound.db`
-4. The host sweep picks up the task when it's due
+</Step>
+<Step title="Know what fires it">
 
-## Task execution
+Nothing watches the clock per-task. The [host sweep](/concepts/architecture#what-runs-when) visits every active session **every 60 seconds**, counts pending rows with `process_after <= now`, and wakes the session's container if one isn't already running. The agent's poll loop then picks the task up like any inbound message and executes the prompt.
 
-The host sweep runs every 60 seconds and:
+Two consequences worth internalizing:
 
-1. Finds tasks where `process_after <= now`
-2. Wakes the session's container (or spawns a new one)
-3. The agent-runner's poll loop picks up the task
-4. Agent executes the task prompt
-5. Host sweep syncs `processing_ack` and marks the task completed
-6. For recurring tasks, creates the next occurrence with updated `process_after`
+- **±60 seconds is the precision floor.** A task due at 09:00:00 fires whenever the next sweep tick lands, plus container cold-start if nothing is warm. Don't schedule anything that needs second-level timing.
+- **Recurring tasks are clones, not loops.** When a recurring occurrence completes, the next sweep tick computes the next run with cron-parser, inserts a fresh `pending` row carrying the same `series_id` forward, and clears `recurrence` on the completed row so it isn't re-cloned. The series id is the stable handle; individual occurrence ids come and go.
 
-<Note>
-Tasks share the container concurrency pool with interactive messages. If all container slots are busy (default: 5), tasks wait until a slot is available.
-</Note>
+</Step>
+<Step title="Manage it in chat">
 
-## Timezone configuration
+All management goes through the agent too:
 
-Tasks use the configured timezone for cron evaluation. The resolver checks:
+```text
+Scout, list my scheduled tasks
+Scout, pause the standup reminder
+Scout, move the standup reminder to 9:30
+Scout, cancel the standup reminder
+```
 
-1. `process.env.TZ`
-2. `.env` file's `TZ` value
-3. System locale
-4. Falls back to `UTC`
+Exact tool behaviors behind those phrases:
 
-Each candidate is validated as a real IANA timezone identifier.
+| Tool | Behavior |
+|---|---|
+| `list_tasks` | One row per series — the live `pending` or `paused` occurrence, not the pile of completed firings. The id shown is the series id, which every other tool expects. |
+| `update_task` | Edits the live occurrence in place (matches by id *or* series id). Omitted fields are untouched; an **empty string clears** `recurrence` (the task becomes one-shot) or `script`. If nothing matches, the host messages the agent back so it can tell you. |
+| `pause_task` / `resume_task` | Flip status between `pending` and `paused`. Paused rows are never counted as due, so they don't fire or wake anything. |
+| `cancel_task` | Marks all live rows in the series `completed` and nulls `recurrence` — the series ends, history rows stay. |
 
-To override:
+Full parameter schemas are in the [MCP tools reference](/reference/mcp-tools#scheduling).
+
+</Step>
+<Step title="Gate frequent tasks with a script">
+
+Every firing that reaches the agent is a Claude API call. For tasks that run more than a few times a day, `schedule_task` accepts an optional `script` — a bash script that runs *before* the agent is invoked:
+
+```text
+Scout, every hour check for open PRs needing my review. Use a script that
+curls the GitHub API and only wake yourself if there are any.
+```
+
+The contract, from `container/agent-runner/src/scheduling/task-script.ts`:
+
+1. When the task fires, the script runs first inside the container — 30-second timeout, 1 MB output cap.
+2. The **last line of stdout** must be JSON: `{ "wakeAgent": true|false, "data": ... }`.
+3. `wakeAgent: false` — or any script error, timeout, or invalid output — marks the occurrence completed without invoking the agent. A recurring series still continues: the sweep clones the next occurrence from the completed row.
+4. `wakeAgent: true` — the agent wakes with `data` injected into the task prompt as `scriptOutput`.
+
+Be honest about what this saves: the container still wakes on every firing (the sweep can't know the script's verdict in advance). The script gates the expensive part — the agent invocation — not the container spawn. Skip scripts entirely for tasks that need the agent's judgment every time, like daily briefings.
+
+</Step>
+<Step title="Set the timezone">
+
+When you say "9am", three layers have to agree on whose 9am. The chain: the host resolves `TIMEZONE` once at startup — `process.env.TZ`, then the `.env` file's `TZ`, then the system locale, falling back to `UTC`, each candidate validated as a real IANA identifier (`src/config.ts`). Every container is spawned with `-e TZ=<that value>` (`src/container-runner.ts`), and the agent-runner's `timezone.ts` resolves the same way inside.
+
+The result: naive timestamps the agent passes (`2026-06-11T09:00:00`, no offset) and **cron expressions** — both at schedule time and when the host sweep computes the next recurrence — are all interpreted in that one zone. To pin it:
 
 ```bash
-export TZ="America/New_York"
+# in .env (or the host's environment)
+TZ=Europe/Madrid
 ```
 
-## Task management
+Restart the host after changing it; the value is read once at startup.
 
-Manage tasks through natural language:
+</Step>
+<Step title="Inspect from the host">
 
-```
-@Andy list all scheduled tasks
-@Andy pause the Monday briefing task
-@Andy resume the calendar summary task
-@Andy cancel the reminder about the meeting
-@Andy update the PR monitor to check every 30 minutes instead
-```
-
-### Available operations
-
-| Operation | What it does |
-|-----------|-------------|
-| `schedule_task` | Creates a new task with `process_after` and optional `recurrence` |
-| `cancel_task` | Marks all rows in the series as completed, nulls recurrence |
-| `pause_task` | Toggles task to `paused` (skipped by host sweep) |
-| `resume_task` | Toggles task back to `pending` |
-| `update_task` | Updates prompt, script, schedule, or recurrence in-place |
-
-## Task scripts
-
-For recurring tasks, add a `script` to minimize unnecessary agent wake-ups. The script runs first, and the agent is only invoked when the script determines action is needed.
-
-### How it works
-
-1. The script runs first (30-second timeout)
-2. It prints JSON to stdout: `{ "wakeAgent": true/false, "data": {...} }`
-3. If `wakeAgent` is `false` — task completes silently, no agent invocation
-4. If `wakeAgent` is `true` — the agent wakes with the script's data in its prompt
-
-### Example
-
-```
-@Andy every hour, check for new GitHub PRs needing my review. Use this script to check first:
-curl -s https://api.github.com/repos/org/repo/pulls?state=open | jq '{wakeAgent: (length > 0), data: .}'
-```
-
-### Always test your script first
-
-Before scheduling, run the script in the sandbox:
+There is no `ncl tasks` resource — the agent is the interface, and the rows live in each session's inbound database, not the central DB. To look at them directly, find the session:
 
 ```bash
-bash -c 'curl -s https://api.github.com/repos/owner/repo/pulls?state=open | jq "{wakeAgent: (length > 0), data: .}"'
+ncl sessions list --agent-group-id <agent-id>
 ```
 
-### When NOT to use scripts
+then read its inbound database (host-owned — query read-only, never write to it):
 
-If a task requires agent judgment every time (daily briefings, reminders, reports), skip the script.
-
-### Frequent task guidance
-
-If a task runs more than roughly twice a day and a script can't reduce agent wake-ups:
-
-- Each wake-up uses API credits
-- Restructure with a script that checks conditions first
-- Find the minimum viable frequency
-
-<Note>
-Scripts have a 30-second timeout and 1 MB output limit. If the script fails or produces no output, the agent is not invoked.
-</Note>
-
-## Recurring task series
-
-Recurring tasks use a series model:
-
-- Each occurrence gets a new `messages_in` row sharing the same `series_id`
-- When an occurrence completes, the host creates the next one
-- `cancel_task` stops the entire series
-- `update_task` matches by `series_id` to hit the live next-occurrence row
-
-## Example use cases
-
-### Daily standup summary
-
-```
-@Andy every weekday at 9am, compile my calendar events for the day and send me a brief summary
+```bash
+sqlite3 "file:data/v2-sessions/<agent_group_id>/<session_id>/inbound.db?mode=ro" \
+  "SELECT id, status, process_after, recurrence, series_id
+     FROM messages_in WHERE kind='task' ORDER BY process_after"
 ```
 
-### GitHub PR monitor (with script)
+A healthy recurring series shows one `pending` row (the next run) plus one `completed` row per past firing, all sharing a `series_id`.
 
-```
-@Andy check for PRs needing review every hour. Script: curl -s https://api.github.com/repos/org/repo/pulls?state=open | jq '{wakeAgent: (length > 0), data: .}'
-```
+</Step>
+</Steps>
 
-### Weekly report
+## What you built
 
-```
-@Andy every Friday at 5pm, review the git history for the past week and compile a summary
-```
+A recurring task that is nothing but data: a `messages_in` row the 60-second host sweep wakes a container for, a clone-on-completion loop keyed by `series_id`, and an optional script gate between "the task fired" and "Claude got called". No daemon, no crontab — delete the row series (via `cancel_task`) and it's gone.
 
-### One-time reminder
+## Next steps
 
-```
-@Andy remind me tomorrow at 2pm to review the budget proposal
-```
-
-## Error handling
-
-If a task fails:
-
-1. Processing is acknowledged with error state
-2. For recurring tasks, the next occurrence is still created
-3. For one-time tasks, the task is marked completed even if it failed
-4. Check container logs for error details
-
-## Related documentation
-
-- [Messaging](/channels/overview) — the inbox/outbox pattern that scheduling rides on
-- [Customization](/guides/customize-an-agent) — sweep interval, timezone, and concurrency
+- [MCP tools reference](/reference/mcp-tools#scheduling) — exact parameters for all six scheduling tools
+- [Session DB schema](/reference/db-schema#session-databases) — every column on `messages_in`
+- [Multi-agent swarm](/guides/multi-agent-swarm) — schedule work that fans out to other agents


### PR DESCRIPTION
PR 8 of 9 (spec: docs/superpowers/specs/2026-06-10-docs-portal-v2-refactor-design.md). Verified against nanocoai/nanoclaw@dc34ceb (v2.1.4). Every command in every tutorial was traced through the actual CLI parsers and routing code.

## Pages
- **guides/first-agent** (NEW): build a second agent by hand via ncl + the CLI channel — includes the real routing gotchas (mention never fires on CLI, fail-open regex, double-reply avoidance)
- **guides/customize-an-agent** (rewritten): CLAUDE.local.md persona edits (conversational + direct), model/effort via container config, precise apply-timing
- **guides/scheduled-tasks** (rewritten): conversational scheduling, the script/wakeAgent gate, sweep mechanics, timezone chain, honest no-ncl-tasks note
- **guides/multi-agent-swarm** (rewritten): create_agent + destinations + return-path mechanics, the worker/manager/supervisor build with parseable commands, honest limits (no a2a loop protection — upstream's own test calls it a BUG)

## Code-first catches
- ncl wirings create does NOT auto-create destination edges (only module/init paths do) — tutorial wires them explicitly
- /customize SKILL.md still routes persona to the composed CLAUDE.md (clobbered every spawn) — noted; tutorial teaches CLAUDE.local.md
- The dead MAX_CONCURRENT_CONTAINERS claim was kept out (again)

Validation: mint validate ✅ · mint broken-links ✅