### PR TITLE
docs(tooling): /drift-sweep skill + workflow wiring + CLAUDE.md learnings

### DIFF
--- a/.claude/skills/drift-sweep/SKILL.md
+++ b/.claude/skills/drift-sweep/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: drift-sweep
+description: Use when the docs have fallen behind upstream nanoclaw (a multi-version gap, a new release, or the weekly audit flags drift) and need a rigorous re-verification sweep — classify every page clean/dirty, verify in parallel, ship stacked PRs, reconstruct the changelog, and bump verified-against SHAs honestly. This is the thorough operator-run version of the auto sync-upstream-changes workflow.
+---
+
+# Drift Sweep
+
+Bring the whole docs site current with upstream `nanocoai/nanoclaw` after it has moved — especially across several versions, where the lightweight auto `sync-upstream-changes` workflow under-performs. Produces a prioritized set of stacked PRs, each verified against source and confirmed live.
+
+## When to use
+
+- Docs are several versions behind upstream (the weekly audit flags "N versions behind").
+- A big upstream release landed and you want a rigorous pass, not just the per-push reconciler.
+- `verified-against` anchors across the site are stale and need re-verification + bumping.
+
+For triaging *open automated PRs* instead, use `/triage-docs-prs`. For a single-page fix, just edit it.
+
+## Before you start
+
+Read this repo's `CLAUDE.md` — the **NanoClaw Architecture Context**, **Drift Detection**, **Sidebar Tags**, and **PR Workflow** sections are the source of truth and list the confirmed upstream-doc traps. **Code is the only source of truth** — verify every claim against `src/`, `container/`, `setup/`, `.claude/skills/`, never against upstream markdown prose. Shell is zsh and macOS (see CLAUDE.md gotchas: `grep -oE` not `-oP`; unquoted `$var` doesn't word-split; git flags before the `<rev>..<rev>` range).
+
+Upstream checkout lives at the path in CLAUDE.md's "Upstream PRs" section; `upstream` remote = `nanocoai/nanoclaw`.
+
+## Workflow
+
+### Phase 1 — Scope the gap
+
+```bash
+UP=<upstream-checkout>          # from CLAUDE.md
+git -C "$UP" fetch upstream --quiet
+git -C "$UP" log upstream/main -1 --format='%h %ci %s'
+git -C "$UP" show upstream/main:package.json | grep '"version"'   # current version
+git -C "$UP" show upstream/main:repo-tokens/badge.svg | grep -oE '[0-9]+k' | head -1   # token count (only valid source)
+
+# Docs anchors in play (most pages share one or two SHAs)
+grep -rhoE 'verified-against:.*@ [0-9a-f]{7,}' --include='*.mdx' . | grep -oE '[0-9a-f]{7,}' | sort | uniq -c | sort -rn
+
+# Delta size
+git -C "$UP" rev-list --count <docs-anchor>..upstream/main
+```
+
+Registry branches can be **force-pushed** — fetch into explicit refs and diff with three dots:
+
+```bash
+git -C "$UP" fetch upstream 'refs/heads/channels:refs/remotes/upstream/channels' 'refs/heads/providers:refs/remotes/upstream/providers' --quiet
+git -C "$UP" merge-base --is-ancestor <providers-anchor> upstream/providers && echo "fast-forward" || echo "force-pushed → use 3-dot"
+git -C "$UP" diff <providers-anchor>...upstream/providers --name-only   # 3-dot is force-push-safe
+```
+
+### Phase 2 — Classify every page (clean vs dirty)
+
+For each page, intersect its `verified-against` cited files with the changed-file set (`git diff <anchor>..upstream/main --name-only`, plus the registry-branch diffs).
+
+- **Clean** — no cited file changed → safe to bump the SHA, no content work.
+- **Dirty** — at least one cited file changed → needs verification.
+
+Do NOT trust a quick regex intersection: citations use brace globs with internal commas (`{a,b,c}.ts`) that naive comma-splitting mangles, silently under-reporting drift. Use the parallel verification in Phase 3 as the authority.
+
+### Phase 3 — Verify in parallel (read-only subagents)
+
+Fan out one read-only subagent per page-area (channels / concepts / operate / guides+extend / get-started+reference). Each agent, for its pages:
+
+1. Extracts cited files (expanding brace globs; noting which branch each is on).
+2. Diffs each cited file across the correct branch's `<anchor>..<head>` (trunk: `e3986eb..upstream/main`; channels: `8137440..upstream/channels`; providers: 3-dot).
+3. Reads the diff of every changed cited file and judges whether the page's specific claims still hold.
+4. Returns a per-page verdict: **CLEAN** (no cited file changed) | **BUMP-OK** (changed but claims accurate) | **NEEDS-EDIT** (a claim is now wrong/stale, OR a notable new behavior is missing where the page would mention it) — with the exact stale quote, the correct fact, and source evidence.
+
+Dispatch all area-agents in one message so they run concurrently. You keep the verdicts and apply all edits/bumps yourself (no agent edits) to avoid conflicts.
+
+### Phase 4 — Plan stacked PRs
+
+Group findings by concern, one concern per PR (CLAUDE.md PR Workflow). Typical tiers:
+
+- **Tier 1 — new features** (need content, not just a SHA): one PR per feature, touching its natural page set.
+- **Tier 2 — re-verify + bump**: pages whose cited files changed via churn but whose claims still hold → SHA bump only.
+- **Cosmetic**: token badge, tag hygiene.
+
+Reconstruct the product changelog by mapping features to versions via the bump commits (upstream `CHANGELOG.md` parks everything under `[Unreleased]`):
+
+```bash
+git -C "$UP" log --reverse --format='%H %ci %s' <anchor>..upstream/main -- package.json | grep -i 'bump version'
+# then per consecutive bump range (flags BEFORE the range):
+git -C "$UP" log --format='%s' <bumpA>..<bumpB> | grep -iE '^(feat|fix)' | grep -viE 'lint|typo|chore|test:'
+```
+
+### Phase 5 — Execute (with user approval)
+
+Per PR, in order:
+
+1. Branch off `main`. Edit pages; **bump a page's `verified-against` SHA only where you actually re-verified its cited files** — a narrow prose fix can leave the old SHA for a later full pass.
+2. `mint validate` and (if links/anchors changed) `mint broken-links` — both from the `docs.json` dir.
+3. `gh pr create` + apply labels/metadata; `gh pr merge --squash` once the Mintlify Deployment check is green.
+4. **Verify live in a browser** (Playwright) — the docs edge 404s to `curl`. Deploy lags ~1–2 min after merge; wait before checking.
+5. `git checkout main && git pull --rebase origin main` before the next PR (post-merge deploy-bot push race).
+
+Finish the sweep with: product + docs-updates changelogs, the token badge if it moved, and **tag hygiene** — keep `UPDATED` only on pages with real new content (cap ~10; strip stale `NEW` and SHA-only badges, per CLAUDE.md Sidebar Tags).
+
+## Common mistakes
+
+- Bumping a SHA on a page you didn't actually re-verify (the anchor then lies).
+- Plain `git diff anchor..branch` on a force-pushed registry branch (misses dropped commits — use `...`).
+- Trusting a regex clean/dirty split over the subagent verdicts (brace-comma citations break it).
+- Citing a token count from memory or a PR instead of `repo-tokens/badge.svg`.
+- `curl`-checking a live page (always 404) instead of a browser; checking before the deploy propagates.
+- Cramming unrelated fixes into one PR, or letting a sweep leave dozens of sidebar badges.
+
+## Output format
+
+A short scope line (versions behind, commit delta, anchors), the per-page verdict map (clean / bump-ok / needs-edit), and the stacked-PR plan with each PR's page set and concern. Then execute on approval, reporting each PR merged + verified live.

--- a/.mintlify/workflows/sync-upstream-changes.md
+++ b/.mintlify/workflows/sync-upstream-changes.md
@@ -63,6 +63,8 @@ When changes don't map cleanly through verified-against comments (e.g., brand-ne
 
 ### 5. Housekeeping
 
+- **Scale guard.** This workflow handles the per-push trickle. If the push reveals a large gap — the affected pages' cited SHAs are several releases behind, or many pages drifted at once — don't attempt a single-pass rewrite of everything; update what's clearly in this push, then flag in the PR that a full re-verification is due via the `/drift-sweep` skill.
+- When diffing a registry branch (`channels`, `providers`) that may have been force-pushed, use a three-dot diff (`git diff <anchor>...upstream/<branch>`) so dropped commits aren't missed.
 - If a change doesn't affect documentation, skip it.
 - Keep documentation concise. Match the existing style of each page.
 - For every page where you make a **content change** (corrected facts, new sections, changed behavior), add or keep `tag: "UPDATED"` in the frontmatter. Do NOT add the tag for cosmetic-only changes (formatting, component swaps, whitespace, or a SHA-only bump of the verified-against comment). If the page already has a different tag (e.g., `NEW`), replace it with `UPDATED`. If your only change to a page is a SHA-only `verified-against` bump, leave its existing tag exactly as-is — do not add, refresh, or remove it; the weekly audit ages tags out by content date and enforces the badge cap. Example:

--- a/.mintlify/workflows/weekly-docs-audit.md
+++ b/.mintlify/workflows/weekly-docs-audit.md
@@ -27,6 +27,8 @@ Every page carries `{/* verified-against: <files> @ <sha> */}` after the frontma
 
 Pages whose cited files did not change are fine even if their SHA is old.
 
+If many pages are stale at once, or the docs anchor is several releases behind upstream `package.json` (compare the dominant `verified-against` SHA's version against `nanocoai/nanoclaw` HEAD), don't try to reconcile everything in this audit — flag in the report that a full re-verification is due and recommend an operator run the **`/drift-sweep`** skill, which classifies every page and ships the fixes as stacked PRs.
+
 ### 3. Check for stale code references
 
 Compare code snippets and function references in the docs against the actual upstream source code in the `nanocoai/nanoclaw` context repo. Flag any that no longer match, specifically:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,9 +30,11 @@ Deployment is automatic after merge to `main` (via Mintlify GitHub app).
 
 **macOS gotcha**: `grep -oP` (Perl regex) is not available on macOS. Use `grep -oE` with POSIX extended regex instead (e.g., `grep -oE '[0-9.]+k'`).
 
+**Shell is zsh**: unquoted `$var` does NOT word-split (`set -- $r` leaves later positionals empty — use `${=var}` or list args explicitly), and `git log`/`git diff` flags must come *before* the `<rev>..<rev>` range or git misreads it as a path.
+
 ## NanoClaw Architecture Context
 
-The site was fully rewritten for v2 (PRs #296–#303), verified against `nanocoai/nanoclaw@dc34ceb` (v2.1.4). Keep these facts current when editing:
+The site was fully rewritten for v2 (PRs #296–#303) and fully re-verified to `nanocoai/nanoclaw@2afbd182` (v2.1.21); channel pages at `channels@fdbfb6a`. Keep these facts current when editing:
 
 - **Upstream:** https://github.com/nanocoai/nanoclaw (org moved from `qwibitai`; old URLs redirect).
 - **Code is the ONLY source of truth.** Upstream `docs/`, README.md, CLAUDE.md, and even SKILL.md prose all drift from reality. Verify every claim against `src/`, `container/`, `setup/`, `.claude/skills/` (treat SKILL.md as the executable spec for a skill's BEHAVIOR, but never as a source of facts about core code), and the shell scripts. Every docs page carries a `{/* verified-against: <files> @ <sha> */}` comment — update it whenever you re-verify a page.
@@ -55,6 +57,10 @@ git -C <upstream-checkout> diff <page-sha>..HEAD --name-only
 ```
 
 Compare the output against the paths cited in each page's `verified-against` comment; re-verify and bump the SHA only on pages whose cited files actually changed.
+
+- Registry branches (`channels`, `providers`) can be force-pushed — diff with three dots (`git diff <anchor>...upstream/<branch>`) and fetch into an explicit ref (`git fetch upstream <branch>:refs/remotes/upstream/<branch>`), since a plain fetch may not move the tracking ref.
+- Bump a page's SHA only when you actually re-verified its cited files at that SHA. A narrow prose fix can leave the old SHA for the next full sweep — bumping it falsely claims re-verification.
+- For a multi-version sweep, fan out read-only subagents (one per page-area) that diff each page's cited files and return keep/fix verdicts. A naive regex intersection mis-parses brace-comma citations (`{a,b,c}`) and silently under-reports drift.
 
 ## PR Workflow
 
@@ -137,10 +143,10 @@ keywords: ["relevant", "search", "terms"]
 
 ## Sidebar Tags
 
-Mintlify workflows in `.mintlify/workflows/` auto-manage `tag` frontmatter:
+Mintlify workflows in `.mintlify/workflows/` auto-manage `tag` frontmatter (`.mintlify/` is gitignored but these files are tracked — new ones need `git add -f`):
 - `tag: "UPDATED"` — applied by sync workflow for content changes (not cosmetic)
 - `tag: "NEW"` — applied by skill-docs workflow for new pages
-- Tags are cleaned up after 2 weeks by the weekly audit workflow
+- The weekly audit expires `UPDATED` off the last *content* commit (SHA-only `verified-against` bumps and tag edits don't count) and caps it at ~10 pages; `NEW` only for pages under 2 weeks old. Don't let a large sweep leave dozens of badges.
 - Do NOT add tags for cosmetic-only changes (formatting, component swaps)
 
 ## Automated PR Triage
@@ -184,7 +190,7 @@ To PR changes to `nanocoai/nanoclaw` from Ethan's fork (`glifocat/nanoclaw-glifo
 
 ## Token Count
 
-Source of truth: `repo-tokens/badge.svg` in upstream (auto-generated) — the ONLY valid source. Never cite a number from prose, memory, or an automated PR; read the badge first. Last seen: 195k (~98% of the context window) at e3986eb (v2.1.16). Update pages that cite the count (e.g., `introduction.mdx`) if the badge value changes significantly.
+Source of truth: `repo-tokens/badge.svg` in upstream (auto-generated) — the ONLY valid source. Never cite a number from prose, memory, or an automated PR; read the badge first. Last seen: 199k at 2afbd182 (v2.1.21). Update pages that cite the count (e.g., `introduction.mdx`) if the badge value changes significantly.
 
 ## Writing Standards
 


### PR DESCRIPTION
Makes this session's drift-sweep methodology repeatable, and wires it into the existing automation so big gaps get caught and handed off.

## What this adds
- **`.claude/skills/drift-sweep/SKILL.md`** (new operator skill, sibling to `/triage-docs-prs`) — the thorough, on-demand sweep: scope the gap → classify every page clean/dirty → verify in parallel with read-only subagents → plan stacked PRs → reconstruct the changelog from version-bump commits → execute with live verification → bump `verified-against` SHAs only where actually re-verified.
- **`sync-upstream-changes`** (auto, per-push) — a **scale guard**: hand large multi-version gaps to `/drift-sweep` rather than attempting a single-pass rewrite; use 3-dot diffs for force-pushed registry branches.
- **`weekly-docs-audit`** (cron) — flags when the docs anchor is several releases behind and recommends running `/drift-sweep`.
- **`CLAUDE.md`** — the `/revise-claude-md` learnings (v2.1.21 anchor, 199k token count, zsh/git-arg, force-push/3-dot, SHA-bump honesty, parallel-subagent verification, tag cap).

## Why both
The auto `sync-upstream-changes` workflow already fires on every upstream commit — good for the trickle. The skill is the rigorous catch-up for when the docs fall behind (as they had, by 5 versions). The audit + scale guard connect them: automation flags the gap, the operator runs the skill.

`mint validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)