### PR TITLE
docs: reset sidebar badges — strip stale NEW + SHA-only UPDATED

### DIFF
--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -3,7 +3,6 @@ title: "Releases"
 description: "NanoClaw release history, changelog, and version-by-version feature and fix notes."
 icon: "tag"
 rss: true
-tag: "UPDATED"
 ---
 
 <Update label="v2.1.21" description="2026-06-25" tags={["Feature"]}>

--- a/channels/cli.mdx
+++ b/channels/cli.mdx
@@ -1,7 +1,6 @@
 ---
 title: "CLI channel"
 description: "Talk to your agents straight from the terminal over a local Unix socket — the only channel that ships on trunk, with zero credentials and zero setup."
-tag: "NEW"
 keywords: ["cli", "terminal", "pnpm run chat", "unix socket", "cli.sock", "local channel", "init-cli-agent"]
 ---
 

--- a/channels/discord.mdx
+++ b/channels/discord.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Discord"
 description: "Connect NanoClaw to a Discord bot via the Chat SDK adapter — Developer Portal app, Gateway connection, and per-thread sessions."
-tag: "UPDATED"
 keywords: ["discord", "bot token", "add-discord", "gateway", "message content intent", "chat sdk", "threads", "developer portal"]
 ---
 

--- a/channels/imessage.mdx
+++ b/channels/imessage.mdx
@@ -1,7 +1,6 @@
 ---
 title: "iMessage"
 description: "Connect NanoClaw to iMessage via the Chat SDK adapter — local mode on your own Mac with Full Disk Access, or remote mode through a Photon API server."
-tag: "NEW"
 keywords: ["imessage", "add-imessage", "photon", "full disk access", "chat.db", "macos", "chat sdk", "apple messages"]
 ---
 

--- a/channels/more-channels.mdx
+++ b/channels/more-channels.mdx
@@ -1,7 +1,6 @@
 ---
 title: "More channels"
 description: "Catalog of the ten NanoClaw channels installed conversationally with /add-<channel> — Delta Chat, Emacs, GitHub, Google Chat, Linear, Matrix, Resend, Webex, WeChat, and WhatsApp Cloud API."
-tag: "NEW"
 keywords: ["channels", "add-gchat", "add-github", "add-linear", "add-matrix", "add-webex", "add-wechat", "add-deltachat", "add-emacs", "add-resend", "add-whatsapp-cloud", "chat sdk", "webhook"]
 ---
 

--- a/channels/overview.mdx
+++ b/channels/overview.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Channels overview"
 description: "How NanoClaw channels work: the built-in CLI channel, the adapter catalog on the channels branch, and the /add-<channel> skills that install them."
-tag: "UPDATED"
 keywords: ["channels", "adapters", "channel registry", "chat sdk", "webhook", "add-telegram", "add-discord", "add-slack", "manage-channels"]
 ---
 

--- a/channels/signal.mdx
+++ b/channels/signal.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Signal"
 description: "Connect NanoClaw to Signal via a native signal-cli adapter — QR-code device linking, a local JSON-RPC daemon, and no bot API required."
-tag: "NEW"
 keywords: ["signal", "signal-cli", "add-signal", "linked devices", "qr code", "json-rpc", "daemon", "secondary device"]
 ---
 

--- a/channels/teams.mdx
+++ b/channels/teams.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Microsoft Teams"
 description: "Connect NanoClaw to Microsoft Teams via the Chat SDK adapter — Azure app registration, bot resource, messaging endpoint, manifest sideload, and thread sessions."
-tag: "NEW"
 keywords: ["teams", "microsoft teams", "add-teams", "azure bot", "app registration", "client secret", "sideload", "manifest", "webhook", "chat sdk", "threads"]
 ---
 

--- a/channels/telegram.mdx
+++ b/channels/telegram.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Telegram"
 description: "Connect NanoClaw to a Telegram bot via the Chat SDK adapter — BotFather token, polling mode, and code-based chat pairing."
-tag: "UPDATED"
 keywords: ["telegram", "botfather", "bot token", "add-telegram", "pairing code", "chat sdk", "polling", "group privacy"]
 ---
 

--- a/channels/whatsapp.mdx
+++ b/channels/whatsapp.mdx
@@ -1,7 +1,6 @@
 ---
 title: "WhatsApp"
 description: "Connect NanoClaw to your personal WhatsApp with the native Baileys adapter — QR or pairing-code login, shared or dedicated number."
-tag: "UPDATED"
 keywords: ["whatsapp", "baileys", "qr code", "pairing code", "add-whatsapp", "ASSISTANT_HAS_OWN_NUMBER", "linked devices"]
 ---
 

--- a/concepts/architecture.mdx
+++ b/concepts/architecture.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Architecture"
 description: "How NanoClaw works from the top down: a host process that routes messages between channel adapters and per-session agent containers, with SQLite files as the only transport."
-tag: "UPDATED"
 keywords: ["architecture", "host process", "router", "delivery", "host sweep", "inbound.db", "outbound.db", "container", "agent-runner", "poll loop", "IPC"]
 ---
 

--- a/concepts/contributing.mdx
+++ b/concepts/contributing.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Contributing to NanoClaw"
 description: "How the nanoclaw repo is laid out, the dev loop, the three-branch model, and what kinds of contributions get accepted."
-tag: "UPDATED"
 keywords: ["contributing", "development", "pnpm", "vitest", "bun", "channels branch", "providers branch", "repo layout", "pull requests", "token count"]
 ---
 

--- a/concepts/entity-model.mdx
+++ b/concepts/entity-model.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Entity model"
 description: "The five entities behind every NanoClaw conversation — agent groups, messaging groups, wirings, users, and sessions — and how a message finds its way through them."
-tag: "UPDATED"
 keywords: ["entity model", "agent groups", "messaging groups", "wirings", "messaging_group_agents", "engage_mode", "session_mode", "sender_scope", "roles", "owner", "admin", "sessions"]
 ---
 

--- a/concepts/isolation-levels.mdx
+++ b/concepts/isolation-levels.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Isolation levels"
 description: "A decision guide for how isolated your agents and conversations should be — from fully separate agent groups down to one shared conversation across channels."
-tag: "NEW"
 keywords: ["isolation", "session_mode", "shared", "per-thread", "agent-shared", "agent groups", "privacy", "workspace", "sessions", "multi-tenant"]
 ---
 

--- a/extend/overview.mdx
+++ b/extend/overview.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Skills: how NanoClaw extends itself"
 description: "What a NanoClaw skill is in v2 — SKILL.md workflows that Claude Code executes in your checkout, fetching code additively from registry branches. Never a git merge."
-tag: "UPDATED"
 keywords: ["skills", "extend", "SKILL.md", "registry branches", "channels branch", "providers branch", "REMOVE.md", "container skills", "additive fetch"]
 ---
 

--- a/extend/self-modification.mdx
+++ b/extend/self-modification.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Agent self-modification"
 description: "What agents can change about themselves — editing their own memory freely, and requesting packages or MCP servers through admin approval."
-tag: "NEW"
+tag: "UPDATED"
 keywords: ["self-modification", "install_packages", "add_mcp_server", "CLAUDE.local.md", "approval", "self-customize", "rebuild", "agent memory"]
 ---
 

--- a/extend/tools.mdx
+++ b/extend/tools.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Give agents tools"
 description: "Two ways to add MCP tools to NanoClaw agents — install a tool skill like /add-gmail-tool, or register any MCP server yourself via the container config."
-tag: "UPDATED"
 keywords: ["tools", "mcp", "gmail", "google calendar", "ollama", "atomic chat", "agent-browser", "web access", "add-mcp-server", "tool skills"]
 ---
 

--- a/extend/writing-skills.mdx
+++ b/extend/writing-skills.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Writing skills"
 description: "How to author a NanoClaw skill: SKILL.md anatomy, idempotent apply steps, REMOVE.md, registration tests, and the path from a private skill to an upstream PR."
-tag: "NEW"
 keywords: ["writing skills", "SKILL.md", "REMOVE.md", "skill authoring", "idempotency", "registration test", "skill-guidelines", "vitest", "integration points"]
 ---
 

--- a/guides/customize-an-agent.mdx
+++ b/guides/customize-an-agent.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Customize an agent"
 description: "Hands-on tutorial: change an agent's personality through CLAUDE.local.md, swap its model and effort with ncl, and verify the changes landed."
-tag: "UPDATED"
 keywords: ["customize", "CLAUDE.local.md", "personality", "model", "effort", "ncl groups config update", "self-customize", "/customize"]
 ---
 

--- a/guides/first-agent.mdx
+++ b/guides/first-agent.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Your first agent"
 description: "Hands-on tutorial: build an agent from parts with ncl — create the agent group, wire it to the CLI channel, talk to it, and inspect everything it created."
-tag: "NEW"
 keywords: ["tutorial", "first agent", "ncl groups create", "wirings", "messaging group", "cli channel", "pnpm run chat", "CLAUDE.local.md"]
 ---
 

--- a/guides/scheduled-tasks.mdx
+++ b/guides/scheduled-tasks.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Schedule recurring work"
 description: "Hands-on tutorial: have your agent schedule a recurring task in chat, understand what fires it, manage the series, gate frequent runs with a script, and inspect it all from the host."
-tag: "UPDATED"
 keywords: ["scheduled tasks", "schedule_task", "cron", "recurrence", "process_after", "series_id", "host sweep", "wakeAgent", "task script", "timezone"]
 ---
 

--- a/migrate-from-v1.mdx
+++ b/migrate-from-v1.mdx
@@ -2,7 +2,6 @@
 title: "Migrate from v1 or OpenClaw"
 description: "Move a NanoClaw v1 install to v2 with migrate-v2.sh and the /migrate-from-v1 skill, or import an OpenClaw setup with /migrate-from-openclaw."
 icon: "route"
-tag: "NEW"
 keywords: ["migration", "v1", "v2", "upgrade", "OpenClaw", "migrate-v2.sh", "migrate-from-v1", "migrate-from-openclaw", "handoff"]
 ---
 

--- a/operate/configuration.mdx
+++ b/operate/configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Configuration"
 description: "Configure a NanoClaw install — environment variables in .env and the service environment, plus per-group container config in the database."
-tag: "NEW"
+tag: "UPDATED"
 keywords: ["configuration", "environment variables", ".env", "container config", "ASSISTANT_NAME", "CONTAINER_TIMEOUT", "LOG_LEVEL", "container_configs"]
 ---
 

--- a/operate/credentials.mdx
+++ b/operate/credentials.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Credentials"
 description: "How NanoClaw keeps raw API keys out of agent containers — the OneCLI Agent Vault, credential stubs, approval cards, and the .env opt-out."
-tag: "NEW"
 keywords: ["credentials", "OneCLI", "Agent Vault", "secrets", "approval", "onecli-managed", "credential proxy", "ANTHROPIC_BASE_URL"]
 ---
 

--- a/operate/ncl-cli.mdx
+++ b/operate/ncl-cli.mdx
@@ -1,7 +1,6 @@
 ---
 title: "The ncl admin CLI"
 description: "Administer a running NanoClaw host from the terminal — inspect and modify groups, wirings, users, sessions, and approvals over the ncl Unix socket."
-tag: "UPDATED"
 keywords: ["ncl", "cli", "admin", "unix socket", "cli_scope", "groups", "wirings", "sessions", "approvals"]
 ---
 

--- a/operate/troubleshooting.mdx
+++ b/operate/troubleshooting.mdx
@@ -2,7 +2,6 @@
 title: "Troubleshooting"
 description: "Diagnose NanoClaw v2 failures: host startup stops, container spawn errors, dropped messages, silent agents, and stuck sessions."
 keywords: ["troubleshooting", "debugging", "dropped messages", "container spawn", "upgrade tripwire", "host sweep", "LOG_LEVEL"]
-tag: "UPDATED"
 ---
 
 {/* verified-against: .claude/skills/debug/SKILL.md, src/container-runtime.ts, src/container-runner.ts, src/host-sweep.ts, src/upgrade-state.ts, src/log.ts, src/cli/resources/dropped-messages.ts, src/cli/resources/sessions.ts, src/egress-lockdown.ts, src/modules/mount-security/index.ts, src/webhook-server.ts, src/circuit-breaker.ts, setup/service.ts @ 2afbd182 (v2.1.21) */}

--- a/operate/uninstall.mdx
+++ b/operate/uninstall.mdx
@@ -2,7 +2,6 @@
 title: "Uninstall NanoClaw"
 description: "Remove a NanoClaw install — service, containers, data, and credential agents — with a scan, confirm, and execute flow scoped to this checkout."
 icon: "trash"
-tag: "NEW"
 keywords: ["uninstall", "remove", "delete", "cleanup", "nanoclaw.sh --uninstall", "dry run", "install slug"]
 ---
 

--- a/operate/upgrading.mdx
+++ b/operate/upgrading.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Upgrading"
 description: "Update NanoClaw and its skills with /update-nanoclaw and /update-skills — preview, backup, merge, validate, and restart."
-tag: "NEW"
+tag: "UPDATED"
 keywords: ["upgrade", "update", "update-nanoclaw", "update-skills", "migrate-nanoclaw", "upstream", "merge", "rollback"]
 ---
 

--- a/reference/adapter-interface.mdx
+++ b/reference/adapter-interface.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Channel adapter interface"
 description: "The ChannelAdapter contract for building your own channel — lifecycle, delivery, registration, and the Chat SDK bridge."
-tag: "NEW"
 keywords: ["channel adapter", "ChannelAdapter", "adapter interface", "custom channel", "chat sdk bridge", "registerChannelAdapter", "initChannelAdapters", "supportsThreads", "deliver", "InboundMessage"]
 ---
 

--- a/reference/container-config.mdx
+++ b/reference/container-config.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Container configuration"
 description: "Every per-group container config field — storage, defaults, spawn-time consumption, and when changes take effect."
-tag: "NEW"
 keywords: ["container config", "container_configs", "container.json", "provider", "model", "effort", "image_tag", "mcp_servers", "additional_mounts", "cli_scope", "skills", "packages"]
 ---
 

--- a/reference/db-schema.mdx
+++ b/reference/db-schema.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Database schema"
 description: "Every table in NanoClaw's central database and the per-session inbound/outbound database pairs — columns, defaults, and intent."
-tag: "NEW"
+tag: "UPDATED"
 keywords: ["database", "schema", "sqlite", "v2.db", "inbound.db", "outbound.db", "messages_in", "messages_out", "sessions", "container_configs", "pending_sender_approvals", "migrations"]
 ---
 

--- a/reference/environment-variables.mdx
+++ b/reference/environment-variables.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Environment variables"
 description: "Every environment variable NanoClaw reads — .env keys, host process environment, setup-time variables, and container-side overrides — with defaults and source locations."
-tag: "NEW"
+tag: "UPDATED"
 keywords: ["environment variables", ".env", "configuration", "ASSISTANT_NAME", "CONTAINER_TIMEOUT", "LOG_LEVEL", "NANOCLAW_SKIP", "NANOCLAW_EGRESS_LOCKDOWN", "setup", "reference"]
 ---
 

--- a/reference/mcp-tools.mdx
+++ b/reference/mcp-tools.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Agent MCP tools"
 description: "Every MCP tool the agent can call inside its container — messaging, scheduling, interactive cards, sub-agents, and self-modification."
-tag: "NEW"
 keywords: ["mcp tools", "send_message", "send_file", "schedule_task", "ask_user_question", "create_agent", "install_packages", "add_mcp_server", "nanoclaw mcp server", "agent tools"]
 ---
 

--- a/reference/ncl-cli.mdx
+++ b/reference/ncl-cli.mdx
@@ -1,7 +1,7 @@
 ---
 title: "ncl CLI reference"
 description: "Every ncl resource, verb, flag, enum, and default — extracted from the v2 CLI registry."
-tag: "NEW"
+tag: "UPDATED"
 keywords: ["ncl", "cli", "reference", "commands", "flags", "groups", "wirings", "sessions", "roles", "members", "destinations", "approvals", "cli_scope"]
 ---
 

--- a/reference/skills-catalog.mdx
+++ b/reference/skills-catalog.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Skills catalog"
 description: "Every skill that ships with NanoClaw — host-side workspace skills you invoke in Claude Code, and container skills mounted into every agent container."
-tag: "NEW"
+tag: "UPDATED"
 keywords: ["skills", "catalog", "reference", "add-channel", "providers", "tools", "container skills", "workspace skills", "slash commands"]
 ---
 


### PR DESCRIPTION
The v2 rewrite plus the v2.1.21 sweep left **~44 of ~46 pages badged**, so the sidebar's NEW/UPDATED signal had become noise — when almost everything is flagged, nothing stands out.

This resets badges to the pages a returning reader actually benefits from.

- **Removed all 21 `NEW` tags.** None of these pages are new — they date from the June v2 rewrite, and the `.mintlify` 2-week audit hadn't cleared them, so they were advertising "NEW" on some of the oldest content.
- **Dropped `UPDATED`** from pages whose only sweep change was a `verified-against` SHA bump, a version-pin tweak, or a one-line cross-reference (cosmetic / non-reader-facing, per CLAUDE.md's "do not tag cosmetic-only changes").
- **Kept `UPDATED`** on the 16 pages with substantive new v2.1.21 content (a2a policies, Codex v2, container caps, `/learn`, reject-with-reason, Socket Mode, the onboarding rework…), flipping 7 of them from a stale `NEW` to the accurate `UPDATED`.

**44 badges → 16.**

Note: the `.mintlify` sync workflow could re-stamp `UPDATED` on a future upstream sync of these files; if that recurs, the durable fix is tightening the audit workflow's age threshold rather than another manual pass.

`mint validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)