### PR TITLE
docs: make Get started outcome-first for newcomers

### DIFF
--- a/changelog/docs-updates.mdx
+++ b/changelog/docs-updates.mdx
@@ -5,6 +5,10 @@ icon: "file-pen"
 rss: true
 ---
 
+<Update label="Beginner-friendlier Get started" description="2026-06-29" tags={["Updated"]}>
+  Reworked the on-ramp to lead with outcome before architecture. `introduction` now opens with what NanoClaw does for you (text it like a coworker; it runs code in a sandbox) and a "Key terms" callout defining agent / channel / sandbox / provider; the SQLite-queue framing moved into "How a message flows" rather than the lede. `quickstart` gained a time/effort/prerequisite expectation-setter. No facts changed — resequenced and scaffolded.
+</Update>
+
 <Update label="Slack Socket Mode" description="2026-06-29" tags={["Updated"]}>
   Documented Slack's **Socket Mode** (now the setup default) across `channels/slack` and `channels/overview`. Setting `SLACK_APP_TOKEN` (`xapp-…`) opens an outbound WebSocket, so the host needs **no public URL** — alongside the existing webhook mode. Reverses the page's old "v2 doesn't use Socket Mode" note and the webhook-only framing.
 </Update>

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -9,9 +9,17 @@ keywords: ["nanoclaw", "multi-agent", "claude", "container isolation", "inbox ou
 
 {/* verified-against: src/index.ts, src/router.ts, src/channels/index.ts, src/container-runtime.ts, src/container-runner.ts, src/db/schema.ts, src/modules/, container/agent-runner/src/mcp-tools/agents.ts, agents.instructions.md, core.ts, .claude/skills/, .claude/skills/add-telegram/SKILL.md, repo-tokens/badge.svg, package.json @ 2afbd182 (v2.1.21) */}
 
-NanoClaw runs AI agents that talk to you over your messaging apps — and to each other. Claude is the default provider, with Codex, OpenCode, and Ollama available as alternatives. One Node host process handles routing and delivery. Every active session gets its own Docker container, so agents can run Bash and edit files without touching your host or each other.
+NanoClaw is a personal AI assistant you run on your own machine and reach from the messaging apps you already use — Telegram, WhatsApp, Discord, Slack, or just your terminal. Text it like you'd text a coworker: it can search the web, run code, edit files, and follow up on a schedule. Each agent works inside its own locked-down sandbox, so it does real work without touching the rest of your computer.
 
-A single pattern drives the whole system: every message is a row in a SQLite queue. A user chat, an inbound webhook, a scheduled job, an agent delegating to another agent — all of them land in an inbox table (`messages_in`), and every response leaves through an outbox (`messages_out`). A scheduled task is just a message with a `process_after` timestamp. There is no separate scheduler, RPC layer, or job system to learn.
+It's self-hosted and yours — clone the repo, run one setup command, connect a chat app. Claude powers agents by default, with Codex, OpenCode, and Ollama as alternatives.
+
+<Info>
+  **New here? Four words that show up everywhere:**
+  - **Agent** — one AI identity with its own memory, workspace, and personality.
+  - **Channel** — a messaging app you reach an agent through (Telegram, WhatsApp, … or the terminal).
+  - **Sandbox** — the isolated Docker container an agent runs in; it only sees what you explicitly share.
+  - **Provider** — the AI model behind an agent (Claude by default; Codex, OpenCode, or Ollama optional).
+</Info>
 
 <CardGroup cols={2}>
   <Card title="Run it" icon="rocket" href="/quickstart">
@@ -29,6 +37,8 @@ A single pattern drives the whole system: every message is a row in a SQLite que
 </CardGroup>
 
 ## How a message flows
+
+One idea drives the whole system: every message is a row in a SQLite queue. A user chat, an inbound webhook, a scheduled job, an agent delegating to another agent — all of them land in an inbox table (`messages_in`), and every response leaves through an outbox (`messages_out`). A scheduled task is just a message with a `process_after` timestamp. There's no separate scheduler, RPC layer, or job system to learn.
 
 Every channel — Telegram, Discord, a webhook, the built-in CLI — feeds the same pipeline:
 

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -8,7 +8,7 @@ keywords: ["setup", "install", "getting started", "nanoclaw.sh", "setup wizard",
 
 {/* verified-against: nanoclaw.sh, setup.sh, setup/auto.ts, setup/probe.sh, setup/install-node.sh, setup/channels/*.ts, setup/providers/registry.ts, scripts/init-first-agent.ts, .claude/skills/setup/SKILL.md, package.json @ 2afbd182 (v2.1.21) */}
 
-From a fresh machine to an agent you can message — one command and a handful of prompts.
+About 15 minutes from a fresh machine to an assistant you can message — one command, a handful of prompts, and one thing you bring yourself: a credential for your AI provider (a Claude or Codex subscription, or an API key). The script installs everything else.
 
 ## Prerequisites
 


### PR DESCRIPTION
The Get started section read architecture-first — great for evaluators, intimidating for someone new to NanoClaw. This resequences and scaffolds the on-ramp. **No facts changed.**

- **introduction** — new outcome-first lede (what it does for you: text it like a coworker, it runs code in a sandbox) + a **Key terms** callout defining agent / channel / sandbox / provider. The SQLite-queue framing isn't cut — it moves into "How a message flows" as that section's lead-in, instead of being the first thing a beginner reads.
- **quickstart** — a time/effort/prerequisite expectation-setter (~15 min, one command, one credential).
- **changelog/docs-updates** — entry.

Scoped for "a technical person new to NanoClaw" — terminal commands and the self-hosted `git clone` flow are unchanged.

`mint validate` and `mint broken-links` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)