### PR TITLE
docs: multi-instance adapters (instance dimension) for v2.1.15

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,52 @@
+# Repository Guidelines
+
+## Project structure & module organization
+
+This repository contains the Mintlify documentation site for NanoClaw. Site configuration, navigation, redirects, branding, and search settings live in `docs.json`. Pages are MDX files at the root and in topic directories:
+
+- `channels/`, `operate/`, `guides/`, `extend/`, `concepts/`, and `reference/` contain public docs pages.
+- `changelog/` contains product and documentation update logs.
+- `images/` contains static assets.
+- `docs/superpowers/` contains internal planning/spec files and is not part of the public docs navigation.
+
+Root pages such as `introduction.mdx`, `quickstart.mdx`, and `installation.mdx` form the getting-started flow.
+
+## Build, test, and development commands
+
+Install the Mintlify CLI once:
+
+```bash
+npm i -g mint
+```
+
+Use these commands from the repository root:
+
+```bash
+mint dev
+mint validate
+mint broken-links
+mint a11y
+mint rename old-path.mdx new-path.mdx
+```
+
+`mint dev` starts a local preview at `http://localhost:3000`. `mint validate` checks the site build and should pass before a PR. `mint broken-links` is required when changing links. `mint a11y` checks content accessibility. `mint rename` moves pages while updating references.
+
+## Coding style & naming conventions
+
+Write docs in MDX. Every public page needs YAML frontmatter with at least `title` and `description`. Use kebab-case file names such as `scheduled-tasks.mdx`. Use sentence case headings, active voice, second person, and concise examples.
+
+Internal links must be root-relative and omit extensions, for example `/guides/first-agent`. Store images in `images/`, reference them as `/images/name.svg`, and include descriptive alt text. Prefer Mintlify components such as `<Note>`, `<Warning>`, `<Steps>`, `<Tabs>`, and `<Card>`.
+
+## Testing guidelines
+
+There is no unit test suite in this docs repo. Validation is Mintlify-based. Run `mint validate` for content or config changes. Run `mint broken-links` when touching navigation, redirects, anchors, or page links. For major visual or structural changes, run `mint dev` and inspect affected pages locally.
+
+## Commit & pull request guidelines
+
+Recent history uses concise Conventional Commit-style messages, especially `docs:` and scoped variants such as `docs(changelog): add portal refactor entry`. Keep commits focused on one documentation concern.
+
+Pull requests should describe what changed, why it changed, and which pages were affected. Link related issues when applicable. Include screenshots for layout, navigation, or component changes. Before review, confirm `mint validate` passed and note whether `mint broken-links` was run.
+
+## Agent-specific instructions
+
+Read `CLAUDE.md` before larger edits. It contains architecture notes, source-of-truth rules, drift traps, and PR workflow details. When documenting product behavior, verify claims against the upstream NanoClaw source instead of older prose.

--- a/changelog/docs-updates.mdx
+++ b/changelog/docs-updates.mdx
@@ -5,6 +5,14 @@ icon: "file-pen"
 rss: true
 ---
 
+<Update label="Multi-instance adapters: the instance dimension" description="2026-06-14" tags={["Updated"]}>
+  v2.1.15 lets you run several adapters of one platform at once (e.g. three Slack apps in one workspace). A new `instance` dimension threads through the stack, and the docs now describe it where it lands. Verified against `nanocoai/nanoclaw@435233a`.
+
+  - **`reference/adapter-interface.mdx`**: new optional `instance` field on the `ChannelAdapter` contract (defaults to `channelType`; URL-safe routing key); `channelType` clarified as the semantic platform key; webhook registration now uses a `routingPath` and the shared server also accepts raw `registerWebhookHandler()` routes
+  - **`reference/db-schema.mdx`** + **`concepts/entity-model.mdx`**: `messaging_groups` is now keyed `(channel_type, platform_id, instance)`; documented the new `instance` column, migration 016's backfill (`instance = channel_type`), and the per-instance `chat_sdk_kv` key prefix
+  - **`channels/overview.mdx`** + **`concepts/architecture.mdx`**: webhook server routes by `routingPath` with raw handlers taking priority; delivery resolves the owning adapter by `instance` so a reply leaves through the adapter the message arrived on
+</Update>
+
 <Update label="Drift sweep against v2.1.15: token count and container CLIs" description="2026-06-14" tags={["Updated"]}>
   First slice of re-verification against upstream `nanocoai/nanoclaw@435233a` (v2.1.15, up from v2.1.4). Two code-confirmed factual corrections shipped; larger concerns (multi-instance adapters, provider memory scaffold, OneCLI `/v1` upgrade, the new uninstall flow) follow in separate PRs.
 

--- a/channels/overview.mdx
+++ b/channels/overview.mdx
@@ -5,7 +5,7 @@ tag: "UPDATED"
 keywords: ["channels", "adapters", "channel registry", "chat sdk", "webhook", "add-telegram", "add-discord", "add-slack", "manage-channels"]
 ---
 
-{/* verified-against: src/channels/{adapter,channel-registry,index,chat-sdk-bridge,cli}.ts, src/webhook-server.ts, .claude/skills/{manage-channels,add-telegram}/SKILL.md, upstream/channels:src/channels/ @ dc34ceb (v2.1.4) */}
+{/* verified-against: src/channels/{adapter,channel-registry,index,chat-sdk-bridge,cli}.ts, src/webhook-server.ts, .claude/skills/{manage-channels,add-telegram}/SKILL.md, upstream/channels:src/channels/ @ 435233a (v2.1.15) */}
 
 NanoClaw trunk ships channel **infrastructure** — the adapter interface, the registry, the Chat SDK bridge, the webhook server — plus one built-in channel: `cli`, an always-on local-terminal channel that needs no credentials. Every platform adapter (Telegram, Discord, Slack, WhatsApp, …) lives on the `channels` branch of the repo and is installed on demand with an `/add-<channel>` skill. Your fork only contains the channels you actually use.
 
@@ -24,7 +24,7 @@ flowchart LR
     REG[Channel registry] -.->|"instantiates at startup,<br/>resolves adapter for delivery"| A
 ```
 
-The adapter normalizes platform events into inbound messages; the router matches them to a wiring (which agent group handles which chat) and writes them into the right session; the agent's reply drains through the delivery module, which looks up the adapter by channel type in the registry and calls `deliver()`.
+The adapter normalizes platform events into inbound messages; the router matches them to a wiring (which agent group handles which chat) and writes them into the right session; the agent's reply drains through the delivery module, which looks up the owning adapter in the registry — by the messaging group's `instance` (which defaults to the channel type) — and calls `deliver()`, so a reply always leaves through the same adapter the message arrived on.
 
 Adapters come in two flavors:
 
@@ -75,8 +75,11 @@ The built-in `cli` channel isn't in this table because it ships on trunk — see
 Chat SDK channels that receive platform events over HTTP (Slack, Teams, GitHub, and others) share one webhook server. It starts lazily when the first such adapter registers and routes by path:
 
 ```text
-/webhook/{adapterName}   →   that adapter's Chat SDK webhook handler
+/webhook/{routingPath}   →   that adapter's Chat SDK webhook handler
+/webhook/{path}          →   a raw handler from registerWebhookHandler()
 ```
+
+The routing path defaults to the adapter name, so single-instance routes are unchanged; a second adapter of the same platform passes an `instance` and listens on `/webhook/{instance}` with its own signing secret. Modules that need a non–Chat SDK endpoint (a custom GitHub webhook, a payment provider, a health check) register a raw handler on the same server with `registerWebhookHandler(path, handler)` instead of opening a second port — raw routes take priority over adapter routes.
 
 The port comes from the `WEBHOOK_PORT` environment variable, default `3000`. Point the platform's event subscription URL at `https://<your-public-host>/webhook/<channel>` (e.g. `/webhook/slack`) — you'll need a public URL or a tunnel for these channels. Discord is the exception: it uses a persistent Gateway listener instead of inbound webhooks, so no public URL is required. Telegram (long polling), WhatsApp, Signal, and WeChat hold their own outbound connections, so they don't need one either.
 

--- a/concepts/architecture.mdx
+++ b/concepts/architecture.mdx
@@ -71,7 +71,7 @@ On the outbound side, `src/delivery.ts` drains `messages_out`: an in-flight set 
 Modules (permissions, scheduling, approvals, agent-to-agent, typing, and so on) self-register through barrel imports before `main()` runs — they hook into the router and delivery pipeline rather than being called by name from core.
 
 <Note>
-There is no HTTP API. The webhook server (`src/webhook-server.ts`) starts lazily when the first Chat SDK adapter registers, listens on `WEBHOOK_PORT` (default 3000), and only accepts inbound platform webhooks at `/webhook/{adapter}`. The admin surface is the `ncl` CLI over the Unix socket, not HTTP.
+There is no HTTP API. The webhook server (`src/webhook-server.ts`) starts lazily when the first Chat SDK adapter registers and listens on `WEBHOOK_PORT` (default 3000). It routes by path: `/webhook/{routingPath}` reaches a Chat SDK adapter (the routing path defaults to the adapter name; a second instance of one platform gets its own path), and `/webhook/{path}` reaches a raw handler that a module registered with `registerWebhookHandler()` for non–Chat SDK webhooks — raw routes take priority. The admin surface is the `ncl` CLI over the Unix socket, not HTTP.
 </Note>
 
 ## Inside the container

--- a/concepts/entity-model.mdx
+++ b/concepts/entity-model.mdx
@@ -5,7 +5,7 @@ tag: "UPDATED"
 keywords: ["entity model", "agent groups", "messaging groups", "wirings", "messaging_group_agents", "engage_mode", "session_mode", "sender_scope", "roles", "owner", "admin", "sessions"]
 ---
 
-{/* verified-against: src/db/schema.ts, src/db/migrations/{010-engage-modes,011-pending-sender-approvals,012-channel-registration}.ts, src/types.ts, src/router.ts, src/session-manager.ts, src/modules/permissions/{index.ts,access.ts}, src/command-gate.ts @ dc34ceb (v2.1.4) */}
+{/* verified-against: src/db/schema.ts, src/db/migrations/{010-engage-modes,011-pending-sender-approvals,012-channel-registration,016-messaging-group-instance}.ts, src/types.ts, src/router.ts, src/session-manager.ts, src/modules/permissions/{index.ts,access.ts}, src/command-gate.ts @ 435233a (v2.1.15) */}
 
 Everything NanoClaw does reduces to five entities in `data/v2.db`: **agent groups** (where agents run), **messaging groups** (where people talk), **wirings** (the edge connecting them, which holds all the behavior), **users** (who is allowed to do what), and **sessions** (the conversation state in between). This page is the mental model; for column-level detail see the [database schema](/reference/db-schema).
 
@@ -35,7 +35,7 @@ An agent group is a workspace: a folder under `groups/<name>/` with its own work
 
 ## Messaging groups — a platform conversation
 
-A messaging group is one chat or channel on one platform, identified by `(channel_type, platform_id)` — a Discord channel, a WhatsApp group, a DM. It carries an `unknown_sender_policy` (`strict` / `request_approval` / `public`) and can be denied (`denied_at`), after which messages from it drop silently.
+A messaging group is one chat or channel on one platform, identified by `(channel_type, platform_id, instance)` — a Discord channel, a WhatsApp group, a DM. The `instance` names the adapter that owns the chat, so running several adapters of one platform (say three Slack apps in one workspace) keeps their chats distinct; it defaults to the channel type, so single-instance installs effectively key on `(channel_type, platform_id)` as before. It carries an `unknown_sender_policy` (`strict` / `request_approval` / `public`) and can be denied (`denied_at`), after which messages from it drop silently.
 
 You don't pre-register these. When a mention or DM arrives on a chat NanoClaw has never seen, the router auto-creates the row with `unknown_sender_policy = 'request_approval'` — and if no agent is wired to it, escalates to an approver (group admins first, then global admins, then owners) with an approve/deny card before any agent responds. Plain chatter in unwired channels is ignored entirely.
 

--- a/reference/adapter-interface.mdx
+++ b/reference/adapter-interface.mdx
@@ -5,7 +5,7 @@ tag: "NEW"
 keywords: ["channel adapter", "ChannelAdapter", "adapter interface", "custom channel", "chat sdk bridge", "registerChannelAdapter", "initChannelAdapters", "supportsThreads", "deliver", "InboundMessage"]
 ---
 
-{/* verified-against: src/channels/adapter.ts, src/channels/channel-registry.ts, src/channels/chat-sdk-bridge.ts, src/channels/index.ts, src/webhook-server.ts, channels branch src/channels/telegram.ts @ dc34ceb (v2.1.4) */}
+{/* verified-against: src/channels/adapter.ts, src/channels/channel-registry.ts, src/channels/chat-sdk-bridge.ts, src/channels/index.ts, src/webhook-server.ts, channels branch src/channels/telegram.ts @ 435233a (v2.1.15) */}
 
 A channel adapter bridges NanoClaw with a messaging platform. There are two ways to build one:
 
@@ -23,6 +23,15 @@ The full interface, from `src/channels/adapter.ts`:
 export interface ChannelAdapter {
   name: string;
   channelType: string;
+
+  /**
+   * Adapter-instance name — distinguishes N adapters of one platform
+   * (e.g. three Slack apps in one workspace). Defaults to channelType.
+   * channelType stays the SEMANTIC platform key (user ids, formatting,
+   * container config); instance is a host-side routing key only.
+   * Must be unique across active adapters and URL-safe (no '/', '?', ':').
+   */
+  instance?: string;
 
   /**
    * Whether this adapter models conversations as threads.
@@ -83,7 +92,8 @@ How the host calls each member:
 
 | Member | Required | How the host uses it |
 |---|---|---|
-| `name` / `channelType` | Yes | `name` labels logs; `channelType` keys the adapter in the active-adapter map and in `messaging_groups.channel_type`. The bridge sets both to the Chat SDK adapter's name. |
+| `name` / `channelType` | Yes | `name` labels logs; `channelType` is the semantic platform key — user ids, formatting, and `messaging_groups.channel_type`. The bridge sets both to the Chat SDK adapter's name. |
+| `instance?` | No | Names this adapter instance so N adapters of one platform (e.g. three Slack apps in one workspace) can coexist. The host keys the active-adapter map by `instance ?? channelType`, stamps it on inbound events and `messaging_groups.instance`, and routes replies and typing back through the instance a message arrived on. Omit it and the instance defaults to `channelType` — single-instance installs are byte-for-byte unchanged. Must be unique across active adapters and URL-safe (`[A-Za-z0-9._-]`). |
 | `supportsThreads` | Yes | `true`: one thread = one session, replies go to the originating thread. `false`: the router strips thread ids and the channel itself is the conversation. This shapes [session identity](/concepts/entity-model). |
 | `setup(config)` | Yes | Called once at startup by `initChannelAdapters()`. Connect to the platform here and hold on to `config` — its callbacks are how you hand messages to the host. |
 | `teardown()` | Yes | Called on shutdown by `teardownChannelAdapters()`. Close connections; errors are logged, not fatal. |
@@ -164,7 +174,7 @@ export interface ChannelRegistration {
 `createChatSdkBridge(config)` from `src/channels/chat-sdk-bridge.ts` wraps a Chat SDK `Adapter` into a complete `ChannelAdapter`. What it handles for you:
 
 - **Inbound dispatch** — wires all four SDK paths (subscribed threads, new mentions, DMs, plain messages) into `onInbound`, with the platform-confirmed `isMention` flag set correctly for each.
-- **Webhook or gateway registration** — gateway-capable adapters (Discord) get a supervised gateway listener with exponential backoff; everything else is registered on the shared webhook server at `/webhook/{adapterName}` (port `WEBHOOK_PORT`, default 3000).
+- **Webhook or gateway registration** — gateway-capable adapters (Discord) get a supervised gateway listener with exponential backoff; everything else is registered on the shared webhook server at `/webhook/{routingPath}` (port `WEBHOOK_PORT`, default 3000). The routing path defaults to the adapter name, so single-instance routes are unchanged; a second instance of the same platform passes an `instance` and registers on `/webhook/{instance}` with its own signing secret and Chat SDK state namespace. Modules can also claim a raw `/webhook/{path}` for non–Chat SDK webhooks via `registerWebhookHandler()` — raw routes take priority over adapter routes.
 - **Chunking** — set `maxTextLength` and outbound text longer than the platform limit is split on paragraph → line → word (space) → hard-character boundaries into multiple messages. Files ride on the first chunk, and the first chunk's id is returned so edits and reactions still target the head of the reply. Without it, platforms like Discord (2000) and Telegram (4096) truncate silently.
 - **Reply context** — pass `extractReplyContext` to pull quoted-reply text and sender out of the platform's raw message.
 - **Attachments** — inbound attachments are downloaded and base64-embedded before serialization; outbound `message.files` are posted as uploads.

--- a/reference/db-schema.mdx
+++ b/reference/db-schema.mdx
@@ -5,7 +5,7 @@ tag: "NEW"
 keywords: ["database", "schema", "sqlite", "v2.db", "inbound.db", "outbound.db", "messages_in", "messages_out", "sessions", "container_configs", "pending_sender_approvals", "migrations"]
 ---
 
-{/* verified-against: src/db/schema.ts, src/db/connection.ts, src/db/session-db.ts, src/session-manager.ts, src/db/migrations/{001-initial,002-chat-sdk-state,module-approvals-pending-approvals,module-agent-to-agent-destinations,module-approvals-title-options,008-dropped-messages,009-drop-pending-credentials,010-engage-modes,011-pending-sender-approvals,012-channel-registration,013-approval-render-metadata,014-container-configs,015-cli-scope,index}.ts, container/agent-runner/src/db/messages-out.ts, src/modules/scheduling/db.ts @ dc34ceb (v2.1.4) */}
+{/* verified-against: src/db/schema.ts, src/db/connection.ts, src/db/session-db.ts, src/session-manager.ts, src/db/migrations/{001-initial,002-chat-sdk-state,module-approvals-pending-approvals,module-agent-to-agent-destinations,module-approvals-title-options,008-dropped-messages,009-drop-pending-credentials,010-engage-modes,011-pending-sender-approvals,012-channel-registration,013-approval-render-metadata,014-container-configs,015-cli-scope,016-messaging-group-instance,index}.ts, container/agent-runner/src/db/messages-out.ts, src/modules/scheduling/db.ts @ 435233a (v2.1.15) */}
 
 NanoClaw stores everything in SQLite, split across two layers:
 
@@ -36,13 +36,14 @@ Agent workspaces: folder, skills, CLAUDE.md. All workspaces are equal — privil
 
 ### messaging_groups
 
-Platform chats and channels, one row per `(channel_type, platform_id)` pair (UNIQUE).
+Platform chats and channels, one row per `(channel_type, platform_id, instance)` triple (UNIQUE).
 
 | Column | Type | Default | Meaning |
 |---|---|---|---|
 | `id` | TEXT | — | Primary key |
 | `channel_type` | TEXT | — | `whatsapp`, `discord`, `slack`, … |
 | `platform_id` | TEXT | — | The platform's chat/channel ID |
+| `instance` | TEXT | — | Adapter instance that owns the chat — distinguishes N adapters of one platform (e.g. three Slack apps). `NOT NULL`; migration 016 backfills `instance = channel_type`, so the default instance is the channel type itself |
 | `name` | TEXT | `NULL` | Display name |
 | `is_group` | INTEGER | `0` | `1` for group chats, `0` for DMs |
 | `unknown_sender_policy` | TEXT | `'strict'` | `'strict'` \| `'request_approval'` \| `'public'` — what happens when a never-seen sender posts |
@@ -50,6 +51,8 @@ Platform chats and channels, one row per `(channel_type, platform_id)` pair (UNI
 | `created_at` | TEXT | — | ISO timestamp |
 
 The `'strict'` column default is mostly vestigial: every creation callsite passes the policy explicitly, and the router's auto-create path hardcodes `'request_approval'`.
+
+Migration 016 added `instance` and relaxed the UNIQUE constraint from `(channel_type, platform_id)` to `(channel_type, platform_id, instance)` via a full table rebuild (SQLite can't relax a table-level UNIQUE in place). Existing rows backfill to `instance = channel_type`, so single-instance installs see no behavioral change.
 
 ### messaging_group_agents
 
@@ -253,7 +256,7 @@ Audit log of dropped messages from senders that didn't pass policy (migration 00
 
 ### chat_sdk_* tables
 
-Four small tables backing the Chat SDK bridge state (migration 002): `chat_sdk_kv` (key/value with optional `expires_at`), `chat_sdk_subscriptions` (`thread_id`, `subscribed_at`), `chat_sdk_locks` (`thread_id`, `token`, `expires_at`), and `chat_sdk_lists` (`key`, `idx`, `value`, optional `expires_at`).
+Four small tables backing the Chat SDK bridge state (migration 002): `chat_sdk_kv` (key/value with optional `expires_at`), `chat_sdk_subscriptions` (`thread_id`, `subscribed_at`), `chat_sdk_locks` (`thread_id`, `token`, `expires_at`), and `chat_sdk_lists` (`key`, `idx`, `value`, optional `expires_at`). A named non-default adapter instance prefixes its keys with `<instance>:` so sibling instances of one platform never collide; the default instance uses unprefixed keys (the legacy keyspace), so the table layout is unchanged.
 
 ### schema_version
 


### PR DESCRIPTION
Concern **A** of the v2.1.15 drift sweep (stacked on #308). Documents the new *multi-instance adapter* support — running N adapters of one platform at once (e.g. three Slack apps in one workspace) via an `instance` dimension that threads through the registry, webhook routing, the DB, and delivery.

Every claim re-read against `nanocoai/nanoclaw@435233a` directly (not just the verification-agent reports).

## Pages
- **`reference/adapter-interface.mdx`**: new optional `instance` field on the `ChannelAdapter` contract (defaults to `channelType`; URL-safe host-side routing key, `[A-Za-z0-9._-]`). `channelType` clarified as the semantic platform key. Webhook registration now uses a `routingPath` (defaults to adapter name); the shared server also accepts raw `registerWebhookHandler()` routes, which take priority. SHA → `435233a`.
- **`reference/db-schema.mdx`** + **`concepts/entity-model.mdx`**: `messaging_groups` keyed `(channel_type, platform_id, instance)`; new `instance` column, migration 016 backfill (`instance = channel_type`), per-instance `chat_sdk_kv` key prefix. SHA → `435233a`.
- **`channels/overview.mdx`**: webhook routing + raw handlers; delivery resolves the owning adapter by `instance` so a reply leaves through the adapter the message arrived on. SHA → `435233a`.
- **`concepts/architecture.mdx`**: webhook routing note updated. **SHA intentionally left at `dc34ceb`** — the page also cites `container-runner.ts`/`index.ts`/`host-sweep.ts`, which carry concern B/E changes still pending re-verification.

## Verification note
Caught a verification-agent error before it shipped: the `ChannelAdapter` `setTyping`/`deliver` signatures are **unchanged**. The `instance` param was added to the typing → delivery *bridge* (which uses it to select the right adapter), not to the adapter contract. Confirmed against the `adapter.ts` diff (0 `setTyping` hits).

## Deferred to later concerns
Pure SHA-only bumps on pages that span multiple concerns (`isolation-levels`, `multi-agent-swarm`, `channels/{discord,slack,teams,more-channels}`) are left for the PR that completes each page's re-verification, to avoid over-attesting.

`mint validate` passes.