### PR TITLE
docs: OneCLI /v1 requirement and version pins for v2.1.15

### DIFF
--- a/changelog/docs-updates.mdx
+++ b/changelog/docs-updates.mdx
@@ -5,6 +5,13 @@ icon: "file-pen"
 rss: true
 ---
 
+<Update label="OneCLI gateway: /v1 requirement and version pins" description="2026-06-14" tags={["Updated"]}>
+  v2.1.15 moved `@onecli-sh/sdk` to 2.x, which talks to the OneCLI gateway's `/v1` API, and introduced `versions.json` as the machine-checkable source for sanctioned component pins. Verified against `nanocoai/nanoclaw@435233a`.
+
+  - **`operate/credentials.mdx`**: setup installs the gateway and `onecli` CLI at the `versions.json` pins (`onecli-gateway`, `onecli-cli`), never `latest`; it probes `/v1/health` and warns (never auto-upgrades) when the gateway predates the `/v1` API, pointing to the `docs/onecli-upgrades.md` runbook
+  - **`operate/upgrading.mdx`**: the `/update-nanoclaw` breaking-changes step now also diffs `versions.json` for moved component pins and routes each to its migration path — a skill or a `docs/` page
+</Update>
+
 <Update label="Provider capability hooks" description="2026-06-14" tags={["Updated"]}>
   v2.1.15 added provider-agnostic capability hooks so a non-Claude provider can plug into NanoClaw without special-casing. Documented on **`extend/providers.mdx`**, verified against `nanocoai/nanoclaw@435233a`.
 

--- a/operate/credentials.mdx
+++ b/operate/credentials.mdx
@@ -5,7 +5,7 @@ tag: "NEW"
 keywords: ["credentials", "OneCLI", "Agent Vault", "secrets", "approval", "onecli-managed", "credential proxy", "ANTHROPIC_BASE_URL"]
 ---
 
-{/* verified-against: src/modules/approvals/onecli-approvals.ts, src/modules/approvals/primitive.ts, src/cli/resources/approvals.ts, src/config.ts, src/egress-lockdown.ts, src/providers/claude.ts, setup/onecli.ts, setup/auto.ts, setup/register-claude-token.sh, container/skills/onecli-gateway/SKILL.md, .claude/skills/init-onecli/SKILL.md, .claude/skills/use-native-credential-proxy/SKILL.md, .claude/skills/add-gmail-tool/SKILL.md @ dc34ceb */}
+{/* verified-against: src/modules/approvals/onecli-approvals.ts, src/modules/approvals/primitive.ts, src/cli/resources/approvals.ts, src/config.ts, src/egress-lockdown.ts, src/providers/claude.ts, setup/onecli.ts, setup/auto.ts, setup/register-claude-token.sh, container/skills/onecli-gateway/SKILL.md, .claude/skills/init-onecli/SKILL.md, .claude/skills/use-native-credential-proxy/SKILL.md, .claude/skills/add-gmail-tool/SKILL.md @ 435233a (v2.1.15) */}
 
 NanoClaw's credential invariant: **agent containers never hold raw API keys**. Secrets live in the OneCLI Agent Vault on the host, and the vault's gateway injects them into outbound HTTPS requests in flight. An agent that is prompt-injected, jailbroken, or just curious can dump its entire environment and filesystem and find nothing worth stealing.
 
@@ -28,6 +28,8 @@ The [setup wizard](/installation) handles the vault as one of its steps, with th
 - **Fresh install (default)** — runs the OneCLI installer (a Docker Compose stack plus the `onecli` CLI), points the CLI at the new instance, and writes `ONECLI_URL` to `.env`.
 - **Reuse existing** — if setup detects a working `onecli` on the host, it asks before reinstalling. Choosing reuse leaves the running gateway untouched (re-running the installer would rebind the listener and break other apps using it) and just records its URL.
 - **Remote vault** — set `NANOCLAW_ONECLI_API_HOST` before running setup to point at a OneCLI instance on another machine. Setup installs only the CLI, health-checks the remote URL, and writes `ONECLI_URL`. Pass the remote vault's API token via `NANOCLAW_ONECLI_API_TOKEN` so setup can authenticate the CLI and write `ONECLI_API_KEY`.
+
+Setup installs the gateway and `onecli` CLI at the versions pinned in `versions.json` (`onecli-gateway`, `onecli-cli`), never at `latest`. It also probes the gateway's `/v1/health`: `@onecli-sh/sdk` 2.x talks to the gateway's `/v1` API, and a gateway that predates it answers `404` to every vault call — failures that look transient but are permanent. Setup never upgrades the gateway for you; it warns and points to the verbatim migration runbook, [`docs/onecli-upgrades.md`](https://github.com/nanocoai/nanoclaw/blob/main/docs/onecli-upgrades.md). The gateway pin also moves through `/update-nanoclaw` — see [Upgrading](/operate/upgrading).
 
 On an existing install (for example after `/update-nanoclaw` brings in OneCLI as a breaking change), run the `/init-onecli` skill instead. It installs the vault, migrates any credentials it finds in `.env` (Anthropic keys, `OPENAI_API_KEY`, and similar container-facing secrets) into the vault, and removes the raw values from `.env`. Channel tokens like `TELEGRAM_BOT_TOKEN` stay in `.env` — the host process uses those, not the containers.
 

--- a/operate/upgrading.mdx
+++ b/operate/upgrading.mdx
@@ -5,7 +5,7 @@ tag: "NEW"
 keywords: ["upgrade", "update", "update-nanoclaw", "update-skills", "migrate-nanoclaw", "upstream", "merge", "rollback"]
 ---
 
-{/* verified-against: .claude/skills/update-nanoclaw/SKILL.md, .claude/skills/update-skills/SKILL.md, .claude/skills/migrate-nanoclaw/SKILL.md, scripts/upgrade-state.ts, src/upgrade-state.ts @ dc34ceb */}
+{/* verified-against: .claude/skills/update-nanoclaw/SKILL.md, .claude/skills/update-skills/SKILL.md, .claude/skills/migrate-nanoclaw/SKILL.md, scripts/upgrade-state.ts, src/upgrade-state.ts @ 435233a (v2.1.15) */}
 
 Don't update with a raw `git pull`. NanoClaw records each sanctioned upgrade in `data/upgrade-state.json`, and a startup tripwire refuses to boot if the running code's version doesn't match that marker. The supported path is the `/update-nanoclaw` skill, which handles the merge, validation, and the marker stamp for you.
 
@@ -20,7 +20,7 @@ Run `/update-nanoclaw` in a Claude Code session at your project root. The skill 
 5. **Conflict preview.** Dry-runs the merge (`git merge --no-commit --no-ff`, then abort) so you see which files would conflict before committing to anything.
 6. **Merge and resolve.** Applies your chosen path. On conflicts it opens only the conflicted files, resolves the markers, and keeps your local customizations intact.
 7. **Validation.** Runs `pnpm run build` and `pnpm test`. If `container/` files changed, it also rebuilds the container image with `./container/build.sh`.
-8. **Breaking changes.** Scans the new `CHANGELOG.md` entries for `[BREAKING]` lines and offers to run each referenced migration skill.
+8. **Breaking changes.** Scans the new `CHANGELOG.md` entries for `[BREAKING]` lines and diffs `versions.json` for moved component pins (e.g. `onecli-gateway`, `onecli-cli`). Each carries a migration path — a skill to run or a `docs/` page to follow verbatim — and the skill offers to run each one. A moved `onecli-gateway` pin, for example, routes you to [`docs/onecli-upgrades.md`](https://github.com/nanocoai/nanoclaw/blob/main/docs/onecli-upgrades.md); the gateway is an external component, so it's never upgraded for you.
 9. **Marker stamp.** On success, stamps the upgrade marker (`pnpm exec tsx scripts/upgrade-state.ts set "" update-nanoclaw`) so the tripwire passes on next start.
 10. **Summary.** Prints the backup tag, conflicts resolved, and the restart command for your platform.
 


### PR DESCRIPTION
Concern **C** of the v2.1.15 drift sweep. v2.1.15 moved `@onecli-sh/sdk` to 2.x (which talks to the OneCLI gateway's `/v1` API) and added `versions.json` as the machine-checkable source for sanctioned component pins. Re-read against `nanocoai/nanoclaw@435233a` directly.

## Pages
- **`operate/credentials.mdx`**: setup installs the gateway and `onecli` CLI at the `versions.json` pins (`onecli-gateway` 1.36.0, `onecli-cli` 2.2.5), never `latest`. It probes the gateway's `/v1/health` and warns (never auto-upgrades) when the gateway predates the `/v1` API — pre-`/v1` servers `404` every vault call permanently — pointing to the verbatim migration runbook `docs/onecli-upgrades.md`. SHA → `435233a`.
- **`operate/upgrading.mdx`**: the `/update-nanoclaw` breaking-changes step now also diffs `versions.json` for moved component pins and routes each to its migration path — a skill **or** a `docs/` page. SHA → `435233a`.

## Verification notes
- Confirmed the `approvals/primitive.ts` change (which `credentials` cites) is purely additive — a new approval-resolved *callback* mechanism for module observability — with **no** drift to the documented credential approval-card flow.
- `setup/auto.ts`'s change is uninstall wiring (concern D), unrelated to the credential setup paths.

## Deferred
`reference/environment-variables.mdx` cites `setup/onecli.ts` but no env var drifted (the version pins aren't env vars). Its SHA goes with concern D, which touches the `setup-config.ts` uninstall flags it also cites.

`mint validate` and `mint broken-links` pass.