### PR TITLE
docs: meta — v2 CLAUDE.md, workflow updates, final polish

### DIFF
--- a/.mintlify/workflows/new-skill-docs.md
+++ b/.mintlify/workflows/new-skill-docs.md
@@ -1,67 +1,86 @@
 ---
-name: Document new skill branches
+name: Document new skills and channel adapters
 on:
   push:
-    - repo: qwibitai/nanoclaw
-      branch: skill/*
+    - repo: nanocoai/nanoclaw
+      branch: channels
 context:
-  - repo: qwibitai/nanoclaw
+  - repo: nanocoai/nanoclaw
 automerge: false
 ---
 
-A new skill branch was pushed or updated on the upstream NanoClaw repository. Review the skill and create or update its documentation page.
+A push was made to the `channels` registry branch on the upstream NanoClaw repository. New or updated channel adapters land there; new skills land in `.claude/skills/` on `main` (those are caught by the sync workflow, which routes here for documentation rules). Review what changed and create or update the documentation.
+
+Read this repo's `CLAUDE.md` (NanoClaw Architecture Context section) first — it is the source of truth for the v2 model and lists confirmed upstream-doc traps. Key points: skills are SKILL.md workflows, NOT git branches; channel adapters are installed by `/add-<channel>` skills that fetch-and-copy files from the `channels` registry branch, never `git merge`; treat a skill's SKILL.md as the executable spec for its BEHAVIOR, but never as a source of facts about core code — verify claims against `src/`, `setup/*.sh`, and `container/`.
 
 ## Instructions
 
-### 1. Identify the skill
+### 1. Identify what changed
 
-Determine which `skill/*` branch was pushed. Check its contents:
-- New source files added (e.g., `src/channels/telegram.ts`)
-- Modified files (e.g., `src/index.ts`, `src/config.ts`, `package.json`)
-- `.env.example` additions (new environment variables)
-- Any SKILL.md file in the branch
+- New or modified adapter directories on the `channels` registry branch (e.g., `src/channels/<adapter>/`)
+- New or modified `.claude/skills/<name>/SKILL.md` workflows (channel installers, tool installers, provider installers, operational skills)
+- New `setup/add-*.sh` wizards
+- Container skills in `container/skills/`
+- `.env.example` or env-var additions tied to the skill
 
-### 2. Check if documentation already exists
+### 2. Route to the right docs pages
 
-Look in `integrations/` for an existing page for this skill. If it exists, update it. If not, create a new one.
+Classify the skill and update accordingly:
 
-### 3. Create or update the integration page
+| Skill type | Where it's documented |
+|---|---|
+| Channel adapter / `/add-<channel>` skill | `channels/<channel>.mdx` (dedicated page if it has a `setup/add-*.sh` wizard; otherwise a row in `channels/more-channels.mdx`) + a row in `reference/skills-catalog.mdx` |
+| Tool skill (e.g., `/add-*-tool`) | `extend/tools.mdx` + a row in `reference/skills-catalog.mdx` |
+| Provider skill (e.g., `/add-codex`) | `extend/providers.mdx` + a row in `reference/skills-catalog.mdx` |
+| Operational skill | Row in `reference/skills-catalog.mdx` (+ the relevant `operate/` page if it changes day-to-day operations) |
 
-Follow the pattern of existing integration pages (e.g., `integrations/discord.mdx`, `integrations/telegram.mdx`). Each integration page should include:
+### 3. Create or update the page
+
+For dedicated channel pages, follow the pattern of existing ones (e.g., `channels/discord.mdx`, `channels/telegram.mdx`). Each should include:
 
 - **Title and description** in frontmatter
-- **Overview** — what the integration does and which library it uses
-- **Installation** — `git fetch upstream skill/{name}` and `git merge upstream/skill/{name}`
-- **Setup** — environment variables, authentication steps, platform-specific configuration
-- **Registration** — how to register groups with the correct JID format
-- **Features** — what capabilities the integration supports
-- **Removing** — how to revert the merge and clean up registrations
+- **Overview** — what the channel does and which library/API it uses
+- **Installation** — the `/add-<channel>` skill or `setup/add-<channel>.sh` wizard (never `git merge` instructions)
+- **Setup** — environment variables, authentication steps, platform-specific configuration (verify env vars against the installer script and `src/`, not SKILL.md prose)
+- **Wiring** — how to connect the messaging group to an agent group
+- **Features** — what capabilities the channel supports
+- **Removal** — match how existing channel pages document removal (REMOVE.md workflows where they exist)
 - **Troubleshooting** — common issues (bot not responding, auth errors, missing tokens)
 
-### 4. Update the integrations overview
+### 4. Add the verified-against comment
 
-If this is a new integration, add it to `integrations/overview.mdx` in the channel list.
+Every page carries a verification comment right after the frontmatter:
 
-### 5. Update navigation
+```text
+{/* verified-against: <upstream files you checked> @ <upstream sha> */}
+```
 
-If this is a new page, add it to the navigation in `docs.json` under the Integrations group.
+Add it to new pages; bump the SHA (and adjust the file list) on pages you update after re-verifying against upstream code.
 
-### 6. Tag new pages
+### 5. Update overview and catalog
+
+- New channel → add it to `channels/overview.mdx` and/or `channels/more-channels.mdx`
+- Every new skill → add a row to `reference/skills-catalog.mdx`
+
+### 6. Update navigation
+
+If this is a new page, add it to the navigation in `docs.json` under the appropriate group (Channels, Extend, or Reference → Operating).
+
+### 7. Tag new pages
 
 Add `tag: "NEW"` in the frontmatter of any newly created page:
 ```yaml
 ---
-title: "Telegram integration"
+title: "Telegram"
 description: "..."
 tag: "NEW"
 ---
 ```
 
-If you are updating an existing integration page instead of creating one, use `tag: "UPDATED"` instead.
+If you are updating an existing page instead of creating one, use `tag: "UPDATED"` instead.
 
-### 7. Style guidelines
+### 8. Style guidelines
 
-- Match the existing tone and structure of other integration pages
+- Match the existing tone and structure of other pages in the same directory
 - Use Mintlify components (Tabs, Accordions, CodeGroups) where appropriate
-- Include the JID format for group registration
-- Always include a "Removing" section with `git revert` instructions
+- Verify every factual claim against code (`src/`, `setup/`, `container/`) — never against upstream markdown prose

--- a/.mintlify/workflows/sync-upstream-changes.md
+++ b/.mintlify/workflows/sync-upstream-changes.md
@@ -2,50 +2,74 @@
 name: Sync upstream code changes
 on:
   push:
-    - repo: qwibitai/nanoclaw
+    - repo: nanocoai/nanoclaw
       branch: main
 context:
-  - repo: qwibitai/nanoclaw
+  - repo: nanocoai/nanoclaw
 automerge: false
 ---
 
 A push was made to the NanoClaw source repository. Review the changes and update the documentation to reflect any modifications.
 
+Read this repo's `CLAUDE.md` (NanoClaw Architecture Context section) first — it is the source of truth for the v2 model and lists confirmed upstream-doc traps. **Code is the ONLY source of truth.** Never trust upstream `docs/`, README.md, CLAUDE.md, or SKILL.md prose over what `src/`, `setup/`, and `container/` actually do.
+
 ## Instructions
 
-1. Check the latest commits on the `qwibitai/nanoclaw` repo to understand what changed.
-2. For each changed source file, check if there is corresponding documentation that needs updating.
-3. Pay special attention to changes in:
-   - `src/container-runner.ts` — container lifecycle, mounts, credential handling
-   - `src/db.ts` — database schema, queries, table structure
-   - `src/index.ts` — message routing, orchestration, startup sequence
-   - `src/config.ts` — configuration options, defaults, environment variables
-   - `src/mount-security.ts` — mount allowlist format, validation rules
-   - `src/credential-proxy.ts` — authentication, credential injection
-   - `src/task-scheduler.ts` — task lifecycle, scheduling behavior
-   - `src/ipc.ts` — IPC commands, authorization rules
-   - `container/Dockerfile` — container image contents, dependencies
-   - `container/agent-runner/src/index.ts` — MCP servers, allowed tools, SDK config
-   - `package.json` — version bumps, dependency changes
-   - `CHANGELOG.md` — breaking changes, new features
-4. Update the relevant documentation pages. Key mappings:
-   - Container behavior → `concepts/containers.mdx`, `advanced/container-runtime.mdx`
-   - Security model → `concepts/security.mdx`, `advanced/security-model.mdx`
-   - Architecture → `concepts/architecture.mdx`
-   - Configuration → `api/configuration.mdx`
-   - Task scheduling → `concepts/tasks.mdx`, `features/scheduled-tasks.mdx`, `api/task-scheduling.mdx`
-   - Message routing → `features/messaging.mdx`, `api/message-routing.mdx`
-   - Group management → `concepts/groups.mdx`, `api/group-management.mdx`
-   - Troubleshooting → `advanced/troubleshooting.mdx`
-   - Skills → `integrations/skills-system.mdx`, `api/skills/`
-5. If a change doesn't affect documentation, skip it.
-6. Do NOT update code snippets with line number references (e.g., `src/file.ts:123`) — these drift constantly. Use descriptive references instead.
-7. Keep documentation concise. Match the existing style of each page.
-8. For every page where you make a **content change** (corrected facts, new sections, changed behavior), add or keep `tag: "UPDATED"` in the frontmatter. Do NOT add the tag for cosmetic-only changes (formatting, component swaps, whitespace). If the page already has a different tag (e.g., `NEW`), replace it with `UPDATED`. Example:
-   ```yaml
-   ---
-   title: "Container runtime"
-   description: "..."
-   tag: "UPDATED"
-   ---
-   ```
+### 1. Find affected pages via verified-against comments
+
+Every docs page carries a verification comment right after the frontmatter:
+
+```text
+{/* verified-against: <upstream file paths> @ <upstream sha> */}
+```
+
+Use it to scope the work:
+
+1. For each page, take its cited SHA and run a diff against upstream HEAD in the context repo: `git diff <sha>..HEAD --name-only`.
+2. Intersect the changed files with the paths cited in the page's comment.
+3. Only pages whose cited files actually changed need re-verification. Skip the rest.
+
+### 2. Re-verify and update affected pages
+
+For each affected page:
+
+- Read the changed upstream files and compare against the page's claims, code snippets, env vars, defaults, and table/column names.
+- Update the page where the code diverged. If nothing in the page is affected by the diff, still bump the comment.
+- **Always update the verified-against comment's SHA** to the upstream HEAD you verified against (adjust the cited file list if the page now depends on different files).
+
+### 3. Key page mappings
+
+When changes don't map cleanly through verified-against comments (e.g., brand-new upstream files), use these mappings:
+
+- Container lifecycle, runtime, mounts → `concepts/container-lifecycle.mdx`, `reference/container-config.mdx`
+- Security, egress lockdown, mount security → `concepts/security.mdx`, `concepts/isolation-levels.mdx`, `operate/hardening.mdx`
+- Architecture, routing, sessions → `concepts/architecture.mdx`, `concepts/entity-model.mdx`
+- Configuration, env vars → `operate/configuration.mdx`, `reference/environment-variables.mdx`
+- Credentials (Agent Vault) → `operate/credentials.mdx`
+- `ncl` CLI → `operate/ncl-cli.mdx`, `reference/ncl-cli.mdx`
+- Channel adapters, webhook server → `channels/` pages, `reference/adapter-interface.mdx`
+- Skills (`.claude/skills/`, `container/skills/`) → `extend/` pages, `reference/skills-catalog.mdx` (new skills: follow the routing table in the new-skill-docs workflow)
+- MCP tools, agent-runner → `reference/mcp-tools.mdx`
+- DB schema → `reference/db-schema.mdx`
+- Scheduled tasks → `guides/scheduled-tasks.mdx`
+- Setup, upgrade flow → `installation.mdx`, `operate/upgrading.mdx`
+- Version bumps, breaking changes (`package.json`, `CHANGELOG.md`) → `changelog/index.mdx`
+
+### 4. Verification rules
+
+- **Verify against code, not prose.** Upstream markdown (including SKILL.md) drifts from reality — the docs repo's `CLAUDE.md` lists confirmed traps (Apple Container support, tini as PID 1, skills-as-branches, `MAX_CONCURRENT_CONTAINERS`, and more). Treat SKILL.md as the executable spec for a skill's behavior only, never as facts about core code.
+- Code snippets in docs must match actual source — docs prose uses product names (e.g., "Agent Vault") but quoted code must match `src/` verbatim (which says "gateway").
+- Do NOT use line number references (e.g., `src/file.ts:123`) — these drift constantly. Use descriptive references instead.
+
+### 5. Housekeeping
+
+- If a change doesn't affect documentation, skip it.
+- Keep documentation concise. Match the existing style of each page.
+- For every page where you make a **content change** (corrected facts, new sections, changed behavior), add or keep `tag: "UPDATED"` in the frontmatter. Do NOT add the tag for cosmetic-only changes (formatting, component swaps, whitespace, or a SHA-only bump of the verified-against comment). If the page already has a different tag (e.g., `NEW`), replace it with `UPDATED`. Example:
+  ```yaml
+  ---
+  title: "Container lifecycle"
+  description: "..."
+  tag: "UPDATED"
+  ---
+  ```

--- a/.mintlify/workflows/weekly-docs-audit.md
+++ b/.mintlify/workflows/weekly-docs-audit.md
@@ -3,48 +3,61 @@ name: Weekly docs health audit
 on:
   cron: "0 9 * * 1"
 context:
-  - repo: qwibitai/nanoclaw
+  - repo: nanocoai/nanoclaw
 automerge: false
 ---
 
-Run a weekly health check on the documentation, comparing it against the current upstream codebase.
+Run a weekly health check on the documentation, comparing it against the current upstream codebase (`nanocoai/nanoclaw`).
+
+Read this repo's `CLAUDE.md` (NanoClaw Architecture Context section) first — it is the source of truth for the v2 model and lists confirmed upstream-doc traps. Verify all claims against code (`src/`, `setup/`, `container/`, `.claude/skills/`), never against upstream markdown prose.
 
 ## Instructions
 
 ### 1. Check for broken internal links
 
-Scan all `.mdx` files for internal links (e.g., `[text](/path/to/page)`, `[text](./relative.mdx)`) and verify the target pages exist. Report any broken links.
+Scan all `.mdx` files for internal links (e.g., `[text](/path/to/page)`, `[text](./relative.mdx)`) and verify the target pages exist. Watch for links to the pre-refactor tree (`integrations/`, `features/`, `advanced/`, `api/`) — those directories are gone; the current tree is `channels/`, `operate/`, `guides/`, `extend/`, `concepts/`, `reference/`. Report any broken links.
 
-### 2. Check for stale code references
+### 2. Flag stale verified-against comments
 
-Compare code snippets and function references in the docs against the actual upstream source code in the `qwibitai/nanoclaw` context repo. Flag any that no longer match, specifically:
+Every page carries `{/* verified-against: <files> @ <sha> */}` after the frontmatter. For each page:
 
-- Function names that no longer exist (e.g., `readSecrets()` was removed)
-- Database paths or table names that changed
+1. Run `git diff <page-sha>..HEAD --name-only` in the upstream context repo.
+2. Intersect the changed files with the paths cited in the comment.
+3. Flag pages whose SHA is behind upstream `main` AND whose cited files changed in that range — these need re-verification.
+
+Pages whose cited files did not change are fine even if their SHA is old.
+
+### 3. Check for stale code references
+
+Compare code snippets and function references in the docs against the actual upstream source code in the `nanocoai/nanoclaw` context repo. Flag any that no longer match, specifically:
+
+- Function names that no longer exist
+- Database paths or table names that changed (central DB is `data/v2.db`)
 - Configuration option names or defaults that changed
 - File paths referenced in docs that no longer exist
 - Import paths or module structures that changed
 
-### 3. Check for missing documentation
+### 4. Check for missing documentation
 
-Review recent upstream changes (last 7 days of commits on `qwibitai/nanoclaw`) and identify any new features, configuration options, or behavioral changes that aren't documented yet.
+Review recent upstream changes (last 7 days of commits on `nanocoai/nanoclaw` `main`, plus the `channels` registry branch for new adapters) and identify any new features, configuration options, skills, or behavioral changes that aren't documented yet. Route new-skill docs per the table in the new-skill-docs workflow (channel skills → `channels/` + `reference/skills-catalog.mdx`; tool skills → `extend/tools.mdx` + catalog; provider skills → `extend/providers.mdx` + catalog; operational skills → catalog + relevant `operate/` page).
 
-### 4. Check frontmatter quality
+### 5. Check frontmatter quality
 
 Verify all `.mdx` files have:
 - A `title` field
 - A `description` field with at least 50 characters
 
-### 5. Clean up stale sidebar tags
+### 6. Clean up stale sidebar tags
 
 Check all `.mdx` files for `tag` frontmatter fields. Remove tags that are no longer relevant:
 - Remove `tag: "NEW"` from pages that were created more than 2 weeks ago (check git log for the file's first commit date)
 - Remove `tag: "UPDATED"` from pages that were last modified more than 2 weeks ago (check git log for the file's last commit date)
 - Leave other tags (e.g., `BETA`, `DEPRECATED`) untouched — these are intentional and long-lived
 
-### 6. Report and fix
+### 7. Report and fix
 
 - For broken links and stale references: fix them directly
+- For stale verified-against pages: re-verify against code, fix any drift, and bump the comment's SHA
 - For missing documentation: add stub sections with TODO markers
 - For frontmatter issues: add missing fields
 - For stale tags: remove them

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,13 +32,28 @@ Deployment is automatic after merge to `main` (via Mintlify GitHub app).
 
 ## NanoClaw Architecture Context
 
-When editing docs, keep these architectural facts current:
-- **Multi-channel:** NanoClaw supports WhatsApp, Telegram, Discord, Slack, and Gmail as equal channels. No channel is the "default" — avoid WhatsApp-centric language in non-WhatsApp pages.
-- **Skills as git branches:** Skills are `skill/*` branches merged via `git merge`, not a custom engine. No manifest.yaml, no .nanoclaw/state.yaml, no apply-skill.ts. See `integrations/skills-system.mdx` as source of truth.
-- **Channel forks:** Channels live in separate fork repos (`nanoclaw-whatsapp`, `nanoclaw-telegram`, etc.). Channel-specific skills (image-vision, voice-transcription, reactions, pdf-reader) live on the channel fork, not upstream.
-- **Removing a skill:** `git revert -m 1 <merge-commit>`, not manual file deletion.
-- **Source of truth for NanoClaw code:** https://github.com/nanocoai/nanoclaw
-- **Credential management (v1.2.35+):** OneCLI Agent Vault is the sole credential system. The built-in credential proxy is available as an opt-in skill (`/use-native-credential-proxy`). Legacy tabs in docs cover both methods. Note: upstream source code still uses "gateway" in code — docs prose says "Agent Vault" but code snippets must match actual source.
+The site was fully rewritten for v2 (PRs #296–#303), verified against `nanocoai/nanoclaw@dc34ceb` (v2.1.4). Keep these facts current when editing:
+
+- **Upstream:** https://github.com/nanocoai/nanoclaw (org moved from `qwibitai`; old URLs redirect).
+- **Code is the ONLY source of truth.** Upstream `docs/`, README.md, CLAUDE.md, and even SKILL.md prose all drift from reality. Verify every claim against `src/`, `container/`, `setup/`, `.claude/skills/` (treat SKILL.md as the executable spec for a skill's BEHAVIOR, but never as a source of facts about core code), and the shell scripts. Every docs page carries a `{/* verified-against: <files> @ <sha> */}` comment — update it whenever you re-verify a page.
+- **Confirmed upstream-doc traps** (claims that are false in code): Apple Container support (doesn't exist; Docker is hardcoded), tini as PID 1 (image default is overridden at spawn; bun is PID 1), `groups/global/` persistence (deleted on every startup), skills-as-git-branches (never shipped in v2; upstream `docs/skills-as-branches.md` is stale), `MAX_CONCURRENT_CONTAINERS` (parsed in `src/config.ts`, never enforced), adapter SKILL.md version pins (drift from the `setup/*.sh` installer pins — prefer the `.sh`), the customize skill's persona-file claim (stale).
+- **Channels:** trunk ships infrastructure plus a CLI channel only — NO messaging channel lives on `main`. 17 adapters live on the `channels` registry branch (WhatsApp, WhatsApp Cloud, Telegram, Discord, Slack, Signal, iMessage, Teams, Google Chat, Matrix, Delta Chat, Emacs, GitHub, Linear, Resend, Webex, WeChat), installed by `/add-<channel>` skills that fetch-and-copy files — never `git merge`. 7 channels have `setup/add-*.sh` wizards (whatsapp, telegram, discord, slack, signal, imessage, teams).
+- **Skills:** SKILL.md workflows in `.claude/skills/` (channel/provider/tool installers plus operational skills) and container skills in `container/skills/` mounted into every agent container. Skills are NOT git branches.
+- **No HTTP API:** inbound webhook server (`/webhook/{adapterName}`) plus Unix sockets — the `ncl` admin CLI on `data/ncl.sock`, the CLI channel on `data/cli.sock`.
+- **Runtime:** Docker only. Host runs Node + pnpm; the agent-runner inside the container runs Bun.
+- **Entity model:** `agent_groups` ↔ `messaging_groups` connected via wirings. `engage_mode`: `pattern` | `mention` | `mention-sticky`. `session_mode`: `shared` | `per-thread` | `agent-shared` (the router forces per-thread on thread-capable group chats). Central DB is `data/v2.db`; each session gets an inbound/outbound SQLite pair — that pair IS the host↔container IPC.
+- **Credentials:** OneCLI Agent Vault invariant — containers never hold raw API keys (stub key + in-flight injection). Docs prose says "Agent Vault"; code snippets must match source (which says "gateway"). `/use-native-credential-proxy` is the opt-in alternative.
+- **Per-group customization:** `CLAUDE.local.md` is the editable per-group file. `groups/<folder>/CLAUDE.md` is composed at every spawn — never teach users to edit it.
+
+## Drift Detection
+
+Each page's `verified-against` SHA is the re-verification anchor. When upstream moves, re-check pages whose cited files changed:
+
+```bash
+git -C <upstream-checkout> diff <page-sha>..HEAD --name-only
+```
+
+Compare the output against the paths cited in each page's `verified-against` comment; re-verify and bump the SHA only on pages whose cited files actually changed.
 
 ## PR Workflow
 
@@ -56,12 +71,16 @@ When editing docs, keep these architectural facts current:
 All content is `.mdx` (Markdown + JSX components). Navigation and site config live in `docs.json`.
 
 **Content directories:**
-- `concepts/` — Architecture, security model, containers, groups, tasks
-- `features/` — Messaging, scheduled tasks, agent swarms, customization, web access
-- `integrations/` — Channel setup (WhatsApp, Telegram, Discord, Slack, Gmail) and skills system
-- `advanced/` — Deep dives: container runtime, IPC, Docker sandboxes, troubleshooting
-- `api/` — Core API reference and skills development guides
-- Root: `introduction.mdx`, `quickstart.mdx`, `installation.mdx`
+- `channels/` — Channel setup: overview, whatsapp, telegram, discord, slack, signal, imessage, teams, cli, more-channels (10 pages)
+- `operate/` — Configuration, ncl CLI, credentials, hardening, upgrading, troubleshooting (6 pages)
+- `guides/` — Agent-building tutorials: first agent, customization, scheduled tasks, multi-agent swarm (4 pages)
+- `extend/` — Skills overview, tools, providers, self-modification, writing skills (5 pages)
+- `concepts/` — Architecture, entity model, isolation levels, container lifecycle, security, contributing (6 pages)
+- `reference/` — ncl CLI, environment variables, container config, skills catalog, adapter interface, MCP tools, DB schema (7 pages)
+- `changelog/` — Product releases (`index.mdx`) and docs updates (`docs-updates.mdx`)
+- Root: `introduction.mdx`, `quickstart.mdx`, `installation.mdx`, `migrate-from-v1.mdx`
+
+Old paths (`features/`, `integrations/`, `advanced/`, `api/`) are gone — `docs.json` carries redirects for all of them.
 
 ## Mintlify Skill (`/mintlify`)
 
@@ -93,11 +112,11 @@ keywords: ["relevant", "search", "terms"]
 
 **`mint validate`**: Must be run from the directory containing `docs.json` — fails otherwise.
 
-**Non-docs files**: `mint validate` and `mint broken-links` parse ALL `.md`/`.mdx` files in the repo tree, including non-docs files (plans, specs). MDX snippets in markdown code blocks cause parsing errors. Keep non-docs markdown files outside the repo or delete them before validating.
+**Non-docs files**: `mint validate` and `mint broken-links` parse ALL `.md`/`.mdx` files in the repo tree, including non-docs files (plans, specs). MDX snippets in markdown code blocks cause parsing errors. Keep non-docs markdown files outside the repo, or list them in `.mintignore` (the `docs/` directory is already ignored there for this reason — it holds internal non-docs markdown).
 
 **Multi-issue PRs**: When closing multiple issues, put each `Closes #N` on its own line AND add matching labels via `gh pr edit --add-label`.
 
-**Navigation:** When adding or moving pages, update the `navigation` array in `docs.json`. The site has two tabs: "Documentation" (5 groups) and "API Reference" (2 groups). New pages not added to `docs.json` won't appear in the sidebar.
+**Navigation:** When adding or moving pages, update the `navigation` array in `docs.json`. The site has two tabs — "Documentation" (7 groups: Get started, Channels, Operate, Build with agents, Extend, Understand, Changelog) and "Reference" (2 groups: Operating, Internals) — plus a global Changelog anchor. New pages not added to `docs.json` won't appear in the sidebar.
 
 **File naming:** Use kebab-case (e.g., `agent-swarms.mdx`). Match existing patterns in the directory.
 
@@ -107,7 +126,7 @@ keywords: ["relevant", "search", "terms"]
 
 **Components available:** `<Note>`, `<Info>`, `<Tip>`, `<Warning>`, `<Check>`, `<Danger>`, `<Steps>/<Step>`, `<Tabs>/<Tab>`, `<CodeGroup>`, `<Columns>`, `<Card>`, `<AccordionGroup>/<Accordion>`, Mermaid diagrams, and more (see `/mintlify` skill for full list).
 
-**Version-gated features**: When documenting a breaking change where older versions are still valid, use `<Tabs>` with version labels (e.g., "OneCLI Agent Vault (v1.2.22+)" / "Credential Proxy (legacy)") for sections with substantial content, and `<Note>` callouts for passing references. Use version placeholders (`vX.Y.Z`) when the release version isn't confirmed yet.
+**Version-gated features**: When documenting a breaking change where older versions are still valid, use `<Tabs>` with version labels for sections with substantial content, and `<Note>` callouts for passing references. Use version placeholders (`vX.Y.Z`) when the release version isn't confirmed yet. The docs are v2-only — v1 behavior belongs in `migrate-from-v1.mdx`, not in version tabs.
 
 **Directory trees:** Use `<Tree>` component (not ASCII art). See `reference/components.md` for syntax.
 
@@ -125,8 +144,8 @@ Mintlify workflows generate automated PRs (`mintlify/*` branches) on upstream ch
 - **Always verify claims against source**: `gh search code "<term>" repo:nanocoai/nanoclaw` or fetch files directly
 - **Check for overlapping PRs**: Multiple automated PRs often fix the same thing (e.g., table renames). Merge the most thorough one first, then cherry-pick unique changes from the rest.
 - **Common errors in automated PRs**: fabricated commit references, incorrect renames (verify exported types), speculative feature descriptions, `allowed-tools` or other frontmatter claims that don't exist in source
-- **Common fabrications found**: inventing env vars that only exist in skill SKILL.md files (not core config), inventing skill branches that don't exist, claiming runtime-based routing that doesn't exist in code, getting enum defaults wrong (e.g., `context_mode` default is `'isolated'` not `'group'`)
-- **Telegram is NOT on main**: Automated PRs repeatedly claim Telegram is a core channel — it lives in `nanoclaw-telegram` fork. Only stubs and `/add-telegram` skill exist on main.
+- **Common fabrications found**: inventing env vars that only exist in skill SKILL.md files (not core config), repeating upstream-doc traps as fact (Apple Container, tini PID 1, skills-as-branches — see Architecture Context above), claiming runtime-based routing that doesn't exist in code, getting enum defaults wrong
+- **No messaging channel is on main**: Automated PRs repeatedly claim WhatsApp/Telegram/etc. are core channels — all 17 adapters live on the `channels` registry branch. Only the CLI channel and the `/add-<channel>` installer skills exist on trunk.
 - **Token counts in automated PRs are always wrong**: Every automated PR uses a hallucinated value. Only verify against `repo-tokens/badge.svg` in upstream.
 - **Code snippets must match source**: Automated PRs sometimes rename terms in code snippets to match marketing (e.g., "gateway" → "Agent Vault" in logger.warn). Always compare code blocks against actual upstream files — docs prose uses product names but code must match `src/`.
 - **Cascading merge conflicts**: Merging one PR invalidates others touching the same files. When triaging a batch, merge isolated-file PRs first, then tackle overlapping clusters. Close conflicting PRs and consolidate verified changes into a single new PR.
@@ -153,13 +172,13 @@ Two changelogs to maintain — update both after any docs work session:
 
 To PR changes to `nanocoai/nanoclaw` from Ethan's fork (`glifocat/nanoclaw-glifocat`):
 - Work in `/Users/ethanmunoz/Projects/clients/qwibit/nanoclaw-glifocat`
-- Remote `upstream` = `nanocoai/nanoclaw`, `origin` = `glifocat/nanoclaw-glifocat`
+- Remote `upstream` = `nanocoai/nanoclaw` (the remote URL may still read `qwibitai/nanoclaw` — GitHub redirects after the org move), `origin` = `glifocat/nanoclaw-glifocat`
 - Branch from `upstream/main`, push to `origin`, PR with `--repo nanocoai/nanoclaw --head glifocat:<branch>`
 - The fork may be on a different branch (e.g., `feat/dashboard-api`) — stash before switching
 
 ## Token Count
 
-Source of truth: `repo-tokens/badge.svg` in upstream (auto-generated). Currently ~127k tokens (~64% of Claude's context window — jumped from 43.7k at v1.2.53 to 127k at v2.0.0 due to the ground-up rewrite). Update `introduction.mdx` and `integrations/skills-system.mdx` if the badge value changes significantly.
+Source of truth: `repo-tokens/badge.svg` in upstream (auto-generated) — the ONLY valid source. Never cite a number from prose, memory, or an automated PR; read the badge first. Last seen: 185k (~92% of Claude's context window) at dc34ceb (v2.1.4). Update pages that cite the count (e.g., `introduction.mdx`) if the badge value changes significantly.
 
 ## Writing Standards
 

--- a/changelog/docs-updates.mdx
+++ b/changelog/docs-updates.mdx
@@ -5,6 +5,25 @@ icon: "file-pen"
 rss: true
 ---
 
+<Update label="Full portal refactor: job-based navigation, v2-only, code-verified" description="2026-06-10" tags={["New", "Updated"]}>
+  The whole site was restructured and rewritten across nine PRs (#296–#304), replacing the feature-centric tree (`integrations/`, `features/`, `advanced/`, `api/`) with a job-based journey: **Get started → Channels → Operate → Build with agents → Extend → Understand**, plus a **Reference** tab derived entirely from source code.
+
+  ## Structure
+  - New navigation with 7 Documentation groups and a 2-group Reference tab; Changelog is a global anchor
+  - 29+ redirects — no pre-refactor URL 404s
+  - The fictional HTTP "API Reference" tab is gone; `reference/` now documents the real surfaces: the `ncl` admin CLI (all 11 resources), environment variables, container config, the skills catalog (45 + 8 container skills), the channel adapter contract, agent MCP tools, and the full database schema
+
+  ## Content
+  - Every page rewritten or written new against upstream source at `nanocoai/nanoclaw@dc34ceb` (v2.1.4) — never against upstream markdown, which has drifted
+  - Every page carries a `verified-against` comment naming the source files and SHA it was checked against, so future drift is detectable per page
+  - 12 v1 ghost pages deleted (x-twitter, parallel-ai, voice-transcription, image-vision, pdf-reader, remote-control, ipc-system and more — all verified absent from v2 code)
+  - New pages: v1/OpenClaw migration guide, Signal/iMessage/Teams/CLI-channel/more-channels, configuration, credentials, upgrading, isolation levels, self-modification, writing skills, first-agent tutorial, and the seven reference pages
+  - Code-first corrections shipped along the way: tini is not PID 1 at runtime, `groups/global/` is dead code, skills were never git branches in v2, Gmail is an MCP tool rather than a channel, `MAX_CONCURRENT_CONTAINERS` is parsed but unenforced, and the Teams wizard prints a webhook path the server 404s (documented with a warning)
+
+  ## Meta
+  - The repo's own `CLAUDE.md` and the three Mintlify automation workflows were rewritten so future sessions and automated PRs inherit the v2 model and the code-first verification rule
+</Update>
+
 <Update label="v2.0.0 launch readiness: front-door rewrites" description="2026-04-22" tags={["Updated"]}>
   Phase A of the v2 documentation sprint — bringing the pages every new user lands on into alignment with the v2 rewrite. All claims verified directly against upstream source (`src/db/schema.ts`, `src/types.ts`, `src/config.ts`, `container/Dockerfile`, `src/delivery.ts`) rather than upstream `docs/` (which includes a stale `architecture.md` draft and a `db-session.md` that omits the `container_state` table).
 

--- a/concepts/architecture.mdx
+++ b/concepts/architecture.mdx
@@ -46,7 +46,7 @@ sequenceDiagram
     end
 ```
 
-Step by step on the inbound side ([`src/router.ts`](https://github.com/qwibitai/nanoclaw/blob/main/src/router.ts)):
+Step by step on the inbound side ([`src/router.ts`](https://github.com/nanocoai/nanoclaw/blob/main/src/router.ts)):
 
 1. The adapter normalizes a platform event and hands it to the router (see [Channels overview](/channels/overview) for the adapter side).
 2. Non-threaded adapters collapse `threadId` to null; the router looks up the messaging group for `(channel_type, platform_id)`, auto-creating one on a mention or DM. Unwired channels escalate to the owner for approval instead of routing.

--- a/extend/providers.mdx
+++ b/extend/providers.mdx
@@ -15,7 +15,7 @@ Don't confuse providers with [tools](/extend/tools). A tool skill like `/add-oll
 
 ## How the provider is resolved
 
-At spawn time the host resolves the provider name with a fixed precedence ([`src/container-runner.ts`](https://github.com/qwibitai/nanoclaw/blob/main/src/container-runner.ts)):
+At spawn time the host resolves the provider name with a fixed precedence ([`src/container-runner.ts`](https://github.com/nanocoai/nanoclaw/blob/main/src/container-runner.ts)):
 
 1. `sessions.agent_provider` — per-session override
 2. `container_configs.provider` — the group's [container config](/reference/container-config#provider)

--- a/reference/environment-variables.mdx
+++ b/reference/environment-variables.mdx
@@ -13,7 +13,7 @@ Channel adapters (Telegram bot tokens, Slack app credentials, and so on) have th
 
 ## Read from .env
 
-NanoClaw's own parser ([`src/env.ts`](https://github.com/qwibitai/nanoclaw/blob/main/src/env.ts)) reads exactly these keys from `.env` at the project root. Values are never loaded into `process.env`, so they don't leak to child processes. For the first five, a value already in the process environment takes precedence over `.env`; `ANTHROPIC_BASE_URL` is read from `.env` only.
+NanoClaw's own parser ([`src/env.ts`](https://github.com/nanocoai/nanoclaw/blob/main/src/env.ts)) reads exactly these keys from `.env` at the project root. Values are never loaded into `process.env`, so they don't leak to child processes. For the first five, a value already in the process environment takes precedence over `.env`; `ANTHROPIC_BASE_URL` is read from `.env` only.
 
 | Variable | Default | Read in | Effect |
 |---|---|---|---|
@@ -81,4 +81,4 @@ Read inside the agent container by the agent runner. The host injects only `TZ` 
 | `CLAUDE_CONFIG_DIR` | `~/.claude` | `agent-runner/src/providers/claude.ts:269` | Base directory the runner scans for Claude Code project transcripts. |
 | `CLAUDE_CODE_AUTO_COMPACT_WINDOW` | `165000` | `agent-runner/src/providers/claude.ts:322` | Token window at which Claude Code auto-compacts context. Raise for 1M-context model variants. |
 
-Line numbers reference [`qwibitai/nanoclaw`](https://github.com/qwibitai/nanoclaw) at v2.1.4 and will drift with future releases.
+Line numbers reference [`nanocoai/nanoclaw`](https://github.com/nanocoai/nanoclaw) at v2.1.4 and will drift with future releases.


### PR DESCRIPTION
PR 9 of 9 — the meta close-out (spec: docs/superpowers/specs/2026-06-10-docs-portal-v2-refactor-design.md).

## Changes
- **CLAUDE.md rewritten**: v2 architecture facts, the code-is-source-of-truth rule with the confirmed trap list (Apple Container, tini/PID-1, groups/global, skills-as-branches, MAX_CONCURRENT_CONTAINERS, SKILL.md version-pin drift), the new IA, the verified-against drift-detection convention, token badge rule (185k last seen)
- **All three .mintlify/workflows updated**: new paths, registry-branch model, the verified-against SHA workflow for sync + audit (the old instructions are what produced the 73 broken automated PRs we closed)
- **Final sweep**: four stale qwibitai source links fixed; zero drift banners remain (grep-verified); mint a11y clean for all 48 MDX files
- **Changelog**: refactor entry added to docs-updates

## Notes for the operator
- mint a11y flags the brand teal palette for contrast (docs.json colors) — pre-existing, left for a design decision
- The local fork's upstream remote was updated to nanocoai

Validation: mint validate ✅ · mint broken-links ✅ · mint a11y (content) ✅