### PR TITLE
docs: front door for v2.1.15 — facts + provider-neutral framing

### DIFF
--- a/changelog/docs-updates.mdx
+++ b/changelog/docs-updates.mdx
@@ -5,6 +5,13 @@ icon: "file-pen"
 rss: true
 ---
 
+<Update label="Drift sweep against v2.1.15: token count and container CLIs" description="2026-06-14" tags={["Updated"]}>
+  First slice of re-verification against upstream `nanocoai/nanoclaw@435233a` (v2.1.15, up from v2.1.4). Two code-confirmed factual corrections shipped; larger concerns (multi-instance adapters, provider memory scaffold, OneCLI `/v1` upgrade, the new uninstall flow) follow in separate PRs.
+
+  - **`introduction.mdx`**: codebase token count ~185k → ~194k (verified against `repo-tokens/badge.svg`)
+  - **`installation.mdx`** and **`concepts/container-lifecycle.mdx`**: the container's pinned global CLIs now come from a `container/cli-tools.json` manifest installed by `install-cli-tools.sh` — `agent-browser` is pinned to an exact version rather than tracking `latest`
+</Update>
+
 <Update label="Full portal refactor: job-based navigation, v2-only, code-verified" description="2026-06-10" tags={["New", "Updated"]}>
   The whole site was restructured and rewritten across nine PRs (#296–#304), replacing the feature-centric tree (`integrations/`, `features/`, `advanced/`, `api/`) with a job-based journey: **Get started → Channels → Operate → Build with agents → Extend → Understand**, plus a **Reference** tab derived entirely from source code.
 

--- a/concepts/container-lifecycle.mdx
+++ b/concepts/container-lifecycle.mdx
@@ -18,7 +18,7 @@ Setup builds one base image per install from `container/Dockerfile` (see [Instal
 - **`node:22-slim`** base with **Bun** as the agent-runner's runtime — TypeScript runs directly, no compile step
 - **`tini`** as the image's default entrypoint — though production spawns override the entrypoint entirely, so Bun runs as PID 1 (see the spawn section below)
 - **Chromium** plus its library stack for browser automation (`agent-browser` drives it; CJK fonts are an opt-in `INSTALL_CJK_FONTS=true` build arg)
-- **Pinned global CLIs** via pnpm: `@anthropic-ai/claude-code` and `vercel` at fixed versions, `agent-browser` tracking latest
+- **Pinned global CLIs** via pnpm — `@anthropic-ai/claude-code`, `agent-browser`, and `vercel`, each pinned to an exact version. The versions live in `container/cli-tools.json`; `install-cli-tools.sh` reads that manifest and runs `pnpm install -g` for each entry, so a skill adds a CLI by appending to the manifest instead of editing the Dockerfile
 
 The agent-runner source is **never baked in** — the host bind-mounts it read-only at `/app/src` on every spawn, so source changes never require a rebuild. Rebuilds are only for the Dockerfile itself, CLI version bumps, or agent-runner dependency changes — `package.json` and `bun.lock` are copied in and `bun install`ed at build time.
 

--- a/installation.mdx
+++ b/installation.mdx
@@ -55,7 +55,7 @@ Every run writes two logs: a progression log at `logs/setup.log` (one entry per 
 NanoClaw deliberately splits runtimes:
 
 - **Host**: Node 20+ and pnpm. The wizard compiles TypeScript with `tsc` and the service runs `node dist/index.js`.
-- **Agent container**: Bun 1.3.12 runs the agent-runner TypeScript directly — no build step. The image (from `container/Dockerfile`) is based on `node:22-slim` with Chromium for browser automation and globally installed CLIs — `@anthropic-ai/claude-code` and `vercel` pinned for reproducibility, `agent-browser` tracking latest.
+- **Agent container**: Bun 1.3.12 runs the agent-runner TypeScript directly — no build step. The image (from `container/Dockerfile`) is based on `node:22-slim` with Chromium for browser automation and globally installed CLIs — `@anthropic-ai/claude-code`, `agent-browser`, and `vercel`, each pinned to an exact version for reproducibility. The versions live in `container/cli-tools.json` (installed by `install-cli-tools.sh`).
 
 Two consequences worth knowing:
 

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -1,6 +1,6 @@
 ---
 title: "What is NanoClaw?"
-description: "A multi-agent Claude assistant. One host process, one Docker container per session, and a SQLite queue that carries every message in the system."
+description: "A multi-agent AI assistant. One host process, one Docker container per session, and a SQLite queue that carries every message in the system."
 icon: "house"
 sidebarTitle: "Introduction"
 tag: "UPDATED"
@@ -9,7 +9,7 @@ keywords: ["nanoclaw", "multi-agent", "claude", "container isolation", "inbox ou
 
 {/* verified-against: src/index.ts, src/router.ts, src/channels/index.ts, src/container-runtime.ts, src/container-runner.ts, src/db/schema.ts, src/modules/, container/agent-runner/src/mcp-tools/agents.ts, agents.instructions.md, core.ts, .claude/skills/, .claude/skills/add-telegram/SKILL.md, repo-tokens/badge.svg, package.json @ 435233a (v2.1.15) */}
 
-NanoClaw runs Claude agents that talk to you over your messaging apps — and to each other. One Node host process handles routing and delivery. Every active session gets its own Docker container, so agents can run Bash and edit files without touching your host or each other.
+NanoClaw runs AI agents that talk to you over your messaging apps — and to each other. Claude is the default provider, with Codex, OpenCode, and Ollama available as alternatives. One Node host process handles routing and delivery. Every active session gets its own Docker container, so agents can run Bash and edit files without touching your host or each other.
 
 A single pattern drives the whole system: every message is a row in a SQLite queue. A user chat, an inbound webhook, a scheduled job, an agent delegating to another agent — all of them land in an inbox table (`messages_in`), and every response leaves through an outbox (`messages_out`). A scheduled task is just a message with a `process_after` timestamp. There is no separate scheduler, RPC layer, or job system to learn.
 
@@ -48,7 +48,7 @@ The router resolves who sent the message, which agent group should handle it, an
 
 **Container isolation.** Agents run in Docker containers and see only what you explicitly mount. Bash and file edits execute inside the container, never on your host. Each session gets its own container, so parallel conversations can't interfere with each other.
 
-**Small enough to hold in context.** The codebase is ~194k tokens — small enough for Claude Code to hold in context. That's also how you customize it: edit the code, not a config sprawl.
+**Small enough to hold in context.** The codebase is ~194k tokens — compact enough for a long-context agent to hold in context. That's also how you customize it: edit the code, not a config sprawl.
 
 **Channels are skills, not bundled features.** Main ships exactly one channel — the local CLI. Everything else lives on the `channels` branch and gets copied into your fork by a skill: `/add-telegram`, `/add-discord`, `/add-whatsapp`, `/add-slack`, `/add-signal`, `/add-imessage`, and several more. Your install contains the adapters you asked for and nothing else. The same mechanism covers alternative agent providers (`/add-codex`, `/add-opencode`, `/add-ollama-provider`).
 

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -7,7 +7,7 @@ tag: "UPDATED"
 keywords: ["nanoclaw", "multi-agent", "claude", "container isolation", "inbox outbox", "sqlite", "channels", "skills", "v2"]
 ---
 
-{/* verified-against: src/index.ts, src/router.ts, src/channels/index.ts, src/container-runtime.ts, src/container-runner.ts, src/db/schema.ts, src/modules/, container/agent-runner/src/mcp-tools/agents.ts, agents.instructions.md, core.ts, .claude/skills/, .claude/skills/add-telegram/SKILL.md, repo-tokens/badge.svg, package.json @ dc34ceb */}
+{/* verified-against: src/index.ts, src/router.ts, src/channels/index.ts, src/container-runtime.ts, src/container-runner.ts, src/db/schema.ts, src/modules/, container/agent-runner/src/mcp-tools/agents.ts, agents.instructions.md, core.ts, .claude/skills/, .claude/skills/add-telegram/SKILL.md, repo-tokens/badge.svg, package.json @ 435233a (v2.1.15) */}
 
 NanoClaw runs Claude agents that talk to you over your messaging apps — and to each other. One Node host process handles routing and delivery. Every active session gets its own Docker container, so agents can run Bash and edit files without touching your host or each other.
 
@@ -48,7 +48,7 @@ The router resolves who sent the message, which agent group should handle it, an
 
 **Container isolation.** Agents run in Docker containers and see only what you explicitly mount. Bash and file edits execute inside the container, never on your host. Each session gets its own container, so parallel conversations can't interfere with each other.
 
-**Small enough to hold in context.** The codebase is ~185k tokens — small enough for Claude Code to hold in context. That's also how you customize it: edit the code, not a config sprawl.
+**Small enough to hold in context.** The codebase is ~194k tokens — small enough for Claude Code to hold in context. That's also how you customize it: edit the code, not a config sprawl.
 
 **Channels are skills, not bundled features.** Main ships exactly one channel — the local CLI. Everything else lives on the `channels` branch and gets copied into your fork by a skill: `/add-telegram`, `/add-discord`, `/add-whatsapp`, `/add-slack`, `/add-signal`, `/add-imessage`, and several more. Your install contains the adapters you asked for and nothing else. The same mechanism covers alternative agent providers (`/add-codex`, `/add-opencode`, `/add-ollama-provider`).
 


### PR DESCRIPTION
First slice of re-verifying the docs against upstream `nanocoai/nanoclaw@435233a` (v2.1.15, up from the last verified `dc34ceb`/v2.1.4), plus the start of a provider-neutral voice shift. The larger drift concerns land as separate stacked PRs.

## Verified factual corrections
- **`introduction.mdx`**: codebase token count `~185k` → `~194k`, verified against `repo-tokens/badge.svg`. SHA bumped to `435233a` (page fully re-read).
- **`installation.mdx`** + **`concepts/container-lifecycle.mdx`**: the container's pinned global CLIs now come from a `container/cli-tools.json` manifest that `install-cli-tools.sh` installs via `pnpm install -g`. `agent-browser` is now pinned to an exact version rather than "tracking latest".
  - These two pages' `verified-against` SHAs are intentionally **left at `dc34ceb`** — they cite `container-runner.ts`/`host-sweep.ts`/`session-manager.ts`, which carry multi-instance/provider changes still pending full re-verification.

## Provider-neutral framing (front door)
v2.1.15 advanced provider-pluggability (capability seams for Codex/OpenCode/Ollama), so the introduction no longer leads with Claude as the only option:
- "multi-agent Claude assistant" → "multi-agent AI assistant"
- "runs Claude agents" → "runs AI agents" (Claude named as the **default** provider, alternatives listed)
- "small enough for Claude Code to hold in context" → "compact enough for a long-context agent" (kept accurate — a small local model can't hold 194k)
- Claude stays named as the default; literal identifiers (`CLAUDE.md` paths, the `claude` search keyword) unchanged.

## Still to come (separate stacked PRs)
- **A** Multi-instance adapters (`instance` column, migration 016, adapter registry keying, webhook/delivery routing)
- **B** Provider capabilities (memory scaffold, `providesAgentSurfaces`, `onExchangeComplete`)
- **C** OneCLI SDK 2.2.1 / `/v1` requirement + `versions.json` pins
- **D** New uninstall page (`./nanoclaw.sh --uninstall`)
- Provider-neutral voice continues per-page through A–D, plus a sweep of remaining top-of-funnel pages

`mint validate` passes.