### PR TITLE
docs(ncl): add --instance flag to the messaging-groups reference

### DIFF
--- a/reference/ncl-cli.mdx
+++ b/reference/ncl-cli.mdx
@@ -5,7 +5,7 @@ tag: "UPDATED"
 keywords: ["ncl", "cli", "reference", "commands", "flags", "groups", "wirings", "sessions", "roles", "members", "destinations", "approvals", "cli_scope"]
 ---
 
-{/* verified-against: src/cli/dispatch.ts, src/cli/crud.ts, src/cli/client.ts, src/cli/format.ts, src/cli/transport-errors.ts, src/cli/registry.ts, src/cli/frame.ts, src/cli/commands/help.ts, src/cli/resources/{approvals,destinations,dropped-messages,groups,members,messaging-groups,policies,roles,sessions,user-dms,users,wirings}.ts, bin/ncl @ 2afbd182 (v2.1.21) */}
+{/* verified-against: src/cli/dispatch.ts, src/cli/crud.ts, src/cli/client.ts, src/cli/format.ts, src/cli/transport-errors.ts, src/cli/registry.ts, src/cli/frame.ts, src/cli/commands/help.ts, src/cli/resources/{approvals,destinations,dropped-messages,groups,members,messaging-groups,policies,roles,sessions,user-dms,users,wirings}.ts, bin/ncl @ cb6e3d1 (v2.1.23) */}
 
 Exhaustive reference for the `ncl` admin CLI. For a task-oriented walkthrough, see [The ncl admin CLI](/operate/ncl-cli).
 
@@ -119,6 +119,7 @@ One chat or channel on one platform. Identity is the unique `(channel_type, plat
 | --- | --- | --- |
 | `--channel-type` | string | Required on create. Adapter type registered by `/add-<channel>` (e.g. `telegram`, `discord`, `slack`, `whatsapp`). |
 | `--platform-id` | string | Required on create. Platform chat ID (Telegram chat ID, Discord snowflake, Slack channel ID, phone number, email address). |
+| `--instance` | string | Updatable. Adapter instance that owns the chat when running N adapters of one channel type. Defaults to the `--channel-type` value when omitted. |
 | `--name` | string | Updatable. Display name, often auto-populated by the adapter. |
 | `--is-group` | number | Updatable, default `0`. `1` = multi-user group chat, `0` = DM. Affects session scoping. |
 | `--unknown-sender-policy` | enum | Updatable, default `strict`. `strict` drops silently; `request_approval` sends an approval card to an admin; `public` allows anyone. |


### PR DESCRIPTION
## What

Adds the `--instance` flag row to the messaging-groups flag table in the exhaustive `ncl` CLI reference.

## Why

Upstream PR nanocoai/nanoclaw#2882 (commit `0d841bc`, shipped in v2.1.22) added an `instance` column (string, updatable, `defaultFrom: 'channel_type'`) — the flag exists on `create`/`update` and defaults to the `--channel-type` value when omitted. The page bills itself as "every resource, verb, flag, enum, and default", so this was a NEEDS-EDIT in the drift sweep.

`operate/ncl-cli.mdx` (representative commands, non-exhaustive) and `guides/first-agent.mdx` were verified unaffected — their examples remain valid; they get SHA bumps in the sweep PR.

## Verification

- Diffed `src/cli/crud.ts` + `src/cli/resources/messaging-groups.ts` over `2afbd182..cb6e3d1`; row text matches the column definition
- All other page claims re-verified at `cb6e3d1`; anchor bumped
- `mint validate` passes

Part of the v2.1.21→v2.1.23 drift sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)