### PR TITLE
docs(tooling): providers-branch coverage + census-derived sweep anchors

### DIFF
--- a/.claude/skills/drift-sweep/SKILL.md
+++ b/.claude/skills/drift-sweep/SKILL.md
@@ -61,7 +61,7 @@ Do NOT trust a quick regex intersection: citations use brace globs with internal
 Fan out one read-only subagent per page-area (channels / concepts / operate / guides+extend / get-started+reference). Each agent, for its pages:
 
 1. Extracts cited files (expanding brace globs; noting which branch each is on).
-2. Diffs each cited file across the correct branch's `<anchor>..<head>` (trunk: `e3986eb..upstream/main`; channels: `8137440..upstream/channels`; providers: 3-dot).
+2. Diffs each cited file across the correct branch's `<anchor>..<head>` (trunk: `<trunk-anchor>..upstream/main`; channels: `<channels-anchor>..upstream/channels` if fast-forward, 3-dot otherwise; providers: 3-dot). The anchors come from the Phase 1 census of the pages' own `verified-against` comments — never reuse a SHA from a previous sweep, an example, or memory; a hardcoded anchor goes stale the moment a sweep merges.
 3. Reads the diff of every changed cited file and judges whether the page's specific claims still hold.
 4. Returns a per-page verdict: **CLEAN** (no cited file changed) | **BUMP-OK** (changed but claims accurate) | **NEEDS-EDIT** (a claim is now wrong/stale, OR a notable new behavior is missing where the page would mention it) — with the exact stale quote, the correct fact, and source evidence.
 
@@ -103,6 +103,7 @@ Finish the sweep with: product + docs-updates changelogs, the token badge if it 
 - Citing a token count from memory or a PR instead of `repo-tokens/badge.svg`.
 - `curl`-checking a live page (always 404) instead of a browser; checking before the deploy propagates.
 - Cramming unrelated fixes into one PR, or letting a sweep leave dozens of sidebar badges.
+- Diffing from an anchor that didn't come from the Phase 1 census — a SHA remembered from a previous sweep (or copied from an old example) silently under-scopes the whole classification.
 
 ## Output format
 

--- a/.mintlify/workflows/new-skill-docs.md
+++ b/.mintlify/workflows/new-skill-docs.md
@@ -1,15 +1,17 @@
 ---
-name: Document new skills and channel adapters
+name: Document new skills, channel adapters, and providers
 on:
   push:
     - repo: nanocoai/nanoclaw
       branch: channels
+    - repo: nanocoai/nanoclaw
+      branch: providers
 context:
   - repo: nanocoai/nanoclaw
 automerge: false
 ---
 
-A push was made to the `channels` registry branch on the upstream NanoClaw repository. New or updated channel adapters land there; new skills land in `.claude/skills/` on `main` (those are caught by the sync workflow, which routes here for documentation rules). Review what changed and create or update the documentation.
+A push was made to a registry branch (`channels` or `providers`) on the upstream NanoClaw repository. New or updated channel adapters land on `channels`; provider adapters (Codex, OpenCode, Ollama, …) land on `providers`; new skills land in `.claude/skills/` on `main` (those are caught by the sync workflow, which routes here for documentation rules). Review what changed and create or update the documentation.
 
 Read this repo's `CLAUDE.md` (NanoClaw Architecture Context section) first — it is the source of truth for the v2 model and lists confirmed upstream-doc traps. Key points: skills are SKILL.md workflows, NOT git branches; channel adapters are installed by `/add-<channel>` skills that fetch-and-copy files from the `channels` registry branch, never `git merge`; treat a skill's SKILL.md as the executable spec for its BEHAVIOR, but never as a source of facts about core code — verify claims against `src/`, `setup/*.sh`, and `container/`.
 
@@ -18,6 +20,7 @@ Read this repo's `CLAUDE.md` (NanoClaw Architecture Context section) first — i
 ### 1. Identify what changed
 
 - New or modified adapter directories on the `channels` registry branch (e.g., `src/channels/<adapter>/`)
+- New or modified provider files on the `providers` registry branch (e.g., `container/agent-runner/src/providers/<provider>.ts`, `setup/providers/<provider>.ts`)
 - New or modified `.claude/skills/<name>/SKILL.md` workflows (channel installers, tool installers, provider installers, operational skills)
 - New `setup/add-*.sh` wizards
 - Container skills in `container/skills/`

--- a/.mintlify/workflows/weekly-docs-audit.md
+++ b/.mintlify/workflows/weekly-docs-audit.md
@@ -41,7 +41,7 @@ Compare code snippets and function references in the docs against the actual ups
 
 ### 4. Check for missing documentation
 
-Review recent upstream changes (last 7 days of commits on `nanocoai/nanoclaw` `main`, plus the `channels` registry branch for new adapters) and identify any new features, configuration options, skills, or behavioral changes that aren't documented yet. Route new-skill docs per the table in the new-skill-docs workflow (channel skills → `channels/` + `reference/skills-catalog.mdx`; tool skills → `extend/tools.mdx` + catalog; provider skills → `extend/providers.mdx` + catalog; operational skills → catalog + relevant `operate/` page).
+Review recent upstream changes (last 7 days of commits on `nanocoai/nanoclaw` `main`, plus the `channels` registry branch for new adapters and the `providers` registry branch for new or updated provider adapters) and identify any new features, configuration options, skills, or behavioral changes that aren't documented yet. Route new-skill docs per the table in the new-skill-docs workflow (channel skills → `channels/` + `reference/skills-catalog.mdx`; tool skills → `extend/tools.mdx` + catalog; provider skills → `extend/providers.mdx` + catalog; operational skills → catalog + relevant `operate/` page).
 
 ### 5. Check frontmatter quality
 


### PR DESCRIPTION
Two fixes from the drift-tooling review that followed the v2.1.23 sweep (#333–#336):

## 1. The `providers` registry branch was invisible to all automation

- `new-skill-docs` triggered only on `channels` pushes
- `sync-upstream-changes` triggers only on `main`
- the weekly audit's missing-docs step reviewed "main + the channels registry branch" only

Provider adapters (Codex, OpenCode, Ollama, …) land on `origin/providers` — a push there fired nothing and was audited by nothing, so provider docs drifted until an operator happened to run `/drift-sweep` (which *does* handle providers). Fixed by adding `providers` to `new-skill-docs`'s `on.push` (+ prose/routing) and to audit step 4.

## 2. `/drift-sweep` hardcoded anchor SHAs that go stale every sweep

Phase 3 read "trunk: `e3986eb..upstream/main`; channels: `8137440..upstream/channels`" — the anchors current when the skill was written. One sweep later the live census was `2afbd182`/`fdbfb6a`, and after this week's sweep it's `cb6e3d1`/`90dd87d`: any agent following the text literally diffs from the wrong baseline and silently under-scopes the classification. Replaced with placeholders explicitly derived from the Phase 1 census grep, plus a Common-mistakes entry for the failure mode.

## Verification

- `mint validate` passes
- No hardcoded SHAs remain in the skill (`grep -E '[0-9a-f]{7,8}'` clean)
- `.mintlify/` files are gitignored-but-tracked (per CLAUDE.md) — modified in place, no `add -f` needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)