### PR TITLE
docs(workflows): fix tag-audit expiry + add badge saturation cap

### DIFF
--- a/.mintlify/workflows/sync-upstream-changes.md
+++ b/.mintlify/workflows/sync-upstream-changes.md
@@ -65,7 +65,7 @@ When changes don't map cleanly through verified-against comments (e.g., brand-ne
 
 - If a change doesn't affect documentation, skip it.
 - Keep documentation concise. Match the existing style of each page.
-- For every page where you make a **content change** (corrected facts, new sections, changed behavior), add or keep `tag: "UPDATED"` in the frontmatter. Do NOT add the tag for cosmetic-only changes (formatting, component swaps, whitespace, or a SHA-only bump of the verified-against comment). If the page already has a different tag (e.g., `NEW`), replace it with `UPDATED`. Example:
+- For every page where you make a **content change** (corrected facts, new sections, changed behavior), add or keep `tag: "UPDATED"` in the frontmatter. Do NOT add the tag for cosmetic-only changes (formatting, component swaps, whitespace, or a SHA-only bump of the verified-against comment). If the page already has a different tag (e.g., `NEW`), replace it with `UPDATED`. If your only change to a page is a SHA-only `verified-against` bump, leave its existing tag exactly as-is — do not add, refresh, or remove it; the weekly audit ages tags out by content date and enforces the badge cap. Example:
   ```yaml
   ---
   title: "Container lifecycle"

--- a/.mintlify/workflows/weekly-docs-audit.md
+++ b/.mintlify/workflows/weekly-docs-audit.md
@@ -49,10 +49,14 @@ Verify all `.mdx` files have:
 
 ### 6. Clean up stale sidebar tags
 
-Check all `.mdx` files for `tag` frontmatter fields. Remove tags that are no longer relevant:
-- Remove `tag: "NEW"` from pages that were created more than 2 weeks ago (check git log for the file's first commit date)
-- Remove `tag: "UPDATED"` from pages that were last modified more than 2 weeks ago (check git log for the file's last commit date)
-- Leave other tags (e.g., `BETA`, `DEPRECATED`) untouched — these are intentional and long-lived
+Sidebar `tag` badges are a contrast signal — they only help when they mark the *few* pages worth a second look. Keep them scarce: a badge on most of the nav reads as noise, not news.
+
+Check all `.mdx` files for `tag` frontmatter fields and apply these rules in order:
+
+- **`NEW`** — remove from any page whose *first* commit is more than 2 weeks old (`git log --diff-filter=A --follow --format=%cI -- <file> | tail -1`). `NEW` is only for genuinely new pages; a page that merely gained content should carry `UPDATED`, not `NEW`.
+- **`UPDATED`** — date this off the page's last **content** change, NOT its last commit. A commit whose only change to the file is the `{/* verified-against … */}` comment line or the `tag:` frontmatter field is bookkeeping, not content — it must not keep a page badged. Inspect each candidate commit's diff (`git log -p --follow -- <file>`) and use the most recent commit that touches any *other* line as the freshness date; remove `UPDATED` if that date is more than 2 weeks old. (This is the key fix: SHA-only `verified-against` bumps and tag edits no longer reset the clock.)
+- **Saturation cap** — after the above, if more than **10 pages** still carry `UPDATED` (~20% of the nav), keep the tag only on the 10 with the most recent content change and strip it from the rest, oldest first. This bounds the badge count no matter how many pages an upstream sync touched at once.
+- Leave other tags (e.g., `BETA`, `DEPRECATED`) untouched — these are intentional and long-lived.
 
 ### 7. Report and fix
 


### PR DESCRIPTION
Follow-up to the sidebar badge reset (#330) — fixes the workflow logic so the noise can't recur.

## Root cause
The weekly audit expired `UPDATED` based on a file's **last commit date**. But bookkeeping commits — a SHA-only `verified-against` bump, a tag edit, a typo fix — count as commits, so any cosmetic touch reset the 2-week clock and kept pages badged with no reader-facing change. With no cap on total badges, a large upstream sweep saturated the sidebar faster than the once-a-week, manually-merged cleanup could drain it (hence ~44 of ~46 pages badged).

## Fix
- **`weekly-docs-audit.md`** — date `UPDATED` off the last **content** commit, explicitly ignoring commits that only touch the `verified-against` comment or the `tag:` field; clarified `NEW` expiry (first-commit date; `NEW` is for new pages only); and added a **hard cap of 10 `UPDATED` pages (~20% of nav)**, oldest stripped first. The cap bounds badge count regardless of how many pages a sync touches at once.
- **`sync-upstream-changes.md`** — a SHA-only bump must leave the existing tag untouched, not refresh it.

These are the `.mintlify/workflows/` agent instructions (tracked, though `.mintlify/` is otherwise gitignored). `mint validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)