### PR TITLE
docs: re-verify 8 channel pages against v2.1.16 + pin channels SHA

### DIFF
--- a/channels/discord.mdx
+++ b/channels/discord.mdx
@@ -5,7 +5,7 @@ tag: "UPDATED"
 keywords: ["discord", "bot token", "add-discord", "gateway", "message content intent", "chat sdk", "threads", "developer portal"]
 ---
 
-{/* verified-against: src/channels/discord.ts (channels branch), src/channels/chat-sdk-bridge.ts, setup/channels/discord.ts, .claude/skills/add-discord/SKILL.md @ dc34ceb */}
+{/* verified-against: src/channels/discord.ts (channels branch), src/channels/chat-sdk-bridge.ts, setup/channels/discord.ts, .claude/skills/add-discord/SKILL.md @ e3986eb (v2.1.16); channels @ 8137440 */}
 
 The Discord adapter connects NanoClaw to a bot you create in the Discord Developer Portal. It's built on the Chat SDK bridge (`@chat-adapter/discord` 4.26.0, pinned — the `/add-discord` skill may pin a slightly newer adapter version) and connects over Discord's **Gateway** — a WebSocket NanoClaw opens outbound, with events forwarded to a local loopback server. No public URL, webhook, or open port needed; works behind NAT and on a laptop.
 

--- a/channels/imessage.mdx
+++ b/channels/imessage.mdx
@@ -5,7 +5,7 @@ tag: "NEW"
 keywords: ["imessage", "add-imessage", "photon", "full disk access", "chat.db", "macos", "chat sdk", "apple messages"]
 ---
 
-{/* verified-against: src/channels/imessage.ts (channels branch), setup/channels/imessage.ts, setup/add-imessage.sh, .claude/skills/add-imessage/SKILL.md @ dc34ceb */}
+{/* verified-against: src/channels/imessage.ts (channels branch), setup/channels/imessage.ts, setup/add-imessage.sh, .claude/skills/add-imessage/SKILL.md @ e3986eb (v2.1.16); channels @ 8137440 */}
 
 The iMessage adapter connects NanoClaw to Apple's Messages network. It's built on the Chat SDK bridge (`chat-adapter-imessage` 0.1.1, pinned — a community adapter) and runs in one of two modes:
 

--- a/channels/more-channels.mdx
+++ b/channels/more-channels.mdx
@@ -5,7 +5,7 @@ tag: "NEW"
 keywords: ["channels", "add-gchat", "add-github", "add-linear", "add-matrix", "add-webex", "add-wechat", "add-deltachat", "add-emacs", "add-resend", "add-whatsapp-cloud", "chat sdk", "webhook"]
 ---
 
-{/* verified-against: upstream/channels:src/channels/{whatsapp-cloud,gchat,github,linear,matrix,webex,wechat,deltachat,emacs,resend}.ts and .claude/skills/add-{whatsapp-cloud,gchat,github,linear,matrix,webex,wechat,deltachat,emacs,resend}/SKILL.md @ dc34ceb (v2.1.4) */}
+{/* verified-against: upstream/channels:src/channels/{whatsapp-cloud,gchat,github,linear,matrix,webex,wechat,deltachat,emacs,resend}.ts and .claude/skills/add-{whatsapp-cloud,gchat,github,linear,matrix,webex,wechat,deltachat,emacs,resend}/SKILL.md @ e3986eb (v2.1.16); channels @ 8137440 */}
 
 These ten channels don't have a guided flow in the first-run setup wizard. Instead, each one is installed by running its `/add-<channel>` skill in Claude Code — Claude copies the adapter in from the `channels` branch, wires it into the registry, then walks you through credentials conversationally. The install pattern (fetch branch, copy adapter, wire barrel, pin package, build, collect credentials) is the same for every channel — see [Channels overview](/channels/overview) for the full model.
 

--- a/channels/signal.mdx
+++ b/channels/signal.mdx
@@ -5,7 +5,7 @@ tag: "NEW"
 keywords: ["signal", "signal-cli", "add-signal", "linked devices", "qr code", "json-rpc", "daemon", "secondary device"]
 ---
 
-{/* verified-against: src/channels/signal.ts (channels branch), setup/channels/signal.ts, setup/add-signal.sh, setup/install-signal-cli.sh, setup/signal-auth.ts, .claude/skills/add-signal/SKILL.md @ dc34ceb */}
+{/* verified-against: src/channels/signal.ts (channels branch), setup/channels/signal.ts, setup/add-signal.sh, setup/install-signal-cli.sh, setup/signal-auth.ts, .claude/skills/add-signal/SKILL.md @ e3986eb (v2.1.16); channels @ 8137440 */}
 
 The Signal adapter is **native** — no Chat SDK bridge, only Node.js builtins. Signal has no bot API, so NanoClaw talks to [signal-cli](https://github.com/AsamK/signal-cli), which it spawns as a local daemon and drives over a newline-delimited **JSON-RPC TCP socket** (`127.0.0.1:7583` by default). Setup links NanoClaw to your existing Signal account as a **secondary device** — no new phone number needed; your assistant sends and receives as the number on your phone. All connections are outbound, so no public URL, webhook, or open port; works behind NAT and on a laptop.
 

--- a/channels/slack.mdx
+++ b/channels/slack.mdx
@@ -5,7 +5,7 @@ tag: "UPDATED"
 keywords: ["slack", "bot token", "signing secret", "add-slack", "webhook", "event subscriptions", "interactivity", "mrkdwn", "chat sdk", "threads"]
 ---
 
-{/* verified-against: src/channels/slack.ts (channels branch), src/channels/chat-sdk-bridge.ts, src/webhook-server.ts, src/router.ts, setup/channels/slack.ts, setup/add-slack.sh, .claude/skills/add-slack/SKILL.md, container/skills/slack-formatting/SKILL.md @ dc34ceb */}
+{/* verified-against: src/channels/slack.ts (channels branch), src/channels/chat-sdk-bridge.ts, src/webhook-server.ts, src/router.ts, setup/channels/slack.ts, setup/add-slack.sh, .claude/skills/add-slack/SKILL.md, container/skills/slack-formatting/SKILL.md @ e3986eb (v2.1.16); channels @ 8137440 */}
 
 The Slack adapter connects NanoClaw to a Slack app you create in your workspace. It's built on the Chat SDK bridge (`@chat-adapter/slack` 4.26.0, pinned) and receives events over **webhooks**: Slack POSTs to `/webhook/slack` on NanoClaw's shared webhook server. Unlike Discord or Telegram, that means Slack needs a **public URL** that reaches your machine.
 

--- a/channels/teams.mdx
+++ b/channels/teams.mdx
@@ -5,7 +5,7 @@ tag: "NEW"
 keywords: ["teams", "microsoft teams", "add-teams", "azure bot", "app registration", "client secret", "sideload", "manifest", "webhook", "chat sdk", "threads"]
 ---
 
-{/* verified-against: src/channels/teams.ts (channels branch), src/channels/chat-sdk-bridge.ts, src/webhook-server.ts, setup/channels/teams.ts, setup/add-teams.sh, .claude/skills/add-teams/SKILL.md @ dc34ceb */}
+{/* verified-against: src/channels/teams.ts (channels branch), src/channels/chat-sdk-bridge.ts, src/webhook-server.ts, setup/channels/teams.ts, setup/add-teams.sh, .claude/skills/add-teams/SKILL.md @ e3986eb (v2.1.16); channels @ 8137440 */}
 
 The Teams adapter connects NanoClaw to a bot you register in Azure. It's built on the Chat SDK bridge (`@chat-adapter/teams` 4.26.0, pinned — the `/add-teams` skill may pin a slightly newer adapter version) and receives messages over **webhooks**: Azure Bot Service POSTs to NanoClaw's shared webhook server, so Teams needs a **public HTTPS URL** that reaches your machine.
 

--- a/channels/telegram.mdx
+++ b/channels/telegram.mdx
@@ -5,7 +5,7 @@ tag: "UPDATED"
 keywords: ["telegram", "botfather", "bot token", "add-telegram", "pairing code", "chat sdk", "polling", "group privacy"]
 ---
 
-{/* verified-against: src/channels/telegram.ts + telegram-pairing.ts + telegram-markdown-sanitize.ts (channels branch), setup/channels/telegram.ts, .claude/skills/add-telegram/SKILL.md @ dc34ceb */}
+{/* verified-against: src/channels/telegram.ts + telegram-pairing.ts + telegram-markdown-sanitize.ts (channels branch), setup/channels/telegram.ts, .claude/skills/add-telegram/SKILL.md @ e3986eb (v2.1.16); channels @ 8137440 */}
 
 The Telegram adapter connects NanoClaw to a bot you create through @BotFather. It's built on the Chat SDK bridge (`@chat-adapter/telegram` 4.26.0, pinned) and runs in **polling mode** — NanoClaw polls Telegram's Bot API for updates, so you don't need a public URL, webhook, or open port. Works behind NAT and on a laptop.
 

--- a/channels/whatsapp.mdx
+++ b/channels/whatsapp.mdx
@@ -5,7 +5,7 @@ tag: "UPDATED"
 keywords: ["whatsapp", "baileys", "qr code", "pairing code", "add-whatsapp", "ASSISTANT_HAS_OWN_NUMBER", "linked devices"]
 ---
 
-{/* verified-against: src/channels/whatsapp.ts (channels branch), setup/channels/whatsapp.ts, .claude/skills/add-whatsapp/SKILL.md @ dc34ceb */}
+{/* verified-against: src/channels/whatsapp.ts (channels branch), setup/channels/whatsapp.ts, .claude/skills/add-whatsapp/SKILL.md @ e3986eb (v2.1.16); channels @ 8137440 */}
 
 The WhatsApp adapter connects NanoClaw to a personal WhatsApp account as a linked device — no Meta business account, no API key. It's a native adapter built directly on `@whiskeysockets/baileys` 7.0.0-rc.9 (pinned; the WhatsApp Web protocol), not the Chat SDK bridge. For Meta's official Cloud API instead, use `/add-whatsapp-cloud` — see the [channels overview](/channels/overview).
 


### PR DESCRIPTION
## What

Re-verifies the 8 channel pages (still anchored at **v2.1.4** `dc34ceb`) against **v2.1.16**.

**Headline finding:** the `channels` registry branch is **frozen at `8137440`** (confirmed via the GitHub API — its HEAD predates v2.1.4 and hasn't moved since). So every channel *adapter* is unchanged since these pages were written, and there's **no content drift**:

- 5 pages (`whatsapp`, `telegram`, `signal`, `imessage`, `more-channels`) cite only frozen channels-branch adapters + unchanged setup files. `add-github`/`add-linear` changed only a raw-SQL example the docs don't reproduce (no docs page contains an `INSERT INTO messaging_groups`).
- 3 pages (`discord`, `slack`, `teams`) cite main files that *did* change (`chat-sdk-bridge.ts`, `webhook-server.ts`, `router.ts`). Verified: multi-instance (v2.1.5) and the webhook raw-route registry both default to the adapter name, so `/webhook/<channel>` paths, `Unknown adapter` 404 strings, and `per-thread` forcing all still match source.

## Change

Pure anchor bump — `dc34ceb (v2.1.4)` → `e3986eb (v2.1.16)` — plus a new **`channels @ 8137440`** pin on each page. The anchors previously said only "(channels branch)" with no SHA; pinning it makes future adapter-drift detection precise. `mint validate` passes.

With this, **all 44 content pages are anchored at v2.1.16** — no `dc34ceb` references remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)