### PR TITLE
docs: agent-to-agent approval policies, named approver, reject-with-reason (v2.1.21)

### DIFF
--- a/concepts/security.mdx
+++ b/concepts/security.mdx
@@ -5,7 +5,7 @@ tag: "UPDATED"
 keywords: ["security", "threat model", "prompt injection", "container isolation", "egress lockdown", "mount allowlist", "approvals", "credentials", "defense in depth"]
 ---
 
-{/* verified-against: src/container-runner.ts, src/egress-lockdown.ts, src/modules/mount-security/index.ts, src/command-gate.ts, src/modules/permissions/{index.ts,access.ts,channel-approval.ts,sender-approval.ts}, src/modules/approvals/{index.ts,primitive.ts,onecli-approvals.ts}, src/modules/self-mod/index.ts, container/Dockerfile, pnpm-workspace.yaml, docs/SECURITY.md @ e3986eb (v2.1.16) */}
+{/* verified-against: src/container-runner.ts, src/egress-lockdown.ts, src/modules/mount-security/index.ts, src/command-gate.ts, src/modules/permissions/{index.ts,access.ts,channel-approval.ts,sender-approval.ts}, src/modules/approvals/{index.ts,primitive.ts,onecli-approvals.ts,reason-capture.ts,finalize.ts,response-handler.ts}, src/modules/agent-to-agent/{message-gate.ts,db/agent-message-policies.ts}, src/modules/self-mod/index.ts, container/Dockerfile, pnpm-workspace.yaml, docs/SECURITY.md @ 2afbd182 (v2.1.21) */}
 
 NanoClaw connects an AI agent with real tools — a shell, a filesystem, network access — to chat platforms where anyone can type. Every inbound message is untrusted input fed straight into the model's context, and no model reliably distinguishes "instructions from my operator" from "instructions an attacker pasted into the group chat." So the design assumption is blunt: **prompt injection eventually succeeds, and the agent acts as if the attacker wrote its instructions.**
 
@@ -62,6 +62,12 @@ Some actions are too consequential to leave to a model that might be acting on i
 - **Credential use** — vault secrets can require per-request approval; the gateway holds the HTTPS request open while the card shows an admin the method, host, path, and body preview.
 - **Self-modification** — an agent asking to install packages or add an MCP server into its own container is asking to expand its own capabilities, which is exactly what an attacker would ask for. Both actions queue an approval card.
 - **Channel registration** — new chats reaching agents, as above.
+- **Agent-to-agent messages** — an operator can gate a connection between two agents so every message from one to the other is held until a human approves it, without un-wiring the connection. Set it with [`ncl policies set`](/guides/multi-agent-swarm#gate-a-connection); no policy means messages flow freely.
+
+Two refinements control who decides and what the agent learns:
+
+- **Named approver** — most cards fall to the first reachable admin, but an agent-to-agent message policy pins a specific approver. Only that exact user (or an owner) can resolve the card, recorded as `approver_user_id` on the request — so a held message can't be cleared by just anyone with admin rights.
+- **Reject with reason** — alongside Approve and Reject, an admin can decline with a one-line note. NanoClaw parks the request, prompts the admin in their DM, and relays their reply back to the requesting agent (`Your <action> request was rejected by admin: "<reason>"`). If the admin doesn't reply within ~5 minutes — or the host restarts mid-prompt — the host sweep finalizes a plain reject, so the agent is never left waiting on a decision that never comes.
 
 The credential flow in detail, including card expiry and `ncl approvals`, is in [Credentials](/operate/credentials#approving-credential-use).
 

--- a/guides/multi-agent-swarm.mdx
+++ b/guides/multi-agent-swarm.mdx
@@ -5,7 +5,7 @@ tag: "UPDATED"
 keywords: ["multi-agent", "create_agent", "agent-to-agent", "agent destinations", "send_message", "sub-agents", "approval", "ncl destinations"]
 ---
 
-{/* verified-against: src/modules/agent-to-agent/{create-agent,agent-route,write-destinations,index}.ts, src/modules/agent-to-agent/db/agent-destinations.ts, src/modules/approvals/primitive.ts, container/agent-runner/src/mcp-tools/agents.ts + agents.instructions.md, container/agent-runner/src/destinations.ts, src/cli/resources/{destinations,groups,wirings}.ts, src/group-init.ts, src/db/messaging-groups.ts @ e3986eb (v2.1.16) */}
+{/* verified-against: src/modules/agent-to-agent/{create-agent,agent-route,write-destinations,index,message-gate}.ts, src/modules/agent-to-agent/db/{agent-destinations,agent-message-policies}.ts, src/modules/approvals/primitive.ts, container/agent-runner/src/mcp-tools/agents.ts + agents.instructions.md, container/agent-runner/src/destinations.ts, src/cli/resources/{destinations,groups,policies,wirings}.ts, src/group-init.ts, src/db/messaging-groups.ts @ 2afbd182 (v2.1.21) */}
 
 The [introduction](/introduction) promises real teams: a worker per task, a manager that tracks what's in flight, a supervisor that pings you. This tutorial builds the smallest working version — one agent spawning and delegating to another — then scales the same three primitives into that trio. It continues from [your first agent](/guides/first-agent); you'll reuse Scout to see the approval gate.
 
@@ -131,9 +131,25 @@ The destinations list reads as the manager's address book: `parent`, `worker-1`,
 </Step>
 </Steps>
 
+## Gate a connection
+
+A wired destination means messages flow with no further checks — fine for agents you trust, riskier when one agent relays anything attacker-influenced into another's context. A **message policy** holds every message on one edge for human approval, without un-wiring it:
+
+```bash
+ncl policies set --from <source-agent-id> --to <target-agent-id> --approver <user-id>
+```
+
+Now each message from the source agent to the target is parked, and an approval card goes to the named approver — only that user (or an owner) can clear it. The connection stays in place; delivery just waits for a tap. The gate is:
+
+- **Directed** — this gates `source → target` only. Gate the reply path with a second policy.
+- **Operator-only** — agents can't gate or un-gate their own edges; it's a host-side `ncl` command, never reachable through prompt injection.
+- **Tied to the connection** — delete either agent group and its policies go with it, so no gate outlives the edge it guarded.
+
+Return to free flow with `ncl policies remove --from <source-agent-id> --to <target-agent-id>`. Full resource reference: [`ncl policies`](/reference/ncl-cli#policies).
+
 ## Limits
 
-- **No loop protection.** There is no throttle, hop limit, or cycle detection on agent-to-agent messages — two agents told to "always reply" will ping-pong indefinitely, burning API calls. Give every agent's instructions an explicit stop condition ("report back once, then wait").
+- **No loop protection.** There is no throttle, hop limit, or cycle detection on agent-to-agent messages — two agents told to "always reply" will ping-pong indefinitely, burning API calls. Give every agent's instructions an explicit stop condition ("report back once, then wait"). A [message policy](#gate-a-connection) on the edge also breaks a runaway loop, since every hop then waits for a human tap.
 - **No broadcast.** Each message targets one destination. Fan-out means one `<message>` block (or `send_message` call) per recipient — the parent orchestrates, the queue doesn't.
 - **No concurrency cap.** `MAX_CONCURRENT_CONTAINERS` (default 5) is parsed at startup but [not enforced anywhere as of v2.1.4](/reference/environment-variables) — a wide team really does run one container per active agent, so size the host accordingly.
 - **Edits to destinations outside `ncl` don't propagate live.** A running container serves a projection of its destinations, refreshed on every wake and by `ncl destinations add`/`remove` — but direct DB writes leave it stale until the next wake.

--- a/reference/db-schema.mdx
+++ b/reference/db-schema.mdx
@@ -5,7 +5,7 @@ tag: "NEW"
 keywords: ["database", "schema", "sqlite", "v2.db", "inbound.db", "outbound.db", "messages_in", "messages_out", "sessions", "container_configs", "pending_sender_approvals", "migrations"]
 ---
 
-{/* verified-against: src/db/schema.ts, src/db/connection.ts, src/db/session-db.ts, src/session-manager.ts, src/db/migrations/{001-initial,002-chat-sdk-state,module-approvals-pending-approvals,module-agent-to-agent-destinations,module-approvals-title-options,008-dropped-messages,009-drop-pending-credentials,010-engage-modes,011-pending-sender-approvals,012-channel-registration,013-approval-render-metadata,014-container-configs,015-cli-scope,016-messaging-group-instance,index}.ts, container/agent-runner/src/db/messages-out.ts, src/modules/scheduling/db.ts @ e3986eb (v2.1.16) */}
+{/* verified-against: src/db/schema.ts, src/db/connection.ts, src/db/session-db.ts, src/session-manager.ts, src/db/migrations/{001-initial,002-chat-sdk-state,module-approvals-pending-approvals,module-agent-to-agent-destinations,module-approvals-title-options,008-dropped-messages,009-drop-pending-credentials,010-engage-modes,011-pending-sender-approvals,012-channel-registration,013-approval-render-metadata,014-container-configs,015-cli-scope,016-messaging-group-instance,017-agent-message-policies,018-approvals-approver-user-id,index}.ts, src/modules/agent-to-agent/db/agent-message-policies.ts, container/agent-runner/src/db/messages-out.ts, src/modules/scheduling/db.ts @ 2afbd182 (v2.1.21) */}
 
 NanoClaw stores everything in SQLite, split across two layers:
 
@@ -172,9 +172,10 @@ Host-side records for any approval-requiring request: `install_packages` / `add_
 | `agent_group_id` | TEXT | `NULL` | FK → `agent_groups(id)` |
 | `channel_type` / `platform_id` / `platform_message_id` | TEXT | `NULL` | Where the admin card lives, for later edits |
 | `expires_at` | TEXT | `NULL` | Expiry for credential approvals |
-| `status` | TEXT | `'pending'` | Approval status |
+| `status` | TEXT | `'pending'` | `pending` \| `approved` \| `rejected` \| `expired` \| `awaiting_reason` (a reject-with-reason hold, see [security](/concepts/security#human-in-the-loop-approvals)) |
 | `title` | TEXT | `''` | Card title (render metadata) |
 | `options_json` | TEXT | `'[]'` | Card options (render metadata) |
+| `approver_user_id` | TEXT | `NULL` | When set — the named approver of an agent-to-agent [message policy](#agent_message_policies) — only that exact user may resolve the card; `NULL` keeps the group/owner authorization path (migration 018) |
 | `created_at` | TEXT | — | ISO timestamp |
 
 ### pending_sender_approvals
@@ -219,6 +220,19 @@ Per-agent named map of allowed message targets — both the routing map and the 
 | `created_at` | TEXT | — | ISO timestamp |
 
 Primary key: `(agent_group_id, local_name)`. Indexed on `(target_type, target_id)`.
+
+### agent_message_policies
+
+Per-message approval gate on an agent-to-agent connection (migration 017). A row means every message from the source agent to the target is held for human approval before delivery — the [destination](#agent_destinations) stays wired, but each message pauses. **No row = free flow.** The gate is directed and per-pair: gate both directions with two rows. Operator-managed only (agents can't gate their own edges), and a row is deleted in both directions when either agent group is removed, so no policy outlives its connection.
+
+| Column | Type | Default | Meaning |
+|---|---|---|---|
+| `from_agent_group_id` | TEXT | — | Source agent (FK → `agent_groups(id)`) |
+| `to_agent_group_id` | TEXT | — | Target agent (FK → `agent_groups(id)`) |
+| `approver` | TEXT | — | User-id who must approve each gated message; only this user (or an owner) can approve. Persisted onto the held card's `pending_approvals.approver_user_id` |
+| `created_at` | TEXT | — | ISO timestamp |
+
+Primary key: `(from_agent_group_id, to_agent_group_id)`.
 
 ### container_configs
 

--- a/reference/ncl-cli.mdx
+++ b/reference/ncl-cli.mdx
@@ -5,7 +5,7 @@ tag: "NEW"
 keywords: ["ncl", "cli", "reference", "commands", "flags", "groups", "wirings", "sessions", "roles", "members", "destinations", "approvals", "cli_scope"]
 ---
 
-{/* verified-against: src/cli/dispatch.ts, src/cli/crud.ts, src/cli/client.ts, src/cli/format.ts, src/cli/transport-errors.ts, src/cli/registry.ts, src/cli/frame.ts, src/cli/commands/help.ts, src/cli/resources/{approvals,destinations,dropped-messages,groups,members,messaging-groups,roles,sessions,user-dms,users,wirings}.ts, bin/ncl @ e3986eb (v2.1.16) */}
+{/* verified-against: src/cli/dispatch.ts, src/cli/crud.ts, src/cli/client.ts, src/cli/format.ts, src/cli/transport-errors.ts, src/cli/registry.ts, src/cli/frame.ts, src/cli/commands/help.ts, src/cli/resources/{approvals,destinations,dropped-messages,groups,members,messaging-groups,policies,roles,sessions,user-dms,users,wirings}.ts, bin/ncl @ 2afbd182 (v2.1.21) */}
 
 Exhaustive reference for the `ncl` admin CLI. For a task-oriented walkthrough, see [The ncl admin CLI](/operate/ncl-cli).
 
@@ -51,7 +51,7 @@ In-flight approval cards waiting for an admin response. Read-only; rows are dele
 | list | `ncl approvals list [--<column> <value>] [--limit N]` | open |
 | get | `ncl approvals get --id <approval-id>` | open |
 
-Columns (all usable as list filters): `approval_id`, `session_id`, `request_id`, `action` (e.g. `install_packages`, `add_mcp_server`, `onecli_credential`), `payload` (JSON), `created_at`, `agent_group_id`, `channel_type`, `platform_id`, `platform_message_id`, `expires_at`, `status` (`pending` | `approved` | `rejected` | `expired`), `title`, `options_json`.
+Columns (all usable as list filters): `approval_id`, `session_id`, `request_id`, `action` (e.g. `install_packages`, `add_mcp_server`, `onecli_credential`), `payload` (JSON), `created_at`, `agent_group_id`, `channel_type`, `platform_id`, `platform_message_id`, `expires_at`, `status` (`pending` | `approved` | `rejected` | `expired` | `awaiting_reason`), `approver_user_id`, `title`, `options_json`.
 
 ## destinations
 
@@ -123,6 +123,18 @@ One chat or channel on one platform. Identity is the unique `(channel_type, plat
 | `--is-group` | number | Updatable, default `0`. `1` = multi-user group chat, `0` = DM. Affects session scoping. |
 | `--unknown-sender-policy` | enum | Updatable, default `strict`. `strict` drops silently; `request_approval` sends an approval card to an admin; `public` allows anyone. |
 | `--denied-at` | string | Updatable. Set when the owner denies registering the channel; router drops all messages silently while set. Cleared by any explicit wiring mutation. |
+
+## policies
+
+Per-message approval gate on an agent-to-agent connection. A row forces every message from one agent to another to be approved by a human before delivery — without un-wiring the [destination](#destinations). **No row = free flow.** Directed and per-pair: gate both directions with two policies. Operator-only — agents can't manage their own gates, and self-messages (`--from` equal to `--to`) are never gated.
+
+| Operation | Invocation | Access |
+| --- | --- | --- |
+| list | `ncl policies list [--<column> <value>]` | open |
+| set | `ncl policies set --from <agent-group-id> --to <agent-group-id> --approver <user-id>` | approval |
+| remove | `ncl policies remove --from <agent-group-id> --to <agent-group-id>` | approval |
+
+`set` upserts — re-running with a different `--approver` replaces it. Only the named `--approver` (or an owner) can approve a held message. Removing a policy returns the edge to free flow. Columns: `from_agent_group_id`, `to_agent_group_id`, `approver`, `created_at`.
 
 ## roles
 


### PR DESCRIPTION
Documents the agent-to-agent approval-gating feature set that landed between v2.1.16 and **v2.1.21**, found during a drift sweep (docs were pinned at `e3986eb`, upstream now at `2afbd182`).

## What's new upstream
- **Per-message approval policies** on agent-to-agent connections — migration 017 adds `agent_message_policies` (`src/modules/agent-to-agent/db/agent-message-policies.ts`, `message-gate.ts`, `src/cli/resources/policies.ts`). A row holds every message on one directed edge for human approval without un-wiring it; no row = free flow; operator-only.
- **Strict named approver** — migration 018 adds `pending_approvals.approver_user_id`; when a policy names an approver, only that exact user (or an owner) can resolve the card.
- **Reject with reason** — an admin can decline with a one-line note relayed to the requesting agent; host sweep finalizes a plain reject if the admin ghosts (`src/modules/approvals/reason-capture.ts`, `finalize.ts`).

## Pages changed
- `reference/db-schema.mdx` — new `agent_message_policies` table; `approver_user_id` + `awaiting_reason` status on `pending_approvals`; migrations 017/018 added to `verified-against`.
- `reference/ncl-cli.mdx` — new `policies` resource (set/remove/list); `approvals` status enum + `approver_user_id` column.
- `concepts/security.mdx` — a2a gate, named approver, and reject-with-reason in the human-in-the-loop approvals section.
- `guides/multi-agent-swarm.mdx` — new "Gate a connection" section + loop-protection cross-link.

All four `verified-against` SHAs bumped `e3986eb` → `2afbd182` (v2.1.21). Every claim verified against upstream source at that SHA (migrations, `policies.ts` CLI resource, `message-gate.ts`, `reason-capture.ts`). CLI token form (`ncl policies`) confirmed against `crud.ts`.

`mint validate` and `mint broken-links` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)