### PR TITLE
docs: v2.1.16 provider-selection sweep (16 pages)

### DIFF
--- a/channels/overview.mdx
+++ b/channels/overview.mdx
@@ -5,7 +5,7 @@ tag: "UPDATED"
 keywords: ["channels", "adapters", "channel registry", "chat sdk", "webhook", "add-telegram", "add-discord", "add-slack", "manage-channels"]
 ---
 
-{/* verified-against: src/channels/{adapter,channel-registry,index,chat-sdk-bridge,cli}.ts, src/webhook-server.ts, .claude/skills/{manage-channels,add-telegram}/SKILL.md, upstream/channels:src/channels/ @ 435233a (v2.1.15) */}
+{/* verified-against: src/channels/{adapter,channel-registry,index,chat-sdk-bridge,cli}.ts, src/webhook-server.ts, .claude/skills/{manage-channels,add-telegram}/SKILL.md, upstream/channels:src/channels/ @ e3986eb (v2.1.16) */}
 
 NanoClaw trunk ships channel **infrastructure** — the adapter interface, the registry, the Chat SDK bridge, the webhook server — plus one built-in channel: `cli`, an always-on local-terminal channel that needs no credentials. Every platform adapter (Telegram, Discord, Slack, WhatsApp, …) lives on the `channels` branch of the repo and is installed on demand with an `/add-<channel>` skill. Your fork only contains the channels you actually use.
 

--- a/concepts/architecture.mdx
+++ b/concepts/architecture.mdx
@@ -5,7 +5,7 @@ tag: "UPDATED"
 keywords: ["architecture", "host process", "router", "delivery", "host sweep", "inbound.db", "outbound.db", "container", "agent-runner", "poll loop", "IPC"]
 ---
 
-{/* verified-against: src/index.ts, src/router.ts, src/delivery.ts, src/session-manager.ts, src/host-sweep.ts, src/container-runner.ts, src/claude-md-compose.ts, src/webhook-server.ts, container/agent-runner/src/{index,poll-loop,formatter,compact-instructions}.ts @ 435233a (v2.1.15) */}
+{/* verified-against: src/index.ts, src/router.ts, src/delivery.ts, src/session-manager.ts, src/host-sweep.ts, src/container-runner.ts, src/claude-md-compose.ts, src/webhook-server.ts, container/agent-runner/src/{index,poll-loop,formatter,compact-instructions}.ts @ e3986eb (v2.1.16) */}
 
 NanoClaw is one Node.js host process plus one Docker container per active session. The host owns the channels, the routing, and the container lifecycle; the agent runs inside the container and never talks to the network on NanoClaw's behalf. Between them sits the core idea: **every message is a row in SQLite**. There is no internal message bus, no RPC, no shared memory — the host writes rows the container reads, the container writes rows the host reads, and everything else is polling.
 

--- a/concepts/entity-model.mdx
+++ b/concepts/entity-model.mdx
@@ -5,7 +5,7 @@ tag: "UPDATED"
 keywords: ["entity model", "agent groups", "messaging groups", "wirings", "messaging_group_agents", "engage_mode", "session_mode", "sender_scope", "roles", "owner", "admin", "sessions"]
 ---
 
-{/* verified-against: src/db/schema.ts, src/db/migrations/{010-engage-modes,011-pending-sender-approvals,012-channel-registration,016-messaging-group-instance}.ts, src/types.ts, src/router.ts, src/session-manager.ts, src/modules/permissions/{index.ts,access.ts}, src/command-gate.ts @ 435233a (v2.1.15) */}
+{/* verified-against: src/db/schema.ts, src/db/migrations/{010-engage-modes,011-pending-sender-approvals,012-channel-registration,016-messaging-group-instance}.ts, src/types.ts, src/router.ts, src/session-manager.ts, src/modules/permissions/{index.ts,access.ts}, src/command-gate.ts @ e3986eb (v2.1.16) */}
 
 Everything NanoClaw does reduces to five entities in `data/v2.db`: **agent groups** (where agents run), **messaging groups** (where people talk), **wirings** (the edge connecting them, which holds all the behavior), **users** (who is allowed to do what), and **sessions** (the conversation state in between). This page is the mental model; for column-level detail see the [database schema](/reference/db-schema).
 

--- a/concepts/isolation-levels.mdx
+++ b/concepts/isolation-levels.mdx
@@ -5,7 +5,7 @@ tag: "NEW"
 keywords: ["isolation", "session_mode", "shared", "per-thread", "agent-shared", "agent groups", "privacy", "workspace", "sessions", "multi-tenant"]
 ---
 
-{/* verified-against: src/session-manager.ts, src/router.ts, src/container-runner.ts, .claude/skills/manage-channels/SKILL.md, src/cli/resources/wirings.ts @ 435233a (v2.1.15) */}
+{/* verified-against: src/session-manager.ts, src/router.ts, src/container-runner.ts, .claude/skills/manage-channels/SKILL.md, src/cli/resources/wirings.ts @ e3986eb (v2.1.16) */}
 
 Every time you wire a chat to an agent, you answer one question: should this conversation share anything with the others? NanoClaw gives you four levels, built from two dials in the [entity model](/concepts/entity-model) — which agent group the wiring points at, and the wiring's `session_mode`. This page walks them from most to least isolated.
 

--- a/extend/providers.mdx
+++ b/extend/providers.mdx
@@ -2,10 +2,10 @@
 title: "Agent providers"
 description: "Swap the agent brain per group — Claude Code by default, OpenCode or Codex via provider skills, or a local Ollama model with no provider code at all."
 tag: "UPDATED"
-keywords: ["providers", "agent provider", "claude", "opencode", "codex", "ollama", "local models", "agent_provider", "model", "effort"]
+keywords: ["providers", "agent provider", "claude", "opencode", "codex", "ollama", "local models", "agent_provider", "model", "effort", "provider selection", "switch provider", "migrate-memory"]
 ---
 
-{/* verified-against: container/agent-runner/src/providers/{types,factory,claude,provider-registry}.ts, container/agent-runner/src/{config,index,memory-scaffold,poll-loop}.ts, container/agent-runner/src/memory-templates/, src/container-runner.ts, src/container-config.ts, src/providers/{claude,provider-container-registry}.ts, src/cli/resources/{groups,sessions}.ts, .claude/skills/{add-opencode,add-codex,add-ollama-provider}/SKILL.md, docs/ollama.md @ trunk 435233a (v2.1.15); opencode.ts, codex.ts, codex-app-server.ts @ providers branch 5e76b9d */}
+{/* verified-against: container/agent-runner/src/providers/{types,factory,claude,provider-registry}.ts, container/agent-runner/src/{config,index,memory-scaffold,poll-loop}.ts, container/agent-runner/src/memory-templates/, src/container-runner.ts, src/container-config.ts, src/providers/{claude,provider-container-registry}.ts, src/cli/resources/{groups,sessions}.ts, .claude/skills/{add-opencode,add-codex,add-ollama-provider,migrate-memory}/SKILL.md, src/group-init.ts, setup/auto.ts, setup/providers/registry.ts, setup/provider-auth.ts, docs/ollama.md, docs/provider-migration.md @ trunk e3986eb (v2.1.16); opencode.ts, codex.ts, codex-app-server.ts @ providers branch 5e76b9d */}
 
 A **provider** is the agent CLI that runs inside a group's container — the thing that actually plans, calls tools, and writes replies. By default that's Claude Code via the Claude Agent SDK. The provider is pluggable: the agent runner selects an implementation from an open registry at startup, and the trunk ships only `claude` (plus a `mock` provider for tests).
 
@@ -87,6 +87,12 @@ A provider implementation declares a handful of optional capabilities. The runne
 
 - **Owning the agent surfaces** (`providesAgentSurfaces`). By default the host composes the project doc, skill-discovery links, and provider state dir, then mounts them into the container — the composed `CLAUDE.md`, the skill fragments, and `CLAUDE.local.md` seeding. A provider can declare at registration time that it owns these surfaces; the host then skips all of that, and the provider's own config fn composes and mounts its equivalents (it receives the group dir and the resolved skill list to do so).
 
+## Choosing a provider during setup
+
+[Setup](/quickstart) asks which agent runtime should power your assistant. Claude is the default — press Enter and the standard Claude auth runs. **Codex** is offered as an inline install: pick it and setup runs its installer, rebuilds the image, and walks its vault-only auth (a ChatGPT subscription or an OpenAI API key). OpenCode and Ollama aren't in the picker; add them after setup with their `/add-*` skills.
+
+The pick is **not** an install-wide default — it sets the provider on the first agent group as a per-group database property. Every group's provider is independent, and a spawned subagent inherits its creator's provider so a single-provider install never spawns a child on a runtime it can't reach.
+
 ## Switching a group
 
 Set the provider (and optionally model/effort) on the group's container config, then restart:
@@ -97,6 +103,17 @@ ncl groups restart --id <group-id>
 ```
 
 Config changes are saved immediately but only take effect on the next container spawn — the restart forces it. Switching back is `--provider claude` (or clearing the field; the fallback is `claude` either way). To back the code out entirely, OpenCode and Codex each ship a `REMOVE.md`; Ollama needs no removal — its SKILL.md's "Reverting to Claude" steps are just deleting the `env` and `blockedHosts` keys from the container config and the `model` setting from the shared settings file.
+
+### What carries across a switch
+
+Provider-neutral state stays put: group identity, wiring, members, roles, destinations, container config, skills, MCP servers, mounts, workspace files (`groups/<folder>/`), and conversation archives (`conversations/`). Agent surfaces are composed fresh at every spawn, so nothing migrates there.
+
+Two things are provider-specific and **do not** carry across:
+
+- **Agent memory.** Each provider keeps its own store — Claude's is `CLAUDE.local.md`, scaffold providers like Codex keep a `memory/` tree. A switch never touches the old store; the new provider starts with its own. To carry memory across, run **`/migrate-memory`** — the coding agent reads the source store, distills it into the target store (copy, never move), and restarts the group. Both directions work.
+- **In-flight conversation context.** Continuations are per-provider, so the new provider starts a fresh thread; the old slot is kept, so switching back resumes where you left off. Recent context is recoverable from the `conversations/` archives.
+
+Switching to a provider that isn't installed (or a typo'd name) fails the container at boot — the host logs `Container exited non-zero` with a `stderrTail` like `Unknown provider: codexx. Registered: claude, codex`.
 
 ## Next steps
 

--- a/guides/multi-agent-swarm.mdx
+++ b/guides/multi-agent-swarm.mdx
@@ -5,7 +5,7 @@ tag: "UPDATED"
 keywords: ["multi-agent", "create_agent", "agent-to-agent", "agent destinations", "send_message", "sub-agents", "approval", "ncl destinations"]
 ---
 
-{/* verified-against: src/modules/agent-to-agent/{create-agent,agent-route,write-destinations,index}.ts, src/modules/agent-to-agent/db/agent-destinations.ts, src/modules/approvals/primitive.ts, container/agent-runner/src/mcp-tools/agents.ts + agents.instructions.md, container/agent-runner/src/destinations.ts, src/cli/resources/{destinations,groups,wirings}.ts, src/group-init.ts, src/db/messaging-groups.ts @ 435233a (v2.1.15) */}
+{/* verified-against: src/modules/agent-to-agent/{create-agent,agent-route,write-destinations,index}.ts, src/modules/agent-to-agent/db/agent-destinations.ts, src/modules/approvals/primitive.ts, container/agent-runner/src/mcp-tools/agents.ts + agents.instructions.md, container/agent-runner/src/destinations.ts, src/cli/resources/{destinations,groups,wirings}.ts, src/group-init.ts, src/db/messaging-groups.ts @ e3986eb (v2.1.16) */}
 
 The [introduction](/introduction) promises real teams: a worker per task, a manager that tracks what's in flight, a supervisor that pings you. This tutorial builds the smallest working version — one agent spawning and delegating to another — then scales the same three primitives into that trio. It continues from [your first agent](/guides/first-agent); you'll reuse Scout to see the approval gate.
 
@@ -45,7 +45,7 @@ dig in with web search, and report findings back to you with sources.
 The agent calls the `create_agent` MCP tool with a `name` and that role as `instructions`. The call is fire-and-forget — it returns immediately, and the host does the privileged work:
 
 1. Inserts an `agent_groups` row. The folder is the normalized name (`researcher`), with a numeric suffix if taken.
-2. Scaffolds `groups/researcher/` and seeds **`CLAUDE.local.md` with the `instructions` text** — that's the new agent's persistent role and personality, editable later like any agent's memory. A default `container_configs` row comes with it.
+2. Scaffolds `groups/researcher/` and seeds the **`instructions` text into the new agent's memory** — `CLAUDE.local.md` for the Claude default, or the `memory/` scaffold's landing file on a provider that owns its memory. That's the agent's persistent role and personality, editable later like any agent's memory. A default `container_configs` row comes with it, and the child inherits its creator's provider.
 3. Inserts **two destination rows**: the creator gets `researcher` → new agent, and the new agent gets `parent` → creator. The edge is bidirectional from birth, so replies need no extra wiring.
 4. Projects the new destination into the parent's running container immediately, then notifies it: `Agent "researcher" created. You can now message it with <message to="researcher">...</message>.`
 

--- a/guides/scheduled-tasks.mdx
+++ b/guides/scheduled-tasks.mdx
@@ -5,7 +5,7 @@ tag: "UPDATED"
 keywords: ["scheduled tasks", "schedule_task", "cron", "recurrence", "process_after", "series_id", "host sweep", "wakeAgent", "task script", "timezone"]
 ---
 
-{/* verified-against: container/agent-runner/src/mcp-tools/scheduling.ts, container/agent-runner/src/mcp-tools/scheduling.instructions.md, container/agent-runner/src/scheduling/task-script.ts, container/agent-runner/src/poll-loop.ts, container/agent-runner/src/timezone.ts, src/host-sweep.ts, src/modules/scheduling/{actions,db,recurrence}.ts, src/config.ts, src/container-runner.ts, src/cli/resources/ @ 435233a (v2.1.15) */}
+{/* verified-against: container/agent-runner/src/mcp-tools/scheduling.ts, container/agent-runner/src/mcp-tools/scheduling.instructions.md, container/agent-runner/src/scheduling/task-script.ts, container/agent-runner/src/poll-loop.ts, container/agent-runner/src/timezone.ts, src/host-sweep.ts, src/modules/scheduling/{actions,db,recurrence}.ts, src/config.ts, src/container-runner.ts, src/cli/resources/ @ e3986eb (v2.1.16) */}
 
 v2 has no scheduler service. A scheduled task is a row in the session's `messages_in` table with `kind='task'` and a `process_after` timestamp — same inbox, same flow as any chat message. The agent is the entire scheduling interface: you create, change, and cancel tasks by asking it in chat. This tutorial assumes a working install with a wired agent (see [your first agent](/guides/first-agent)).
 

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -7,7 +7,7 @@ tag: "UPDATED"
 keywords: ["nanoclaw", "multi-agent", "claude", "container isolation", "inbox outbox", "sqlite", "channels", "skills", "v2"]
 ---
 
-{/* verified-against: src/index.ts, src/router.ts, src/channels/index.ts, src/container-runtime.ts, src/container-runner.ts, src/db/schema.ts, src/modules/, container/agent-runner/src/mcp-tools/agents.ts, agents.instructions.md, core.ts, .claude/skills/, .claude/skills/add-telegram/SKILL.md, repo-tokens/badge.svg, package.json @ 435233a (v2.1.15) */}
+{/* verified-against: src/index.ts, src/router.ts, src/channels/index.ts, src/container-runtime.ts, src/container-runner.ts, src/db/schema.ts, src/modules/, container/agent-runner/src/mcp-tools/agents.ts, agents.instructions.md, core.ts, .claude/skills/, .claude/skills/add-telegram/SKILL.md, repo-tokens/badge.svg, package.json @ e3986eb (v2.1.16) */}
 
 NanoClaw runs AI agents that talk to you over your messaging apps — and to each other. Claude is the default provider, with Codex, OpenCode, and Ollama available as alternatives. One Node host process handles routing and delivery. Every active session gets its own Docker container, so agents can run Bash and edit files without touching your host or each other.
 
@@ -48,7 +48,7 @@ The router resolves who sent the message, which agent group should handle it, an
 
 **Container isolation.** Agents run in Docker containers and see only what you explicitly mount. Bash and file edits execute inside the container, never on your host. Each session gets its own container, so parallel conversations can't interfere with each other.
 
-**Small enough to hold in context.** The codebase is ~194k tokens — compact enough for a long-context agent to hold in context. That's also how you customize it: edit the code, not a config sprawl.
+**Small enough to hold in context.** The codebase is ~195k tokens — compact enough for a long-context agent to hold in context. That's also how you customize it: edit the code, not a config sprawl.
 
 **Channels are skills, not bundled features.** Main ships exactly one channel — the local CLI. Everything else lives on the `channels` branch and gets copied into your fork by a skill: `/add-telegram`, `/add-discord`, `/add-whatsapp`, `/add-slack`, `/add-signal`, `/add-imessage`, and several more. Your install contains the adapters you asked for and nothing else. The same mechanism covers alternative agent providers (`/add-codex`, `/add-opencode`, `/add-ollama-provider`).
 

--- a/operate/credentials.mdx
+++ b/operate/credentials.mdx
@@ -5,7 +5,7 @@ tag: "NEW"
 keywords: ["credentials", "OneCLI", "Agent Vault", "secrets", "approval", "onecli-managed", "credential proxy", "ANTHROPIC_BASE_URL"]
 ---
 
-{/* verified-against: src/modules/approvals/onecli-approvals.ts, src/modules/approvals/primitive.ts, src/cli/resources/approvals.ts, src/config.ts, src/egress-lockdown.ts, src/providers/claude.ts, setup/onecli.ts, setup/auto.ts, setup/register-claude-token.sh, container/skills/onecli-gateway/SKILL.md, .claude/skills/init-onecli/SKILL.md, .claude/skills/use-native-credential-proxy/SKILL.md, .claude/skills/add-gmail-tool/SKILL.md @ 435233a (v2.1.15) */}
+{/* verified-against: src/modules/approvals/onecli-approvals.ts, src/modules/approvals/primitive.ts, src/cli/resources/approvals.ts, src/config.ts, src/egress-lockdown.ts, src/providers/claude.ts, setup/onecli.ts, setup/auto.ts, setup/register-claude-token.sh, container/skills/onecli-gateway/SKILL.md, .claude/skills/init-onecli/SKILL.md, .claude/skills/use-native-credential-proxy/SKILL.md, .claude/skills/add-gmail-tool/SKILL.md @ e3986eb (v2.1.16) */}
 
 NanoClaw's credential invariant: **agent containers never hold raw API keys**. Secrets live in the OneCLI Agent Vault on the host, and the vault's gateway injects them into outbound HTTPS requests in flight. An agent that is prompt-injected, jailbroken, or just curious can dump its entire environment and filesystem and find nothing worth stealing.
 

--- a/operate/uninstall.mdx
+++ b/operate/uninstall.mdx
@@ -6,7 +6,7 @@ tag: "NEW"
 keywords: ["uninstall", "remove", "delete", "cleanup", "nanoclaw.sh --uninstall", "dry run", "install slug"]
 ---
 
-{/* verified-against: setup/uninstall/{flow,scan,plan,remove,onecli-agents}.ts, setup/lib/setup-config.ts, setup/auto.ts, uninstall.sh, nanoclaw.sh, src/install-slug.ts @ 435233a (v2.1.15) */}
+{/* verified-against: setup/uninstall/{flow,scan,plan,remove,onecli-agents}.ts, setup/lib/setup-config.ts, setup/auto.ts, uninstall.sh, nanoclaw.sh, src/install-slug.ts @ e3986eb (v2.1.16) */}
 
 NanoClaw ships an interactive uninstaller that removes a single install — its service, containers, image, data, and the credential agents it registered. Everything NanoClaw creates is tagged with a per-checkout **install slug** (the first 8 hex characters of `sha1(projectRoot)`), so the uninstaller only ever touches the copy you run it from. Two NanoClaw checkouts on one host never remove each other's artifacts.
 

--- a/operate/upgrading.mdx
+++ b/operate/upgrading.mdx
@@ -5,7 +5,7 @@ tag: "NEW"
 keywords: ["upgrade", "update", "update-nanoclaw", "update-skills", "migrate-nanoclaw", "upstream", "merge", "rollback"]
 ---
 
-{/* verified-against: .claude/skills/update-nanoclaw/SKILL.md, .claude/skills/update-skills/SKILL.md, .claude/skills/migrate-nanoclaw/SKILL.md, scripts/upgrade-state.ts, src/upgrade-state.ts @ 435233a (v2.1.15) */}
+{/* verified-against: .claude/skills/update-nanoclaw/SKILL.md, .claude/skills/update-skills/SKILL.md, .claude/skills/migrate-nanoclaw/SKILL.md, scripts/upgrade-state.ts, src/upgrade-state.ts @ e3986eb (v2.1.16) */}
 
 Don't update with a raw `git pull`. NanoClaw records each sanctioned upgrade in `data/upgrade-state.json`, and a startup tripwire refuses to boot if the running code's version doesn't match that marker. The supported path is the `/update-nanoclaw` skill, which handles the merge, validation, and the marker stamp for you.
 
@@ -20,7 +20,7 @@ Run `/update-nanoclaw` in a Claude Code session at your project root. The skill 
 5. **Conflict preview.** Dry-runs the merge (`git merge --no-commit --no-ff`, then abort) so you see which files would conflict before committing to anything.
 6. **Merge and resolve.** Applies your chosen path. On conflicts it opens only the conflicted files, resolves the markers, and keeps your local customizations intact.
 7. **Validation.** Runs `pnpm run build` and `pnpm test`. If `container/` files changed, it also rebuilds the container image with `./container/build.sh`.
-8. **Breaking changes.** Scans the new `CHANGELOG.md` entries for `[BREAKING]` lines and diffs `versions.json` for moved component pins (e.g. `onecli-gateway`, `onecli-cli`). Each carries a migration path — a skill to run or a `docs/` page to follow verbatim — and the skill offers to run each one. A moved `onecli-gateway` pin, for example, routes you to [`docs/onecli-upgrades.md`](https://github.com/nanocoai/nanoclaw/blob/main/docs/onecli-upgrades.md); the gateway is an external component, so it's never upgraded for you.
+8. **Breaking changes.** Scans the new `CHANGELOG.md` entries for `[BREAKING]` lines, each of which names a migration skill (`Run /<skill-name> to …`); the skill lists them and offers to run the ones you pick. A breaking change that instead points to a `docs/` page — like the OneCLI gateway upgrade ([`docs/onecli-upgrades.md`](https://github.com/nanocoai/nanoclaw/blob/main/docs/onecli-upgrades.md)) — you follow by hand, since the gateway is an external component that's never upgraded for you.
 9. **Marker stamp.** On success, stamps the upgrade marker (`pnpm exec tsx scripts/upgrade-state.ts set "" update-nanoclaw`) so the tripwire passes on next start.
 10. **Summary.** Prints the backup tag, conflicts resolved, and the restart command for your platform.
 

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -6,7 +6,7 @@ tag: "UPDATED"
 keywords: ["setup", "install", "getting started", "nanoclaw.sh", "setup wizard", "first agent"]
 ---
 
-{/* verified-against: nanoclaw.sh, setup.sh, setup/auto.ts, setup/probe.sh, setup/install-node.sh, setup/channels/*.ts, scripts/init-first-agent.ts, .claude/skills/setup/SKILL.md, package.json @ 435233a (v2.1.15) */}
+{/* verified-against: nanoclaw.sh, setup.sh, setup/auto.ts, setup/probe.sh, setup/install-node.sh, setup/channels/*.ts, setup/providers/registry.ts, scripts/init-first-agent.ts, .claude/skills/setup/SKILL.md, package.json @ e3986eb (v2.1.16) */}
 
 From a fresh machine to an agent you can message — one command and a handful of prompts.
 
@@ -37,7 +37,7 @@ Everything else — Homebrew on macOS, Node 22, pnpm, Docker, the OneCLI vault �
     1. **System check** — verifies your environment
     2. **Sandbox build** — builds the agent container image. First build pulls a base image and takes 3–10 minutes on a fresh machine.
     3. **OneCLI vault** — installs the credential vault, or offers to reuse an existing OneCLI instance. Your agent never sees your API keys; the vault injects them into approved requests as they leave the sandbox.
-    4. **Connect to Claude** — sign in with your Claude subscription (opens a browser), paste an OAuth token (`sk-ant-oat…`), or paste an API key (`sk-ant-api…`)
+    4. **Choose your agent runtime and connect** — Claude is the default: press Enter, then sign in with your Claude subscription (opens a browser), paste an OAuth token (`sk-ant-oat…`), or paste an API key (`sk-ant-api…`). Or pick **Codex** to install it inline and authenticate with a ChatGPT subscription or OpenAI API key — either way the credential lands in the vault, never the container
     5. **Access rules** — writes the assistant's filesystem access rules (empty to start — the sandbox only sees what you explicitly share later)
     6. **Background service** — starts NanoClaw under launchd (macOS) or a systemd user service (Linux)
     7. **Your name** — what the assistant should call you

--- a/reference/adapter-interface.mdx
+++ b/reference/adapter-interface.mdx
@@ -5,7 +5,7 @@ tag: "NEW"
 keywords: ["channel adapter", "ChannelAdapter", "adapter interface", "custom channel", "chat sdk bridge", "registerChannelAdapter", "initChannelAdapters", "supportsThreads", "deliver", "InboundMessage"]
 ---
 
-{/* verified-against: src/channels/adapter.ts, src/channels/channel-registry.ts, src/channels/chat-sdk-bridge.ts, src/channels/index.ts, src/webhook-server.ts, channels branch src/channels/telegram.ts @ 435233a (v2.1.15) */}
+{/* verified-against: src/channels/adapter.ts, src/channels/channel-registry.ts, src/channels/chat-sdk-bridge.ts, src/channels/index.ts, src/webhook-server.ts, channels branch src/channels/telegram.ts @ e3986eb (v2.1.16) */}
 
 A channel adapter bridges NanoClaw with a messaging platform. There are two ways to build one:
 

--- a/reference/container-config.mdx
+++ b/reference/container-config.mdx
@@ -5,7 +5,7 @@ tag: "NEW"
 keywords: ["container config", "container_configs", "container.json", "provider", "model", "effort", "image_tag", "mcp_servers", "additional_mounts", "cli_scope", "skills", "packages"]
 ---
 
-{/* verified-against: src/db/container-configs.ts, src/container-config.ts, src/container-runner.ts, src/cli/resources/groups.ts, src/cli/dispatch.ts, src/claude-md-compose.ts, src/modules/mount-security/index.ts, src/db/migrations/{014-container-configs,015-cli-scope}.ts, container/agent-runner/src/{config.ts,index.ts,db/messages-in.ts,providers/types.ts} @ 435233a (v2.1.15) */}
+{/* verified-against: src/db/container-configs.ts, src/container-config.ts, src/container-runner.ts, src/cli/resources/groups.ts, src/cli/dispatch.ts, src/claude-md-compose.ts, src/modules/mount-security/index.ts, src/db/migrations/{014-container-configs,015-cli-scope}.ts, container/agent-runner/src/{config.ts,index.ts,db/messages-in.ts,providers/types.ts} @ e3986eb (v2.1.16) */}
 
 Each agent group has one row in the `container_configs` table in the central SQLite database — the source of truth for how that group's containers spawn. You change it with the [`ncl groups config` subcommands](/reference/ncl-cli#groups); the row is created automatically with defaults when the group is created.
 

--- a/reference/db-schema.mdx
+++ b/reference/db-schema.mdx
@@ -5,7 +5,7 @@ tag: "NEW"
 keywords: ["database", "schema", "sqlite", "v2.db", "inbound.db", "outbound.db", "messages_in", "messages_out", "sessions", "container_configs", "pending_sender_approvals", "migrations"]
 ---
 
-{/* verified-against: src/db/schema.ts, src/db/connection.ts, src/db/session-db.ts, src/session-manager.ts, src/db/migrations/{001-initial,002-chat-sdk-state,module-approvals-pending-approvals,module-agent-to-agent-destinations,module-approvals-title-options,008-dropped-messages,009-drop-pending-credentials,010-engage-modes,011-pending-sender-approvals,012-channel-registration,013-approval-render-metadata,014-container-configs,015-cli-scope,016-messaging-group-instance,index}.ts, container/agent-runner/src/db/messages-out.ts, src/modules/scheduling/db.ts @ 435233a (v2.1.15) */}
+{/* verified-against: src/db/schema.ts, src/db/connection.ts, src/db/session-db.ts, src/session-manager.ts, src/db/migrations/{001-initial,002-chat-sdk-state,module-approvals-pending-approvals,module-agent-to-agent-destinations,module-approvals-title-options,008-dropped-messages,009-drop-pending-credentials,010-engage-modes,011-pending-sender-approvals,012-channel-registration,013-approval-render-metadata,014-container-configs,015-cli-scope,016-messaging-group-instance,index}.ts, container/agent-runner/src/db/messages-out.ts, src/modules/scheduling/db.ts @ e3986eb (v2.1.16) */}
 
 NanoClaw stores everything in SQLite, split across two layers:
 

--- a/reference/environment-variables.mdx
+++ b/reference/environment-variables.mdx
@@ -5,7 +5,7 @@ tag: "NEW"
 keywords: ["environment variables", ".env", "configuration", "ASSISTANT_NAME", "CONTAINER_TIMEOUT", "LOG_LEVEL", "NANOCLAW_SKIP", "NANOCLAW_EGRESS_LOCKDOWN", "setup", "reference"]
 ---
 
-{/* verified-against: src/config.ts, src/env.ts, src/log.ts, src/webhook-server.ts, src/egress-lockdown.ts, src/container-runner.ts, src/providers/claude.ts, setup/auto.ts, setup/onecli.ts, setup/lib/setup-config.ts, setup/lib/claude-assist.ts, setup/lib/diagnostics.ts, setup/signal-auth.ts, setup/container.ts, setup/migrate-v2/select-channels.ts, migrate-v2.sh, container/agent-runner/src/{timezone.ts,providers/claude.ts} @ 435233a (v2.1.15) */}
+{/* verified-against: src/config.ts, src/env.ts, src/log.ts, src/webhook-server.ts, src/egress-lockdown.ts, src/container-runner.ts, src/providers/claude.ts, setup/auto.ts, setup/onecli.ts, setup/lib/setup-config.ts, setup/lib/claude-assist.ts, setup/lib/diagnostics.ts, setup/signal-auth.ts, setup/container.ts, setup/migrate-v2/select-channels.ts, migrate-v2.sh, container/agent-runner/src/{timezone.ts,providers/claude.ts} @ e3986eb (v2.1.16) */}
 
 Exhaustive list of every environment variable the NanoClaw host, setup wizard, and agent runner read. For how to actually set these — `.env` editing, service definitions, restart commands — see [Configuration](/operate/configuration).
 
@@ -49,16 +49,16 @@ Consumed by the setup wizard (`pnpm run setup:auto`) and migration scripts, not 
 
 | Variable | Default | Read in | Effect |
 |---|---|---|---|
-| `NANOCLAW_SKIP` | — | `setup/auto.ts:118` | Comma-separated step names to skip: `environment`, `container`, `onecli`, `auth`, `mounts`, `service`, `cli-agent`, `timezone`, `channel`, `verify`, `first-chat`. |
-| `NANOCLAW_DISPLAY_NAME` | `$USER` | `setup/auto.ts:320` | How agents address the operator — skips the prompt. |
+| `NANOCLAW_SKIP` | — | `setup/auto.ts:135` | Comma-separated step names to skip: `environment`, `container`, `onecli`, `auth`, `mounts`, `service`, `cli-agent`, `timezone`, `channel`, `verify`, `first-chat`. |
+| `NANOCLAW_DISPLAY_NAME` | `$USER` | `setup/auto.ts:414` | How agents address the operator — skips the prompt. |
 | `NANOCLAW_AGENT_NAME` | — | `setup/channels/*.ts` | Pre-fills the agent name prompt in each channel setup flow. The CLI scratch agent is always "Terminal Agent". |
 | `NANOCLAW_CHANNELS` | — | `setup/migrate-v2/select-channels.ts:43` | Comma-separated channel names (e.g. `telegram,discord`) — skips the channel picker in the v2 migration flow. |
 | `NANOCLAW_V1_PATH` | sibling-directory scan | `migrate-v2.sh:196` | Explicit override for v1 install discovery in the migration flow. Validated against `$NANOCLAW_V1_PATH/store/messages.db` — the script fails with a message telling you to set it when auto-discovery misses. |
 | `INSTALL_CJK_FONTS` | `false` | `setup/container.ts:181` | Set `true` to bake CJK fonts (~200 MB) into the agent image. Read from `.env` by regex during the container build step and passed as a Docker `--build-arg` — the only build-arg passed through today. Set it in `.env`, not the service environment. |
-| `NANOCLAW_ONECLI_API_HOST` | `https://api.onecli.sh` | `setup/auto.ts:188` | Use a remote OneCLI vault instead of installing one locally. |
+| `NANOCLAW_ONECLI_API_HOST` | `https://api.onecli.sh` | `setup/auto.ts:236` | Use a remote OneCLI vault instead of installing one locally. |
 | `NANOCLAW_ONECLI_API_TOKEN` | — | `setup/onecli.ts:324` | Bearer token (`oc_…`) for the remote vault. Required when the host is set. |
-| `NANOCLAW_ANTHROPIC_BASE_URL` | — | `setup/auto.ts:717` | Custom Anthropic-compatible endpoint. Setup writes `ANTHROPIC_BASE_URL` to `.env` and stores the token in the vault. |
-| `NANOCLAW_ANTHROPIC_AUTH_TOKEN` | — | `setup/auto.ts:718` | Bearer token for the custom endpoint. Both URL and token must be set together. |
+| `NANOCLAW_ANTHROPIC_BASE_URL` | — | `setup/auto.ts:844` | Custom Anthropic-compatible endpoint. Setup writes `ANTHROPIC_BASE_URL` to `.env` and stores the token in the vault. |
+| `NANOCLAW_ANTHROPIC_AUTH_TOKEN` | — | `setup/auto.ts:845` | Bearer token for the custom endpoint. Both URL and token must be set together. |
 | `NANOCLAW_SETUP_ASSIST_MODE` | `false` | `setup/lib/setup-config.ts:128` | Use non-interactive Claude assist on step failure instead of interactive handoff. |
 | `NANOCLAW_SKIP_CLAUDE_ASSIST` | — | `setup/lib/claude-assist.ts:96` | Set `1` to disable Claude-assisted failure recovery entirely (CI/scripted runs). |
 | `NANOCLAW_NO_DIAGNOSTICS` | — | `setup/lib/diagnostics.ts:45` | Set `1` to disable setup diagnostics reporting. |
@@ -70,7 +70,7 @@ Consumed by the setup wizard (`pnpm run setup:auto`) and migration scripts, not 
 
 ## Container-side variables (agent runner)
 
-Read inside the agent container by the agent runner. The host injects only `TZ` (plus provider-contributed and OneCLI proxy variables) at spawn — `src/container-runner.ts:413`. The rest are not passed through from the host environment; overriding them means baking them into a custom image or a provider container config.
+Read inside the agent container by the agent runner. The host injects only `TZ` (plus provider-contributed and OneCLI proxy variables) at spawn — `src/container-runner.ts:439`. The rest are not passed through from the host environment; overriding them means baking them into a custom image or a provider container config.
 
 | Variable | Default | Read in | Effect |
 |---|---|---|---|


### PR DESCRIPTION
## What

Re-verifies the 16 pages that were current at v2.1.15 against the **v2.1.16** release (`e3986eb`). v2.1.16 is one feature — operator-driven provider selection / switching / `/migrate-memory` (`13a37de`) — plus the 195k token bump.

### Content edits (7 pages)
- **`extend/providers`** — new *Choosing a provider during setup* section (the wizard picker: Claude default, Codex inline install) and a *What carries across a switch* section (provider-neutral state vs per-provider memory; run `/migrate-memory`; unknown-provider boot failure). Verified against `setup/auto.ts`, `setup/providers/registry.ts`, `migrate-memory/SKILL.md`, `docs/provider-migration.md`.
- **`quickstart`** — wizard step 4 now covers the agent-runtime pick.
- **`introduction`** — codebase token count 194k → 195k.
- **`guides/multi-agent-swarm`** — `create_agent` seeds the **provider's own** memory surface (`CLAUDE.local.md` for Claude, `memory/` scaffold otherwise); a child inherits its creator's provider (`group-init.ts`, `create-agent.ts`).
- **`operate/upgrading`** — `/update-nanoclaw`'s breaking-change check is skill-only now; dropped the stale `versions.json` pin-diffing + docs-page auto-follow claims (`update-nanoclaw/SKILL.md`).
- **`reference/environment-variables`** — fixed 6 `file:line` citations that drifted when the picker/boot-logging inserted lines above them.

### SHA-only bumps (9 pages)
`entity-model`, `adapter-interface`, `db-schema`, `architecture`, `isolation-levels`, `container-config`, `scheduled-tasks`, `uninstall`, `credentials` — cited files either unchanged or changed additively (verified `resolveProviderName` is byte-identical, so the documented provider-resolution order holds).

All 16 bumped `435233a (v2.1.15)` → `e3986eb (v2.1.16)`. `mint validate` + `mint broken-links` pass.

## Deliberately excluded

The Codex `cli-tools.json` install refactor (`ac0a799`) lands after the v2.1.16 bump — unreleased — so the providers page keeps the current "Codex installs via the Dockerfile" wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)