### PR TITLE
docs: v2.1.16 changelogs (product + docs-updates) + token 195k

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,7 +184,7 @@ To PR changes to `nanocoai/nanoclaw` from Ethan's fork (`glifocat/nanoclaw-glifo
 
 ## Token Count
 
-Source of truth: `repo-tokens/badge.svg` in upstream (auto-generated) — the ONLY valid source. Never cite a number from prose, memory, or an automated PR; read the badge first. Last seen: 185k (~92% of Claude's context window) at dc34ceb (v2.1.4). Update pages that cite the count (e.g., `introduction.mdx`) if the badge value changes significantly.
+Source of truth: `repo-tokens/badge.svg` in upstream (auto-generated) — the ONLY valid source. Never cite a number from prose, memory, or an automated PR; read the badge first. Last seen: 195k (~98% of the context window) at e3986eb (v2.1.16). Update pages that cite the count (e.g., `introduction.mdx`) if the badge value changes significantly.
 
 ## Writing Standards
 

--- a/changelog/docs-updates.mdx
+++ b/changelog/docs-updates.mdx
@@ -5,6 +5,15 @@ icon: "file-pen"
 rss: true
 ---
 
+<Update label="v2.1.16 sweep: provider selection + full re-verification" description="2026-06-15" tags={["Updated"]}>
+  Brought the whole site current with `nanocoai/nanoclaw@e3986eb` (v2.1.16) — every content page is now anchored at v2.1.16.
+
+  - **Product changelog + token count**: added the v2.1.16 release (operator-driven provider selection, per-group provider switching via `ncl groups config update --provider`, and `/migrate-memory`) and bumped the codebase token count to 195k.
+  - **Provider selection (16 v2.1.15 pages)**: documented the setup-time runtime picker (`quickstart`), the memory-across-a-switch story and `/migrate-memory` (`extend/providers`), and fixed `multi-agent-swarm` (a spawned agent inherits its creator's provider; the seed lands in the provider's own memory surface) and `upgrading` (the `/update-nanoclaw` breaking-change check is skill-only now — it no longer diffs `versions.json` pins). Corrected six drifted `file:line` citations on `reference/environment-variables`.
+  - **Re-verified the 19 v2.1.4 main pages**: 14 were no-drift; 5 fixed — `installation` (new `provider-auth` setup step), `concepts/contributing` (185k → 195k, vitest globs), `reference/skills-catalog` (added `/migrate-memory`; 45 → 46 skills), `operate/troubleshooting` (boot failures now log `Container exited non-zero` with a `stderrTail`), `extend/overview` (provider installs span three barrels now — host, container, and setup).
+  - **Re-verified the 8 channel pages**: the `channels` registry branch is frozen at `8137440` (adapters unchanged since before v2.1.4), so no content drift — pinned that SHA on each page for precise future adapter-drift detection.
+</Update>
+
 <Update label="v2.1.15 sweep: product changelog and SHA re-verification" description="2026-06-14" tags={["Updated"]}>
   Closed out the v2.1.4 → v2.1.15 drift sweep.
 

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -6,6 +6,13 @@ rss: true
 tag: "UPDATED"
 ---
 
+<Update label="v2.1.16" description="2026-06-14" tags={["Feature"]}>
+  - **Operator-driven provider selection in setup** — the installer can select, install, and authenticate a non-default agent provider, then set it on the first agent before its first spawn. A provider registry feeds the picker and a vault-only auth walkthrough; default (Claude) installs are unaffected
+  - **Per-group provider choice** — the provider is a per-group database property, not an install-wide default: `ncl groups config update --id <group-id> --provider <name>` then restart. Group creation stays provider-agnostic
+  - **Memory migrates via `/migrate-memory`, never at runtime** — each provider keeps its own store, so a fresh group on a different provider never inherits stale `CLAUDE.*` files
+  - Container boot failures now log the last stderr lines at `warn` on a non-zero exit instead of looping silently
+</Update>
+
 <Update label="v2.1.15" description="2026-06-14" tags={["Feature"]}>
   - Container global CLIs (`@anthropic-ai/claude-code`, `agent-browser`, `vercel`) are now data-driven from `container/cli-tools.json`, each pinned to an exact version — a skill adds a CLI by appending to the manifest instead of editing the Dockerfile
 </Update>


### PR DESCRIPTION
## What

Brings the docs current with the **v2.1.16** upstream release (`e3986eb`).

- **Product changelog** — adds a `v2.1.16` `<Update>` to `changelog/index.mdx`. v2.1.16 is one feature PR (`13a37de feat(providers)`):
  - Operator-driven provider selection in setup (registry-backed picker + vault-only auth; Claude installs unaffected)
  - Per-group provider choice — `ncl groups config update --id <group-id> --provider <name>` + restart (verified in `src/cli/resources/groups.ts`)
  - `/migrate-memory` — provider memory migrates via the skill, never at runtime
  - Container boot failures now log last stderr at `warn` (`src/container-restart.ts`)
- **CLAUDE.md token baseline** — `185k@dc34ceb (v2.1.4)` → `195k@e3986eb (v2.1.16)`, read from `repo-tokens/badge.svg` (98% of context window).

## Not included (deliberately)

The Codex `cli-tools.json` install refactor (`ac0a799`) lands **after** the v2.1.16 bump — unreleased, so it's out of the changelog and docs until it ships.

## Scope

First of four drift-remediation PRs. Page-disjoint from the re-verification sweeps that follow (provider-selection feature sweep, the 27 v2.1.4 pages, channels branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)