### PR TITLE
docs: drop "Docs are catching up to v2" from the banner

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -34,7 +34,7 @@
     "eyebrows": "breadcrumbs"
   },
   "banner": {
-    "content": "**Docs are catching up to v2.** [Join the Discord community](https://discord.gg/VDdww8qS42) — get help, share what you're building, or just say hi.",
+    "content": "[Join the Discord community](https://discord.gg/VDdww8qS42) — get help, share what you're building, or just say hi.",
     "dismissible": true
   },
   "navbar": {


### PR DESCRIPTION
The v2.1.4 → v2.1.15 sweep is complete and the site is current, so the "Docs are catching up to v2" disclaimer is stale. Removes just that phrase from the banner; keeps the Discord community invite.

`mint validate` passes.