### PR TITLE
docs: re-verify 19 v2.1.4 pages against v2.1.16

### DIFF
--- a/channels/cli.mdx
+++ b/channels/cli.mdx
@@ -5,7 +5,7 @@ tag: "NEW"
 keywords: ["cli", "terminal", "pnpm run chat", "unix socket", "cli.sock", "local channel", "init-cli-agent"]
 ---
 
-{/* verified-against: src/channels/cli.ts, src/channels/index.ts, scripts/chat.ts, scripts/init-cli-agent.ts, setup/auto.ts, src/cli/socket-server.ts, package.json @ dc34ceb (v2.1.4) */}
+{/* verified-against: src/channels/cli.ts, src/channels/index.ts, scripts/chat.ts, scripts/init-cli-agent.ts, setup/auto.ts, src/cli/socket-server.ts, package.json @ e3986eb (v2.1.16) */}
 
 The CLI channel is the one channel built into NanoClaw trunk — `src/channels/index.ts` registers only `cli`. It needs no credentials, no platform account, and no install skill: the daemon listens on a Unix socket at `data/cli.sock`, and `pnpm run chat` connects to it from the same machine. It exists so you can talk to an agent before (or without) wiring any messaging platform — the setup wizard uses it for its first-contact ping/pong check, and CLI-only installs are a fully supported way to run NanoClaw.
 

--- a/concepts/container-lifecycle.mdx
+++ b/concepts/container-lifecycle.mdx
@@ -5,7 +5,7 @@ tag: "UPDATED"
 keywords: ["container", "lifecycle", "docker", "spawn", "wake", "mounts", "image", "tini", "orphan cleanup", "install slug", "egress lockdown", "kill"]
 ---
 
-{/* verified-against: src/container-runner.ts, src/container-runtime.ts, src/egress-lockdown.ts, src/host-sweep.ts, src/install-slug.ts, setup/container.ts, container/Dockerfile @ dc34ceb (v2.1.4) */}
+{/* verified-against: src/container-runner.ts, src/container-runtime.ts, src/egress-lockdown.ts, src/host-sweep.ts, src/install-slug.ts, setup/container.ts, container/Dockerfile @ e3986eb (v2.1.16) */}
 
 Every active session gets exactly one Docker container, spawned on demand and killed when it goes quiet. The container is deliberately disposable: all state lives in mounted host directories, so a kill loses nothing but an in-flight provider call — and the [host sweep](/concepts/architecture#what-runs-when) retries that.
 

--- a/concepts/contributing.mdx
+++ b/concepts/contributing.mdx
@@ -5,7 +5,7 @@ tag: "UPDATED"
 keywords: ["contributing", "development", "pnpm", "vitest", "bun", "channels branch", "providers branch", "repo layout", "pull requests", "token count"]
 ---
 
-{/* verified-against: package.json, CONTRIBUTING.md, RELEASING.md, vitest.config.ts, vitest.skills.config.ts, eslint.config.js, .github/workflows/{ci.yml,update-tokens.yml}, repo-tokens/README.md, CLAUDE.md @ dc34ceb (v2.1.4) */}
+{/* verified-against: package.json, CONTRIBUTING.md, RELEASING.md, vitest.config.ts, vitest.skills.config.ts, eslint.config.js, .github/workflows/{ci.yml,update-tokens.yml}, repo-tokens/README.md, CLAUDE.md @ e3986eb (v2.1.16) */}
 
 This page is for contributing to [nanocoai/nanoclaw](https://github.com/nanocoai/nanoclaw) itself — fixing bugs, simplifying code, or adding a skill to the upstream repo. If you just want to extend your own installation, you don't need any of this: see [Extending NanoClaw](/extend/overview).
 
@@ -27,7 +27,7 @@ The upstream [CONTRIBUTING.md](https://github.com/nanocoai/nanoclaw/blob/main/CO
 
 ## The whole repo fits in context
 
-The token badge in the README currently reads **~185k tokens** for the runtime surface (mainly `src/`, `container/agent-runner/src/`, the Dockerfile, and `CLAUDE.md` — host tests excluded). That's deliberate: the codebase is kept small enough for a coding agent to hold it in context, which is also why feature PRs are redirected to skills. The badge is auto-generated — the `update-tokens.yml` workflow runs the `repo-tokens/` action on every push to `main` that touches `src/`, `container/`, `launchd/`, or `CLAUDE.md` and commits the new badge. Don't update it by hand.
+The token badge in the README currently reads **~195k tokens** for the runtime surface (mainly `src/`, `container/agent-runner/src/`, the Dockerfile, and `CLAUDE.md` — host tests excluded). That's deliberate: the codebase is kept small enough for a coding agent to hold it in context, which is also why feature PRs are redirected to skills. The badge is auto-generated — the `update-tokens.yml` workflow runs the `repo-tokens/` action on every push to `main` that touches `src/`, `container/`, `launchd/`, or `CLAUDE.md` and commits the new badge. Don't update it by hand.
 
 ## Dev loop
 
@@ -59,7 +59,7 @@ CI on every PR runs `format:check`, typechecks for both trees, host tests under 
 
 Tests are split across three configs because the two runtimes can't share one:
 
-- **`vitest.config.ts`** — host tests: `src/**/*.test.ts`, `setup/**/*.test.ts`, `scripts/**/*.test.ts`. Run with `pnpm test`.
+- **`vitest.config.ts`** — host tests: `src/**/*.test.ts`, `setup/**/*.test.ts`, `scripts/**/*.test.ts`, `container/*.test.ts`. Run with `pnpm test`.
 - **`vitest.skills.config.ts`** — skill registration tests: `.claude/skills/**/tests/*.test.ts`. Run with `pnpm exec vitest run --config vitest.skills.config.ts`.
 - **`container/agent-runner`** — Bun tests, because they depend on `bun:sqlite`, which vitest (Node) can't load. Import from `bun:test`, not `vitest`.
 

--- a/concepts/security.mdx
+++ b/concepts/security.mdx
@@ -5,7 +5,7 @@ tag: "UPDATED"
 keywords: ["security", "threat model", "prompt injection", "container isolation", "egress lockdown", "mount allowlist", "approvals", "credentials", "defense in depth"]
 ---
 
-{/* verified-against: src/container-runner.ts, src/egress-lockdown.ts, src/modules/mount-security/index.ts, src/command-gate.ts, src/modules/permissions/{index.ts,access.ts,channel-approval.ts,sender-approval.ts}, src/modules/approvals/{index.ts,primitive.ts,onecli-approvals.ts}, src/modules/self-mod/index.ts, container/Dockerfile, pnpm-workspace.yaml, docs/SECURITY.md @ dc34ceb (v2.1.4) */}
+{/* verified-against: src/container-runner.ts, src/egress-lockdown.ts, src/modules/mount-security/index.ts, src/command-gate.ts, src/modules/permissions/{index.ts,access.ts,channel-approval.ts,sender-approval.ts}, src/modules/approvals/{index.ts,primitive.ts,onecli-approvals.ts}, src/modules/self-mod/index.ts, container/Dockerfile, pnpm-workspace.yaml, docs/SECURITY.md @ e3986eb (v2.1.16) */}
 
 NanoClaw connects an AI agent with real tools — a shell, a filesystem, network access — to chat platforms where anyone can type. Every inbound message is untrusted input fed straight into the model's context, and no model reliably distinguishes "instructions from my operator" from "instructions an attacker pasted into the group chat." So the design assumption is blunt: **prompt injection eventually succeeds, and the agent acts as if the attacker wrote its instructions.**
 

--- a/extend/overview.mdx
+++ b/extend/overview.mdx
@@ -5,7 +5,7 @@ tag: "UPDATED"
 keywords: ["skills", "extend", "SKILL.md", "registry branches", "channels branch", "providers branch", "REMOVE.md", "container skills", "additive fetch"]
 ---
 
-{/* verified-against: CONTRIBUTING.md, docs/skills-model.md, .claude/skills/{add-telegram,add-codex,add-gmail-tool,manage-mounts}/SKILL.md, .claude/skills/{add-telegram,add-gmail-tool}/REMOVE.md, container/skills/, src/container-runner.ts @ dc34ceb (v2.1.4) */}
+{/* verified-against: CONTRIBUTING.md, docs/skills-model.md, .claude/skills/{add-telegram,add-codex,add-gmail-tool,manage-mounts}/SKILL.md, .claude/skills/{add-telegram,add-gmail-tool}/REMOVE.md, container/skills/, src/container-runner.ts, setup/providers/index.ts @ e3986eb (v2.1.16) */}
 
 A NanoClaw skill is a **SKILL.md instruction workflow** in `.claude/skills/` that Claude Code executes in your checkout. When you run `/add-telegram` or `/manage-mounts`, Claude reads the skill's instructions and performs them — copying files, appending an import, installing a dependency, running a test. There is no plugin engine, no manifest.yaml, and no skill state file. The skill *is* the markdown.
 
@@ -50,7 +50,7 @@ These are the skills you invoke as slash commands in Claude Code from your NanoC
 | Category | Example | What installing looks like |
 | --- | --- | --- |
 | **Channel installs** | `/add-telegram` | The flow above: copy the adapter from the `channels` branch, append the barrel import, pin the dependency, run the registration test. See [Channels overview](/channels/overview). |
-| **Provider installs** | `/add-codex` | Same pattern against the `providers` branch, but multi-point: a provider spans the host tree *and* the container's agent-runner tree, so the skill copies into both and runs a registration test per tree. See [Providers](/extend/providers). |
+| **Provider installs** | `/add-codex` | Same pattern against the `providers` branch, but multi-point: a provider spans three trees — the host, the container's agent-runner, and setup — so the skill appends an import to each of the three provider barrels and runs a registration guard per tree. See [Providers](/extend/providers). |
 | **Tool installs** | `/add-gmail-tool` | Wires an MCP server into selected agent groups with vault-managed credentials: the container only ever sees `onecli-managed` placeholder stubs, and the OneCLI gateway injects real OAuth tokens in flight. See [Tools](/extend/tools). |
 | **Operational skills** | `/manage-mounts` | Pure instruction workflows — no code copied, nothing fetched. The SKILL.md walks Claude through a task, like editing the mount allowlist through the setup CLI and restarting the service. |
 

--- a/extend/self-modification.mdx
+++ b/extend/self-modification.mdx
@@ -5,7 +5,7 @@ tag: "NEW"
 keywords: ["self-modification", "install_packages", "add_mcp_server", "CLAUDE.local.md", "approval", "self-customize", "rebuild", "agent memory"]
 ---
 
-{/* verified-against: src/modules/self-mod/{index,request,apply}.ts, src/modules/approvals/primitive.ts, container/agent-runner/src/mcp-tools/self-mod.ts, container/agent-runner/src/mcp-tools/self-mod.instructions.md, container/skills/self-customize/SKILL.md, src/container-runner.ts, src/claude-md-compose.ts @ dc34ceb (v2.1.4) */}
+{/* verified-against: src/modules/self-mod/{index,request,apply}.ts, src/modules/approvals/primitive.ts, container/agent-runner/src/mcp-tools/self-mod.ts, container/agent-runner/src/mcp-tools/self-mod.instructions.md, container/skills/self-customize/SKILL.md, src/container-runner.ts, src/claude-md-compose.ts @ e3986eb (v2.1.16) */}
 
 Agents can change their own environment — but every change that touches the container goes through you. The self-mod module exposes exactly two operations, `install_packages` and `add_mcp_server`, and **both are always approval-gated**: the agent submits a request, an admin gets a card, and nothing changes until someone taps Approve. The one thing an agent can change freely is its own memory file.
 

--- a/extend/tools.mdx
+++ b/extend/tools.mdx
@@ -5,7 +5,7 @@ tag: "UPDATED"
 keywords: ["tools", "mcp", "gmail", "google calendar", "ollama", "atomic chat", "agent-browser", "web access", "add-mcp-server", "tool skills"]
 ---
 
-{/* verified-against: .claude/skills/{add-gmail-tool,add-gcal-tool,add-ollama-tool,add-atomic-chat-tool}/SKILL.md, container/skills/agent-browser/SKILL.md, src/db/container-configs.ts, src/container-runner.ts @ dc34ceb (v2.1.4) */}
+{/* verified-against: .claude/skills/{add-gmail-tool,add-gcal-tool,add-ollama-tool,add-atomic-chat-tool}/SKILL.md, container/skills/agent-browser/SKILL.md, src/db/container-configs.ts, src/container-runner.ts @ e3986eb (v2.1.16) */}
 
 Agents get tools two ways:
 

--- a/extend/writing-skills.mdx
+++ b/extend/writing-skills.mdx
@@ -5,7 +5,7 @@ tag: "NEW"
 keywords: ["writing skills", "SKILL.md", "REMOVE.md", "skill authoring", "idempotency", "registration test", "skill-guidelines", "vitest", "integration points"]
 ---
 
-{/* verified-against: docs/skill-guidelines.md, CONTRIBUTING.md, vitest.skills.config.ts, .claude/skills/{add-telegram,manage-mounts,update-skills,add-ollama-tool}/SKILL.md, .claude/skills/add-telegram/REMOVE.md @ dc34ceb (v2.1.4) */}
+{/* verified-against: docs/skill-guidelines.md, CONTRIBUTING.md, vitest.skills.config.ts, .claude/skills/{add-telegram,manage-mounts,update-skills,add-ollama-tool}/SKILL.md, .claude/skills/add-telegram/REMOVE.md @ e3986eb (v2.1.16) */}
 
 A skill is a markdown file that Claude Code executes — there's no engine to integrate with, so writing one is mostly writing good instructions. The bar upstream holds skills to is [docs/skill-guidelines.md](https://github.com/nanocoai/nanoclaw/blob/main/docs/skill-guidelines.md), and it boils down to two principles: **minimal integration surface** (mostly add files; keep reach-ins into existing code to a line or two that calls your own code) and **a test for every functional integration point** (one that goes red if the wiring is deleted or drifts). This page covers the conventions; [the overview](/extend/overview) explains the model.
 

--- a/guides/customize-an-agent.mdx
+++ b/guides/customize-an-agent.mdx
@@ -5,7 +5,7 @@ tag: "UPDATED"
 keywords: ["customize", "CLAUDE.local.md", "personality", "model", "effort", "ncl groups config update", "self-customize", "/customize"]
 ---
 
-{/* verified-against: src/claude-md-compose.ts, src/container-runner.ts, src/cli/resources/groups.ts, container/agent-runner/src/providers/types.ts, container/skills/self-customize/SKILL.md, .claude/skills/customize/SKILL.md @ dc34ceb (v2.1.4) */}
+{/* verified-against: src/claude-md-compose.ts, src/container-runner.ts, src/cli/resources/groups.ts, container/agent-runner/src/providers/types.ts, container/skills/self-customize/SKILL.md, .claude/skills/customize/SKILL.md @ e3986eb (v2.1.16) */}
 
 This tutorial customizes the Scout agent from [your first agent](/guides/first-agent) — any agent group works, just swap the folder and `--id`. An agent has three customization surfaces:
 

--- a/guides/first-agent.mdx
+++ b/guides/first-agent.mdx
@@ -5,7 +5,7 @@ tag: "NEW"
 keywords: ["tutorial", "first agent", "ncl groups create", "wirings", "messaging group", "cli channel", "pnpm run chat", "CLAUDE.local.md"]
 ---
 
-{/* verified-against: src/cli/resources/{groups,wirings,messaging-groups,sessions}.ts, src/cli/crud.ts, src/router.ts, src/channels/cli.ts, scripts/chat.ts, scripts/init-cli-agent.ts, src/group-init.ts, src/container-runner.ts, setup/auto.ts @ dc34ceb (v2.1.4) */}
+{/* verified-against: src/cli/resources/{groups,wirings,messaging-groups,sessions}.ts, src/cli/crud.ts, src/router.ts, src/channels/cli.ts, scripts/chat.ts, scripts/init-cli-agent.ts, src/group-init.ts, src/container-runner.ts, setup/auto.ts @ e3986eb (v2.1.16) */}
 
 If you followed the [quickstart](/quickstart), the setup wizard already built your first agent. This tutorial builds a **second** one by hand, so you see every part the wizard hides: an **agent group** (the identity), a **messaging group** (the chat), and a **wiring** (the routing rule connecting them). We'll use the [CLI channel](/channels/cli) — it ships on trunk and needs zero platform credentials.
 

--- a/installation.mdx
+++ b/installation.mdx
@@ -6,7 +6,7 @@ tag: "UPDATED"
 keywords: ["requirements", "docker", "node", "pnpm", "bun", "wsl", "launchd", "systemd", "onecli", "nanoclaw.sh", "manual install"]
 ---
 
-{/* verified-against: nanoclaw.sh, setup.sh, setup/probe.sh, setup/auto.ts, setup/index.ts, setup/install-node.sh, setup/install-docker.sh, setup/container.ts, setup/service.ts, setup/set-env.ts, container/Dockerfile, src/container-runtime.ts, src/container-runner.ts, src/claude-md-compose.ts, src/group-init.ts, src/config.ts, src/install-slug.ts, src/session-manager.ts, src/index.ts, package.json @ dc34ceb */}
+{/* verified-against: nanoclaw.sh, setup.sh, setup/probe.sh, setup/auto.ts, setup/index.ts, setup/install-node.sh, setup/install-docker.sh, setup/container.ts, setup/service.ts, setup/set-env.ts, container/Dockerfile, src/container-runtime.ts, src/container-runner.ts, src/claude-md-compose.ts, src/group-init.ts, src/config.ts, src/install-slug.ts, src/session-manager.ts, src/index.ts, package.json @ e3986eb (v2.1.16) */}
 
 This page is the depth companion to [Quick start](/quickstart): what the installer actually does, how to install by hand, how the background service works, and where everything lands on disk. If you just want a running assistant, run `bash nanoclaw.sh` and follow the wizard — quick start covers that flow end to end.
 
@@ -94,7 +94,7 @@ pnpm run setup -- --step service     # rebuild TypeScript and reinstall the serv
 pnpm run setup -- --step verify      # end-to-end health check
 ```
 
-Available steps: `timezone`, `set-env`, `environment`, `container`, `register`, `pair-telegram`, `groups`, `whatsapp-auth`, `signal-auth`, `mounts`, `service`, `verify`, `onecli`, `auth`, `cli-agent`.
+Available steps: `timezone`, `set-env`, `environment`, `container`, `register`, `pair-telegram`, `groups`, `whatsapp-auth`, `signal-auth`, `mounts`, `service`, `verify`, `onecli`, `auth`, `provider-auth`, `cli-agent`.
 
 ### Scripting the wizard
 

--- a/migrate-from-v1.mdx
+++ b/migrate-from-v1.mdx
@@ -6,7 +6,7 @@ tag: "NEW"
 keywords: ["migration", "v1", "v2", "upgrade", "OpenClaw", "migrate-v2.sh", "migrate-from-v1", "migrate-from-openclaw", "handoff"]
 ---
 
-{/* verified-against: migrate-v2.sh, migrate-v2-reset.sh, setup/migrate-v2/*.ts, .claude/skills/migrate-from-v1/SKILL.md, .claude/skills/migrate-from-openclaw/SKILL.md, .claude/skills/migrate-nanoclaw/SKILL.md @ dc34ceb */}
+{/* verified-against: migrate-v2.sh, migrate-v2-reset.sh, setup/migrate-v2/*.ts, .claude/skills/migrate-from-v1/SKILL.md, .claude/skills/migrate-from-openclaw/SKILL.md, .claude/skills/migrate-nanoclaw/SKILL.md @ e3986eb (v2.1.16) */}
 
 NanoClaw v2 is a ground-up rewrite — you don't upgrade in place, you migrate into a fresh v2 checkout. There are two supported paths:
 

--- a/operate/configuration.mdx
+++ b/operate/configuration.mdx
@@ -5,7 +5,7 @@ tag: "NEW"
 keywords: ["configuration", "environment variables", ".env", "container config", "ASSISTANT_NAME", "CONTAINER_TIMEOUT", "LOG_LEVEL", "container_configs"]
 ---
 
-{/* verified-against: src/config.ts, src/env.ts, src/log.ts, src/webhook-server.ts, src/egress-lockdown.ts, src/providers/claude.ts, src/container-config.ts, src/db/container-configs.ts, setup/set-env.ts, setup/service.ts @ dc34ceb */}
+{/* verified-against: src/config.ts, src/env.ts, src/log.ts, src/webhook-server.ts, src/egress-lockdown.ts, src/providers/claude.ts, src/container-config.ts, src/db/container-configs.ts, setup/set-env.ts, setup/service.ts @ e3986eb (v2.1.16) */}
 
 NanoClaw has two configuration layers:
 

--- a/operate/hardening.mdx
+++ b/operate/hardening.mdx
@@ -5,7 +5,7 @@ tag: "UPDATED"
 keywords: ["hardening", "security", "egress lockdown", "NANOCLAW_EGRESS_LOCKDOWN", "mount allowlist", "unknown_sender_policy", "command gate", "container limits"]
 ---
 
-{/* verified-against: src/egress-lockdown.ts, src/modules/mount-security/index.ts, src/modules/permissions/{index.ts,access.ts,sender-approval.ts}, src/command-gate.ts, src/router.ts, src/db/schema.ts, src/config.ts, config-examples/mount-allowlist.json, .claude/skills/manage-mounts/SKILL.md, setup/mounts.ts @ dc34ceb */}
+{/* verified-against: src/egress-lockdown.ts, src/modules/mount-security/index.ts, src/modules/permissions/{index.ts,access.ts,sender-approval.ts}, src/command-gate.ts, src/router.ts, src/db/schema.ts, src/config.ts, config-examples/mount-allowlist.json, .claude/skills/manage-mounts/SKILL.md, setup/mounts.ts @ e3986eb (v2.1.16) */}
 
 NanoClaw's isolation boundary is the Docker container: each agent runs in its own container with a scoped workspace mount (see [Container lifecycle](/concepts/container-lifecycle)). There is no micro-VM or alternative sandbox runtime — hardening means tightening what those containers can reach. This page walks the defense-in-depth controls from network to filesystem to people.
 

--- a/operate/ncl-cli.mdx
+++ b/operate/ncl-cli.mdx
@@ -5,7 +5,7 @@ tag: "UPDATED"
 keywords: ["ncl", "cli", "admin", "unix socket", "cli_scope", "groups", "wirings", "sessions", "approvals"]
 ---
 
-{/* verified-against: src/cli/client.ts, src/cli/dispatch.ts, src/cli/socket-server.ts, src/cli/crud.ts, src/cli/format.ts, src/cli/transport-errors.ts, src/cli/commands/help.ts, src/cli/resources/{approvals,destinations,dropped-messages,groups,members,messaging-groups,roles,sessions,user-dms,users,wirings}.ts, src/db/container-configs.ts, bin/ncl, setup/service.ts @ dc34ceb */}
+{/* verified-against: src/cli/client.ts, src/cli/dispatch.ts, src/cli/socket-server.ts, src/cli/crud.ts, src/cli/format.ts, src/cli/transport-errors.ts, src/cli/commands/help.ts, src/cli/resources/{approvals,destinations,dropped-messages,groups,members,messaging-groups,roles,sessions,user-dms,users,wirings}.ts, src/db/container-configs.ts, bin/ncl, setup/service.ts @ e3986eb (v2.1.16) */}
 
 `ncl` is the admin CLI for a running NanoClaw host. It sends one request frame over a Unix socket at `data/ncl.sock` and prints the response — every command reads or mutates the host's central database live, no restart needed. The socket is `chmod 0600`, so only the user that started the host can connect.
 

--- a/operate/troubleshooting.mdx
+++ b/operate/troubleshooting.mdx
@@ -5,7 +5,7 @@ keywords: ["troubleshooting", "debugging", "dropped messages", "container spawn"
 tag: "UPDATED"
 ---
 
-{/* verified-against: .claude/skills/debug/SKILL.md, src/container-runtime.ts, src/container-runner.ts, src/host-sweep.ts, src/upgrade-state.ts, src/log.ts, src/cli/resources/dropped-messages.ts, src/cli/resources/sessions.ts, src/egress-lockdown.ts, src/modules/mount-security/index.ts, src/webhook-server.ts, src/circuit-breaker.ts, setup/service.ts @ dc34ceb */}
+{/* verified-against: .claude/skills/debug/SKILL.md, src/container-runtime.ts, src/container-runner.ts, src/host-sweep.ts, src/upgrade-state.ts, src/log.ts, src/cli/resources/dropped-messages.ts, src/cli/resources/sessions.ts, src/egress-lockdown.ts, src/modules/mount-security/index.ts, src/webhook-server.ts, src/circuit-breaker.ts, setup/service.ts @ e3986eb (v2.1.16) */}
 
 ## Start here
 
@@ -78,7 +78,7 @@ Trace the message through the pipeline, in order:
     `stopped` is normal between messages — the sweep restarts the container when due messages arrive. If nothing spawns at all, see [Container won't spawn](#container-wont-spawn) below.
   </Step>
   <Step title="Did the agent produce a reply?">
-    Inspect the session DBs (`inbound.db` / `outbound.db` under `data/v2-sessions/<group>/<session>/`). The `/debug` skill walks you through the exact queries. A `Container exited` line with a non-zero `code` in the host log, plus the streamed stderr above it, is where the failure usually shows.
+    Inspect the session DBs (`inbound.db` / `outbound.db` under `data/v2-sessions/<group>/<session>/`). The `/debug` skill walks you through the exact queries. A `Container exited non-zero` warning in the host log carries the exit `code` and a `stderrTail` — the last ~10 lines of container stderr — which is where a boot failure usually shows. A clean or signal-killed exit logs `Container exited` at info level instead.
   </Step>
 </Steps>
 

--- a/reference/mcp-tools.mdx
+++ b/reference/mcp-tools.mdx
@@ -5,7 +5,7 @@ tag: "NEW"
 keywords: ["mcp tools", "send_message", "send_file", "schedule_task", "ask_user_question", "create_agent", "install_packages", "add_mcp_server", "nanoclaw mcp server", "agent tools"]
 ---
 
-{/* verified-against: container/agent-runner/src/mcp-tools/{index,server,types,core,scheduling,interactive,agents,self-mod}.ts, container/agent-runner/src/mcp-tools/{core,scheduling,interactive,agents,self-mod,cli}.instructions.md, src/modules/agent-to-agent/create-agent.ts, src/group-init.ts @ dc34ceb (v2.1.4) */}
+{/* verified-against: container/agent-runner/src/mcp-tools/{index,server,types,core,scheduling,interactive,agents,self-mod}.ts, container/agent-runner/src/mcp-tools/{core,scheduling,interactive,agents,self-mod,cli}.instructions.md, src/modules/agent-to-agent/create-agent.ts, src/group-init.ts @ e3986eb (v2.1.16) */}
 
 These are the tools the agent (Claude) can call from inside its container. They're exposed by the built-in `nanoclaw` MCP server (`container/agent-runner/src/mcp-tools/`), so the agent sees them with the `mcp__nanoclaw__` prefix — e.g. `mcp__nanoclaw__send_message`. As an operator you never call them directly; you see their effects: messages arriving in chats, schedule changes, and approval cards.
 

--- a/reference/ncl-cli.mdx
+++ b/reference/ncl-cli.mdx
@@ -5,7 +5,7 @@ tag: "NEW"
 keywords: ["ncl", "cli", "reference", "commands", "flags", "groups", "wirings", "sessions", "roles", "members", "destinations", "approvals", "cli_scope"]
 ---
 
-{/* verified-against: src/cli/dispatch.ts, src/cli/crud.ts, src/cli/client.ts, src/cli/format.ts, src/cli/transport-errors.ts, src/cli/registry.ts, src/cli/frame.ts, src/cli/commands/help.ts, src/cli/resources/{approvals,destinations,dropped-messages,groups,members,messaging-groups,roles,sessions,user-dms,users,wirings}.ts, bin/ncl @ dc34ceb (v2.1.4) */}
+{/* verified-against: src/cli/dispatch.ts, src/cli/crud.ts, src/cli/client.ts, src/cli/format.ts, src/cli/transport-errors.ts, src/cli/registry.ts, src/cli/frame.ts, src/cli/commands/help.ts, src/cli/resources/{approvals,destinations,dropped-messages,groups,members,messaging-groups,roles,sessions,user-dms,users,wirings}.ts, bin/ncl @ e3986eb (v2.1.16) */}
 
 Exhaustive reference for the `ncl` admin CLI. For a task-oriented walkthrough, see [The ncl admin CLI](/operate/ncl-cli).
 

--- a/reference/skills-catalog.mdx
+++ b/reference/skills-catalog.mdx
@@ -5,11 +5,11 @@ tag: "NEW"
 keywords: ["skills", "catalog", "reference", "add-channel", "providers", "tools", "container skills", "workspace skills", "slash commands"]
 ---
 
-{/* verified-against: .claude/skills/ and container/skills/ listings + each skill's SKILL.md frontmatter @ dc34ceb (v2.1.4) */}
+{/* verified-against: .claude/skills/ and container/skills/ listings + each skill's SKILL.md frontmatter @ e3986eb (v2.1.16) */}
 
 NanoClaw ships two kinds of skills:
 
-- **Host-side workspace skills** (`.claude/skills/`) — invoked as slash commands in Claude Code from your NanoClaw checkout. They install channels, providers, and tools, or operate and maintain your install. 45 skills total: 17 channel installs, 3 provider installs, 10 tool installs, and 15 operational skills.
+- **Host-side workspace skills** (`.claude/skills/`) — invoked as slash commands in Claude Code from your NanoClaw checkout. They install channels, providers, and tools, or operate and maintain your install. 46 skills total: 17 channel installs, 3 provider installs, 10 tool installs, and 16 operational skills.
 - **Container skills** (`container/skills/`) — 8 skills mounted into every agent container at `/app/skills`. The agent loads them at runtime; you don't invoke them yourself.
 
 For how skills work and how to write your own, see [Extending NanoClaw](/extend/overview).
@@ -80,6 +80,7 @@ Setup, maintenance, migration, and day-to-day administration of your install.
 | `/manage-mounts` | Configures which host directories agent containers can access — view, add, or remove mount allowlist entries |
 | `/migrate-from-openclaw` | Migrates from OpenClaw to NanoClaw v2 — detects an existing install, extracts identity, credentials, and tasks, then guides interactive migration |
 | `/migrate-from-v1` | Finishes migrating a NanoClaw v1 install into v2 after `migrate-v2.sh` — seeds the owner, reconciles container configs, helps port custom v1 code |
+| `/migrate-memory` | Carries an agent group's memory across a provider switch (e.g. Claude ↔ Codex) — run after `ncl groups config update --provider`; reads the source provider's memory store, distills it into the target's, and restarts the group |
 | `/migrate-nanoclaw` | Extracts your customizations from a fork, generates a replayable migration guide, and upgrades to upstream by reapplying them on a clean base |
 | `/qodo-pr-resolver` | Reviews and resolves PR issues with Qodo — AI-powered code review fixes for GitHub, GitLab, Bitbucket, and Azure DevOps |
 | `/setup` | Runs initial NanoClaw setup — install, configure, first-time setup |


### PR DESCRIPTION
## What

Re-verifies the 19 main-tracked pages that were still anchored at **v2.1.4** (`dc34ceb`) against **v2.1.16** (`e3986eb`) — a 12-release delta. This clears the SHA-sweep work that was parked until the provider/Codex line shipped.

Subagent-driven verification (4 parallel readers diffed each page's cited files across the delta). **14 pages were no-drift** — SHA bump only. **5 had real drift**, fixed and grounded in source:

| Page | Drift fixed |
|---|---|
| `installation` | `pnpm run setup --step` list gained `provider-auth` (verified in `setup/index.ts` STEPS) |
| `concepts/contributing` | token count 185k → 195k (`badge.svg`); vitest `include` gained `container/*.test.ts` |
| `reference/skills-catalog` | added `/migrate-memory` row; counts 45 → 46 skills, 15 → 16 operational (only skill added in the delta) |
| `operate/troubleshooting` | boot failures now log `Container exited non-zero` with a `stderrTail` at `warn` (`container-runner.ts`) |
| `extend/overview` | provider installs span **three** barrels now — host + container agent-runner + `setup/providers` (verified in `add-codex/SKILL.md`) |

All 19 bumped `dc34ceb (v2.1.4)` → `e3986eb (v2.1.16)`. `mint validate` + `mint broken-links` pass.

## Scope

The 8 channel pages (`whatsapp`, `telegram`, `discord`, `slack`, `signal`, `imessage`, `teams`, `more-channels`) stay at `dc34ceb` here — they track the `channels` registry branch and are re-verified in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)