### PR TITLE
docs: update-nanoclaw OneCLI pin upgrade + update-skills container rebuild

### DIFF
--- a/operate/upgrading.mdx
+++ b/operate/upgrading.mdx
@@ -5,7 +5,7 @@ tag: "NEW"
 keywords: ["upgrade", "update", "update-nanoclaw", "update-skills", "migrate-nanoclaw", "upstream", "merge", "rollback"]
 ---
 
-{/* verified-against: .claude/skills/update-nanoclaw/SKILL.md, .claude/skills/update-skills/SKILL.md, .claude/skills/migrate-nanoclaw/SKILL.md, scripts/upgrade-state.ts, src/upgrade-state.ts @ e3986eb (v2.1.16) */}
+{/* verified-against: .claude/skills/update-nanoclaw/SKILL.md, .claude/skills/update-skills/SKILL.md, .claude/skills/migrate-nanoclaw/SKILL.md, versions.json, scripts/upgrade-state.ts, src/upgrade-state.ts @ 2afbd182 (v2.1.21) */}
 
 Don't update with a raw `git pull`. NanoClaw records each sanctioned upgrade in `data/upgrade-state.json`, and a startup tripwire refuses to boot if the running code's version doesn't match that marker. The supported path is the `/update-nanoclaw` skill, which handles the merge, validation, and the marker stamp for you.
 
@@ -20,9 +20,10 @@ Run `/update-nanoclaw` in a Claude Code session at your project root. The skill 
 5. **Conflict preview.** Dry-runs the merge (`git merge --no-commit --no-ff`, then abort) so you see which files would conflict before committing to anything.
 6. **Merge and resolve.** Applies your chosen path. On conflicts it opens only the conflicted files, resolves the markers, and keeps your local customizations intact.
 7. **Validation.** Runs `pnpm run build` and `pnpm test`. If `container/` files changed, it also rebuilds the container image with `./container/build.sh`.
-8. **Breaking changes.** Scans the new `CHANGELOG.md` entries for `[BREAKING]` lines, each of which names a migration skill (`Run /<skill-name> to …`); the skill lists them and offers to run the ones you pick. A breaking change that instead points to a `docs/` page — like the OneCLI gateway upgrade ([`docs/onecli-upgrades.md`](https://github.com/nanocoai/nanoclaw/blob/main/docs/onecli-upgrades.md)) — you follow by hand, since the gateway is an external component that's never upgraded for you.
-9. **Marker stamp.** On success, stamps the upgrade marker (`pnpm exec tsx scripts/upgrade-state.ts set "" update-nanoclaw`) so the tripwire passes on next start.
-10. **Summary.** Prints the backup tag, conflicts resolved, and the restart command for your platform.
+8. **OneCLI pins.** If the `onecli-gateway` or `onecli-cli` pin in `versions.json` moved since your backup tag, the skill surfaces it and walks you through the OneCLI upgrade ([`docs/onecli-upgrades.md`](https://github.com/nanocoai/nanoclaw/blob/main/docs/onecli-upgrades.md)) before the restart — the gateway and CLI are external components, so the running versions must be bumped to match the merged code. No pin change and the step is skipped.
+9. **Breaking changes.** Scans the new `CHANGELOG.md` entries for `[BREAKING]` lines, each of which names a migration skill (`Run /<skill-name> to …`); the skill lists them and offers to run the ones you pick. A breaking change that points to a `docs/` page instead of a skill is one you follow by hand.
+10. **Marker stamp.** On success, stamps the upgrade marker (`pnpm exec tsx scripts/upgrade-state.ts set "" update-nanoclaw`) so the tripwire passes on next start.
+11. **Summary.** Prints the backup tag, conflicts resolved, and the restart command for your platform.
 
 To roll back, reset to the backup tag the skill printed:
 
@@ -45,8 +46,9 @@ To refresh skills without a full upstream update, run `/update-skills`. Its flow
 3. **Selection.** You pick which skills to re-apply.
 4. **Re-apply.** Invokes each selected skill's own `/add-<name>` apply, which fetches the latest files and overwrites the copied-in code.
 5. **Validation.** `pnpm run build` and `pnpm test` — each channel and provider skill ships a registration test that asserts the barrel still registers the adapter.
+6. **Container rebuild.** If a re-applied skill changed files under `container/` (e.g. a provider's in-container runtime), the skill rebuilds the agent image with `./container/build.sh` — until then new sessions keep running the old image, so the rebuild is what makes the change live, not the file copy. A channel-adapter-only refresh skips this.
 
-Restart the service afterwards to pick up the refreshed code.
+Restart the service afterwards to pick up the refreshed host code.
 
 ## Heavily customized forks
 


### PR DESCRIPTION
`operate/upgrading.mdx` drifted on two `/update-*` behaviors. Found in the v2.1.16 → v2.1.21 sweep; verified against the skills @ `2afbd182`.

- **OneCLI gateway upgrade** — `/update-nanoclaw` now has a step (5.5 in the skill) that detects when `onecli-gateway` / `onecli-cli` in `versions.json` moved since the backup tag and walks you through `docs/onecli-upgrades.md` before the restart. This **reverses** the page's stale claim that "the gateway is an external component that's never upgraded for you" — the upgrade is now surfaced and sequenced by the update flow.
- **Container rebuild on skill re-apply** — `/update-skills` now rebuilds the agent image (`./container/build.sh`) when a re-applied skill changed files under `container/` (e.g. a provider's runtime). The rebuild is what makes in-container code live, not the file copy.

Page SHA bumped to `2afbd182` (re-verified `update-nanoclaw` + `update-skills` SKILL.md).

`mint validate` and `mint broken-links` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)