### PR TITLE
docs: fix changelog global anchor (404)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -124,7 +124,7 @@
   "navigation": {
     "global": {
       "anchors": [
-        { "anchor": "Changelog", "icon": "clock-rotate-left", "href": "https://nanoclaw.dev/changelog/index" }
+        { "anchor": "Changelog", "icon": "clock-rotate-left", "href": "/changelog" }
       ]
     },
     "tabs": [


### PR DESCRIPTION
The global Changelog anchor pointed at the absolute URL https://nanoclaw.dev/changelog/index, which 404s in production (prod collapses index pages to the directory root; local dev serves both, which is why validation didn't catch it). Switched to the relative `/changelog` form — the exact pattern from Mintlify's own global-anchor reference.