### PR TITLE
docs: container CPU/memory limits + /learn skill (v2.1.21)

### DIFF
--- a/extend/writing-skills.mdx
+++ b/extend/writing-skills.mdx
@@ -9,6 +9,10 @@ keywords: ["writing skills", "SKILL.md", "REMOVE.md", "skill authoring", "idempo
 
 A skill is a markdown file that Claude Code executes — there's no engine to integrate with, so writing one is mostly writing good instructions. The bar upstream holds skills to is [docs/skill-guidelines.md](https://github.com/nanocoai/nanoclaw/blob/main/docs/skill-guidelines.md), and it boils down to two principles: **minimal integration surface** (mostly add files; keep reach-ins into existing code to a line or two that calls your own code) and **a test for every functional integration point** (one that goes red if the wiring is deleted or drifts). This page covers the conventions; [the overview](/extend/overview) explains the model.
 
+<Tip>
+Don't start from a blank file. The [`/learn`](/reference/skills-catalog#operational-skills) skill distills a `SKILL.md` from a source — a directory, a URL, pasted notes, or the work you just did in a conversation — authored to these same guidelines, and refines an existing skill the same way. Generate the first draft, then tighten it by hand against the conventions below.
+</Tip>
+
 ## Anatomy of a SKILL.md
 
 Every skill is a directory under `.claude/skills/<name>/` with a `SKILL.md` in the [Claude Code skills format](https://code.claude.com/docs/en/skills):

--- a/operate/hardening.mdx
+++ b/operate/hardening.mdx
@@ -92,14 +92,16 @@ If the permissions module isn't installed (no `user_roles` table), admin command
 
 ## Cap container resources
 
-Four limits bound what a runaway agent can consume. All are read from `process.env` only — set them in the service definition, not `.env` (see [Configuration](/operate/configuration#process-environment-only)):
+These limits bound what a runaway agent can consume. All are read from `process.env` only — set them in the service definition, not `.env` (see [Configuration](/operate/configuration#process-environment-only)):
 
 | Variable | Default | Limits |
 |---|---|---|
 | `CONTAINER_TIMEOUT` | 30 min | Max runtime for an agent container. |
 | `IDLE_TIMEOUT` | 30 min | How long an idle container survives after its last result. |
-| `MAX_CONCURRENT_CONTAINERS` | `5` | Simultaneously running agent containers. |
+| `CONTAINER_CPU_LIMIT` | _unset_ | CPU cap per container, passed to `docker run --cpus` (e.g. `2`). Opt-in; unset leaves containers unbounded. |
+| `CONTAINER_MEMORY_LIMIT` | _unset_ | Memory cap per container, passed to `docker run --memory` (e.g. `8g`). A hard cap only on a swapless host — there a runaway is OOM-killed; with swap it can spill past the limit. |
 | `CONTAINER_MAX_OUTPUT_SIZE` | 10 MB | Output captured from a container. |
+| `MAX_CONCURRENT_CONTAINERS` | `5` | Intended cap on simultaneous containers — [parsed but not enforced](/reference/environment-variables), so setting it currently has no effect. |
 
 ## Credentials
 

--- a/reference/environment-variables.mdx
+++ b/reference/environment-variables.mdx
@@ -32,6 +32,8 @@ Read from `process.env` at host startup. Putting these in `.env` has no effect �
 |---|---|---|---|
 | `CONTAINER_TIMEOUT` | `1800000` (30 min) | `src/config.ts:34` | Max runtime for an agent container, in milliseconds. |
 | `CONTAINER_MAX_OUTPUT_SIZE` | `10485760` (10 MB) | `src/config.ts:35` | Max output captured from a container, in bytes. |
+| `CONTAINER_CPU_LIMIT` | _unset_ (unbounded) | `src/config.ts:44` | Opt-in CPU cap per agent container, passed through to `docker run --cpus` (e.g. `2`). Empty leaves containers unbounded — the current default. |
+| `CONTAINER_MEMORY_LIMIT` | _unset_ (unbounded) | `src/config.ts:45` | Opt-in memory cap per agent container, passed through to `docker run --memory` (e.g. `8g`). A hard cap only on a swapless host — there the runaway is OOM-killed; with swap present the container can spill past it. NanoClaw doesn't manage swap. |
 | `MAX_MESSAGES_PER_PROMPT` | `10` | `src/config.ts:38` | How many queued messages are batched into one agent prompt. Per-group override exists in container config. |
 | `IDLE_TIMEOUT` | `1800000` (30 min) | `src/config.ts:39` | How long a container stays alive after its last result, waiting for follow-ups. |
 | `MAX_CONCURRENT_CONTAINERS` | `5` | `src/config.ts:40` | Intended cap on simultaneous agent containers. Parsed but not enforced anywhere as of v2.1.4 — setting it has no effect. |

--- a/reference/skills-catalog.mdx
+++ b/reference/skills-catalog.mdx
@@ -5,11 +5,11 @@ tag: "NEW"
 keywords: ["skills", "catalog", "reference", "add-channel", "providers", "tools", "container skills", "workspace skills", "slash commands"]
 ---
 
-{/* verified-against: .claude/skills/ and container/skills/ listings + each skill's SKILL.md frontmatter @ e3986eb (v2.1.16) */}
+{/* verified-against: .claude/skills/ and container/skills/ listings + each skill's SKILL.md frontmatter @ 2afbd182 (v2.1.21) */}
 
 NanoClaw ships two kinds of skills:
 
-- **Host-side workspace skills** (`.claude/skills/`) — invoked as slash commands in Claude Code from your NanoClaw checkout. They install channels, providers, and tools, or operate and maintain your install. 46 skills total: 17 channel installs, 3 provider installs, 10 tool installs, and 16 operational skills.
+- **Host-side workspace skills** (`.claude/skills/`) — invoked as slash commands in Claude Code from your NanoClaw checkout. They install channels, providers, and tools, or operate and maintain your install. 47 skills total: 17 channel installs, 3 provider installs, 10 tool installs, and 17 operational skills.
 - **Container skills** (`container/skills/`) — 8 skills mounted into every agent container at `/app/skills`. The agent loads them at runtime; you don't invoke them yourself.
 
 For how skills work and how to write your own, see [Extending NanoClaw](/extend/overview).
@@ -76,6 +76,7 @@ Setup, maintenance, migration, and day-to-day administration of your install.
 | `/get-qodo-rules` | Loads org- and repo-level coding rules from Qodo before code tasks begin, so generation follows team standards |
 | `/init-first-agent` | Walks you through creating the first agent for a DM channel — resolves your channel identity, wires the DM group, and triggers a welcome DM |
 | `/init-onecli` | Installs and initializes OneCLI Agent Vault, migrating existing `.env` credentials to the vault |
+| `/learn` | Distills a reusable skill from a source — a directory, URL, pasted notes, or the work just done in the conversation — or refines an existing one, writing a `.claude/skills/<name>/SKILL.md` to the project's skill guidelines. Creates or refines skills; it doesn't install them from a registry |
 | `/manage-channels` | Wires channels to agent groups, manages isolation levels, and adds new channel groups |
 | `/manage-mounts` | Configures which host directories agent containers can access — view, add, or remove mount allowlist entries |
 | `/migrate-from-openclaw` | Migrates from OpenClaw to NanoClaw v2 — detects an existing install, extracts identity, credentials, and tasks, then guides interactive migration |


### PR DESCRIPTION
Two opt-in capabilities that landed between v2.1.16 and v2.1.21, from the drift sweep.

## Per-container resource caps
New env vars in `src/config.ts` (`:44`/`:45`), applied at every spawn in `src/container-runner.ts`:
- `CONTAINER_CPU_LIMIT` → `docker run --cpus` (e.g. `2`)
- `CONTAINER_MEMORY_LIMIT` → `docker run --memory` (e.g. `8g`) — a hard cap only on a swapless host (runaway is OOM-killed; with swap it can spill past)

Both opt-in; empty = unbounded (today's behavior). Added to:
- `reference/environment-variables.mdx` — two new rows
- `operate/hardening.mdx` — added to the "Cap container resources" table, and annotated `MAX_CONCURRENT_CONTAINERS` as parsed-but-not-enforced (matching the env-var reference's existing note)

## `/learn` skill
New operational skill: distills a reusable skill from a source (directory, URL, pasted notes, or the conversation) or refines an existing one, writing a `.claude/skills/<name>/SKILL.md` to the project's skill guidelines. Creates/refines skills — doesn't install from a registry.
- `reference/skills-catalog.mdx` — added to operational skills; count 46 → 47 (operational 16 → 17). Re-verified the full skill listing at `2afbd182` and bumped that page's SHA.
- `extend/writing-skills.mdx` — cross-linked as a way to scaffold a first draft

`mint validate` and `mint broken-links` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)