### PR TITLE
docs(security): document the inbox symlink-containment guard

### DIFF
--- a/concepts/security.mdx
+++ b/concepts/security.mdx
@@ -5,7 +5,7 @@ tag: "UPDATED"
 keywords: ["security", "threat model", "prompt injection", "container isolation", "egress lockdown", "mount allowlist", "approvals", "credentials", "defense in depth"]
 ---
 
-{/* verified-against: src/container-runner.ts, src/egress-lockdown.ts, src/modules/mount-security/index.ts, src/command-gate.ts, src/modules/permissions/{index.ts,access.ts,channel-approval.ts,sender-approval.ts}, src/modules/approvals/{index.ts,primitive.ts,onecli-approvals.ts,reason-capture.ts,finalize.ts,response-handler.ts}, src/modules/agent-to-agent/{message-gate.ts,db/agent-message-policies.ts}, src/modules/self-mod/index.ts, container/Dockerfile, pnpm-workspace.yaml, docs/SECURITY.md @ 2afbd182 (v2.1.21) */}
+{/* verified-against: src/container-runner.ts, src/egress-lockdown.ts, src/inbox-safety.ts, src/session-manager.ts, src/modules/mount-security/index.ts, src/command-gate.ts, src/modules/permissions/{index.ts,access.ts,channel-approval.ts,sender-approval.ts}, src/modules/approvals/{index.ts,primitive.ts,onecli-approvals.ts,reason-capture.ts,finalize.ts,response-handler.ts}, src/modules/agent-to-agent/{message-gate.ts,agent-route.ts,db/agent-message-policies.ts}, src/modules/self-mod/index.ts, container/Dockerfile, pnpm-workspace.yaml, docs/SECURITY.md @ cb6e3d1 (v2.1.23) */}
 
 NanoClaw connects an AI agent with real tools — a shell, a filesystem, network access — to chat platforms where anyone can type. Every inbound message is untrusted input fed straight into the model's context, and no model reliably distinguishes "instructions from my operator" from "instructions an attacker pasted into the group chat." So the design assumption is blunt: **prompt injection eventually succeeds, and the agent acts as if the attacker wrote its instructions.**
 
@@ -26,6 +26,8 @@ flowchart TD
 A compromised agent is a compromised *container*, and every active session gets its own. The container runs as the unprivileged `node` user (or your host uid/gid), with no added Linux capabilities, and `--rm` so nothing persists past exit. Its filesystem view is exactly the [mount table](/concepts/container-lifecycle#spawn--the-world-rebuilt-every-time): the session folder, the group workspace, and read-only shared code. No host home directory, no `.ssh`, no Docker socket. Its own `container.json` and composed `CLAUDE.md` are re-mounted read-only on top of the writable workspace, so the agent can read its configuration but not rewrite it to grant itself more.
 
 The container is also disposable by design — the host kills it on a stale heartbeat and rebuilds the entire environment at next spawn, so a compromised process doesn't outlive its session. See [Container lifecycle](/concepts/container-lifecycle).
+
+Files flow *into* the container too — channel attachments and files forwarded from other agents are written by the **host** into the session's writable `inbox/`. That's a classic symlink trap: a compromised agent could replace its inbox with a symlink and redirect the host's write anywhere the host can reach. The shared inbox guard (`src/inbox-safety.ts`) closes it — before any write, the host verifies the inbox root and the per-message directory are real directories (not symlinks), resolves the final path, and refuses anything that lands outside the session folder; the writes themselves use exclusive-create flags so a pre-placed symlinked *file* can't be followed either.
 
 ## No raw credentials in containers
 


### PR DESCRIPTION
## What

Adds a paragraph to **Security model → Container isolation** documenting the shared inbox symlink-containment guard, newly modularized upstream as `src/inbox-safety.ts` in v2.1.22.

## Why

Upstream PR nanocoai/nanoclaw#2880 (commits `dd1d0e5`, `36afa40`) contained channel-inbound attachments and agent-to-agent forwarded files via a shared guard: lstat of the inbox root **and** the per-message subdir (reject symlinks), realpath containment check, and exclusive-create write flags (`wx` / `COPYFILE_EXCL`). The security page already documents the sibling symlink defense in the mount allowlist, but this host-write vector (CWE-59) was uncovered.

## Verification

- Read `src/inbox-safety.ts` in full at `origin/main` and both call-site diffs over `2afbd182..cb6e3d1`
- All other page claims re-verified at `cb6e3d1` (v2.1.23); `verified-against` bumped with `src/inbox-safety.ts`, `src/session-manager.ts`, and `agent-route.ts` added to citations
- `mint validate` passes

Part of the v2.1.21→v2.1.23 drift sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)