### PR TITLE
docs: add Uninstall page for v2.1.15

### DIFF
--- a/changelog/docs-updates.mdx
+++ b/changelog/docs-updates.mdx
@@ -5,6 +5,15 @@ icon: "file-pen"
 rss: true
 ---
 
+<Update label="New page: Uninstall NanoClaw" description="2026-06-14" tags={["New"]}>
+  v2.1.15 added an interactive uninstaller (`bash nanoclaw.sh --uninstall`). New **`operate/uninstall.mdx`** documents it, verified against `nanocoai/nanoclaw@435233a`.
+
+  - The scan → confirm → execute flow, the four removal groups, and what's deliberately left alone (the OneCLI vault, other NanoClaw copies — everything is scoped to the per-checkout install slug)
+  - The `--dry-run` and `--yes` flags, the `.env` backup, the Ctrl-C-safe confirm phase, and the manual fallback when `node_modules/` is already gone
+  - Resolved a flag-spelling discrepancy against source: the flags are `--dry-run`/`--yes` (kebab-case), and they're CLI-only — there are no `NANOCLAW_*` env vars for them
+  - `reference/environment-variables.mdx` re-verified (no env var drift in v2.1.15) and its SHA bumped
+</Update>
+
 <Update label="OneCLI gateway: /v1 requirement and version pins" description="2026-06-14" tags={["Updated"]}>
   v2.1.15 moved `@onecli-sh/sdk` to 2.x, which talks to the OneCLI gateway's `/v1` API, and introduced `versions.json` as the machine-checkable source for sanctioned component pins. Verified against `nanocoai/nanoclaw@435233a`.
 

--- a/docs.json
+++ b/docs.json
@@ -144,7 +144,7 @@
           {
             "group": "Operate",
             "icon": "gauge",
-            "pages": ["operate/configuration", "operate/ncl-cli", "operate/credentials", "operate/hardening", "operate/upgrading", "operate/troubleshooting"]
+            "pages": ["operate/configuration", "operate/ncl-cli", "operate/credentials", "operate/hardening", "operate/upgrading", "operate/uninstall", "operate/troubleshooting"]
           },
           {
             "group": "Build with agents",

--- a/operate/uninstall.mdx
+++ b/operate/uninstall.mdx
@@ -1,0 +1,98 @@
+---
+title: "Uninstall NanoClaw"
+description: "Remove a NanoClaw install — service, containers, data, and credential agents — with a scan, confirm, and execute flow scoped to this checkout."
+icon: "trash"
+tag: "NEW"
+keywords: ["uninstall", "remove", "delete", "cleanup", "nanoclaw.sh --uninstall", "dry run", "install slug"]
+---
+
+{/* verified-against: setup/uninstall/{flow,scan,plan,remove,onecli-agents}.ts, setup/lib/setup-config.ts, setup/auto.ts, uninstall.sh, nanoclaw.sh, src/install-slug.ts @ 435233a (v2.1.15) */}
+
+NanoClaw ships an interactive uninstaller that removes a single install — its service, containers, image, data, and the credential agents it registered. Everything NanoClaw creates is tagged with a per-checkout **install slug** (the first 8 hex characters of `sha1(projectRoot)`), so the uninstaller only ever touches the copy you run it from. Two NanoClaw checkouts on one host never remove each other's artifacts.
+
+## Run it
+
+From the project root:
+
+```bash
+bash nanoclaw.sh --uninstall
+```
+
+The uninstaller short-circuits before any setup work, so it never installs dependencies just to remove them. There's also a wrapper that accepts the legacy short flags (`-n` → `--dry-run`, `-y` → `--yes`):
+
+```bash
+./uninstall.sh
+```
+
+And if you run setup on a folder that already has an install, the wizard offers **Uninstall NanoClaw & exit** as an alternative to upgrading.
+
+<Tip>
+Start with `bash nanoclaw.sh --uninstall --dry-run` to see exactly what would be removed without changing anything.
+</Tip>
+
+## What gets removed
+
+The uninstaller groups everything it finds into four confirmation groups. Each group is shown as a what/where table and asks a separate, default-**No** question — you opt into each one.
+
+| Group | Contains |
+|---|---|
+| **1) App & background service** | The background service (launchd/systemd), any running NanoClaw process, this install's Docker containers and image (matched by the install slug), and the `ncl` command symlink. |
+| **2) App data, logs & secrets** | The central database (`data/v2.db`, with message history), logs, build files (`dist/`, `node_modules/`), and your `.env` (API keys and tokens). Removing this erases stored conversations and saved credentials. |
+| **3) Agents' memory & files** | Notes and memory your agents created (`groups/`) and any migrated data (`store/`). Content you made — unrecoverable after deletion. |
+| **4) OneCLI credential agents** | The per-agent entries this copy registered in the OneCLI vault. |
+
+Your `.env` is never deleted outright — it's copied to `.env.bak` first (a timestamped name if a backup already exists), so saved credentials survive the removal.
+
+## What's left alone
+
+The uninstaller is deliberately narrow. It does **not** touch:
+
+- **The OneCLI app, your credentials, and the gateway** — the vault is a shared, out-of-band component, so removing one NanoClaw copy never tears it down.
+- **Other NanoClaw copies on the machine** — the install slug scopes every action to the current checkout.
+- **Anything it can't confidently attribute to this copy** — for example OneCLI agents from another checkout (it labels these "orphans"). These are listed as "left in place" rather than removed.
+
+A final summary prints what was left alone and any step that couldn't complete, with a manual command to finish the job.
+
+## How it works
+
+<Steps>
+<Step title="Scan">
+Inventories the artifacts tagged with this checkout's install slug. If nothing is found, it reports the copy is already clean and exits.
+</Step>
+<Step title="Confirm (or preview)">
+Each non-empty group is shown with its contents and a default-No prompt. Nothing is deleted until every decision is made, so pressing `Ctrl-C` anywhere in this phase leaves the install completely untouched. With `--dry-run`, this phase just prints what would be removed and exits.
+</Step>
+<Step title="Execute">
+Applies your choices in a safe order — service and containers first (so nothing can respawn), then credential agents, data, and your content. The runtime tail (`dist/`, then `node_modules/`) goes last, because the uninstaller itself is running out of `node_modules/`.
+</Step>
+</Steps>
+
+## Flags
+
+| Flag | Effect |
+|---|---|
+| `--uninstall` | Run the uninstaller. |
+| `--dry-run` | Preview what would be removed without changing anything. |
+| `--yes` | Delete everything found without prompting. Orphan vault agents (from other copies) are still kept. |
+
+`--yes` needs no terminal, which makes it the way to uninstall non-interactively; without it (and without `--dry-run`), the uninstaller requires an interactive terminal and stops otherwise.
+
+## If dependencies are missing
+
+The uninstaller runs on the TypeScript toolchain in `node_modules/`. If those are already gone, `bash nanoclaw.sh --uninstall` can't run the full flow — it prints manual cleanup commands instead, including how to remove this install's containers and image by slug:
+
+```bash
+docker ps -aq --filter label=nanoclaw-install=<slug> | xargs -r docker rm -f
+docker rmi nanoclaw-agent-v2-<slug>:latest
+```
+
+## Related pages
+
+<CardGroup cols={2}>
+  <Card title="Upgrading" icon="arrow-up" href="/operate/upgrading">
+    Update NanoClaw and its skills the supported way.
+  </Card>
+  <Card title="Credentials" icon="key" href="/operate/credentials">
+    The OneCLI vault the uninstaller deliberately leaves running.
+  </Card>
+</CardGroup>

--- a/reference/environment-variables.mdx
+++ b/reference/environment-variables.mdx
@@ -5,7 +5,7 @@ tag: "NEW"
 keywords: ["environment variables", ".env", "configuration", "ASSISTANT_NAME", "CONTAINER_TIMEOUT", "LOG_LEVEL", "NANOCLAW_SKIP", "NANOCLAW_EGRESS_LOCKDOWN", "setup", "reference"]
 ---
 
-{/* verified-against: src/config.ts, src/env.ts, src/log.ts, src/webhook-server.ts, src/egress-lockdown.ts, src/container-runner.ts, src/providers/claude.ts, setup/auto.ts, setup/onecli.ts, setup/lib/setup-config.ts, setup/lib/claude-assist.ts, setup/lib/diagnostics.ts, setup/signal-auth.ts, setup/container.ts, setup/migrate-v2/select-channels.ts, migrate-v2.sh, container/agent-runner/src/{timezone.ts,providers/claude.ts} @ dc34ceb (v2.1.4) */}
+{/* verified-against: src/config.ts, src/env.ts, src/log.ts, src/webhook-server.ts, src/egress-lockdown.ts, src/container-runner.ts, src/providers/claude.ts, setup/auto.ts, setup/onecli.ts, setup/lib/setup-config.ts, setup/lib/claude-assist.ts, setup/lib/diagnostics.ts, setup/signal-auth.ts, setup/container.ts, setup/migrate-v2/select-channels.ts, migrate-v2.sh, container/agent-runner/src/{timezone.ts,providers/claude.ts} @ 435233a (v2.1.15) */}
 
 Exhaustive list of every environment variable the NanoClaw host, setup wizard, and agent runner read. For how to actually set these — `.env` editing, service definitions, restart commands — see [Configuration](/operate/configuration).
 


### PR DESCRIPTION
Concern **D** of the v2.1.15 drift sweep — the last content concern. v2.1.15 added an interactive uninstaller; this adds a dedicated page for it, verified directly against `nanocoai/nanoclaw@435233a` (`setup/uninstall/*`, `setup-config.ts`, `auto.ts`, `uninstall.sh`, `nanoclaw.sh`, `install-slug.ts`).

## New page: `operate/uninstall.mdx`
- **Run it**: `bash nanoclaw.sh --uninstall`, the `./uninstall.sh` wrapper (legacy `-n`/`-y`), and the setup-detection "Uninstall & exit" path.
- **Scan → confirm → execute** flow: default-No per group, `Ctrl-C` in the confirm phase leaves the install untouched, runtime tail (`dist/`, `node_modules/`) removed last because the uninstaller runs out of `node_modules/`.
- The **four removal groups** (service/containers, data+`.env`, agent memory, OneCLI agents) and what's **left alone** (the OneCLI vault, other copies — everything scoped to the per-checkout install slug).
- `--dry-run`/`--yes`, the `.env` → `.env.bak` backup, and the manual cleanup fallback when `node_modules/` is gone.
- Added to the **Operate** nav group in `docs.json`.

## Verification note
Resolved a flag-spelling disagreement between the verification agents **against source**: the flags are `--dry-run`/`--yes` (kebab — `setup-config.ts` maps camelCase keys to kebab flags), and they're `surface: 'flag'` only, so **no `NANOCLAW_UNINSTALL`/`NANOCLAW_DRY_RUN` env vars exist** (one agent had invented them).

## Bundled SHA bump
`reference/environment-variables.mdx` → `435233a`. Confirmed **no env var drifted** in v2.1.15 across all its changed cited files (uninstall opts are flags; OneCLI pins aren't env vars; `NANOCLAW_REEXEC_SG`/`NANOCLAW_SKIP` predate `dc34ceb`; `webhook-server`/`container-runner` added none). Content unchanged.

`mint validate` and `mint broken-links` pass.