### PR TITLE
docs(get-started): second beginner pass — what-can-it-do + things-to-try

### DIFF
--- a/changelog/docs-updates.mdx
+++ b/changelog/docs-updates.mdx
@@ -5,6 +5,14 @@ icon: "file-pen"
 rss: true
 ---
 
+<Update label="Get started, second pass" description="2026-07-02" tags={["Updated"]}>
+  Follow-up to the 2026-06-29 rework, aimed at the remaining beginner friction:
+
+  - `introduction` — plain-language page description (was architecture jargon); new **"What can it do?"** section with six concrete, code-verified capabilities; the message-flow diagram and design rationale compressed into a short "Under the hood, briefly" paragraph linking to `concepts/architecture` (which covers it in depth) — the intro no longer duplicates it
+  - `quickstart` — new **"Things to try first"** section: six copy-paste messages exercising web research, reminders, sandboxed code, inbound attachments, persistent memory, and companion agents, each verified against source (web tools are on the Claude provider's allowlist; `schedule_task` routes back to the originating chat; attachments land in the session inbox; `CLAUDE.local.md` persists per group; the wizard's first agent has `global` CLI scope so `create_agent` needs no approval card). Includes the CLI-channel gotcha: reminders that fire while the terminal is disconnected are saved, not pushed live
+  - Placeholder (comment) for a hero chat screenshot on `introduction`, pending a capture from a live install
+</Update>
+
 <Update label="v2.1.23 drift sweep" description="2026-07-02" tags={["Updated"]}>
   Brought the site current with `nanocoai/nanoclaw@cb6e3d1` (v2.1.23) and `channels@90dd87d` — a 14-commit trunk delta plus two channels-branch merges since the v2.1.21 sweep.
 

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -1,16 +1,23 @@
 ---
 title: "What is NanoClaw?"
-description: "A multi-agent AI assistant. One host process, one Docker container per session, and a SQLite queue that carries every message in the system."
+description: "A personal AI assistant you run on your own machine and text from Telegram, WhatsApp, Discord, Slack, or the terminal — every agent working inside its own sandbox."
 icon: "house"
 sidebarTitle: "Introduction"
-keywords: ["nanoclaw", "multi-agent", "claude", "container isolation", "inbox outbox", "sqlite", "channels", "skills", "v2"]
+tag: "UPDATED"
+keywords: ["nanoclaw", "personal ai assistant", "self-hosted", "multi-agent", "claude", "container isolation", "channels", "skills", "v2"]
 ---
 
-{/* verified-against: src/index.ts, src/router.ts, src/channels/index.ts, src/container-runtime.ts, src/container-runner.ts, src/db/schema.ts, src/modules/, container/agent-runner/src/mcp-tools/agents.ts, agents.instructions.md, core.ts, .claude/skills/, .claude/skills/add-telegram/SKILL.md, repo-tokens/badge.svg, package.json @ cb6e3d1 (v2.1.23) */}
+{/* verified-against: src/index.ts, src/router.ts, src/channels/index.ts, src/container-runtime.ts, src/container-runner.ts, src/session-manager.ts, src/claude-md-compose.ts, src/modules/, container/agent-runner/src/providers/claude.ts, container/agent-runner/src/mcp-tools/{agents,scheduling}.ts, agents.instructions.md, .claude/skills/, .claude/skills/add-telegram/SKILL.md, repo-tokens/badge.svg, package.json @ cb6e3d1 (v2.1.23) */}
 
 NanoClaw is a personal AI assistant you run on your own machine and reach from the messaging apps you already use — Telegram, WhatsApp, Discord, Slack, or just your terminal. Text it like you'd text a coworker: it can search the web, run code, edit files, and follow up on a schedule. Each agent works inside its own locked-down sandbox, so it does real work without touching the rest of your computer.
 
 It's self-hosted and yours — clone the repo, run one setup command, connect a chat app. Claude powers agents by default, with Codex, OpenCode, and Ollama as alternatives.
+
+{/* TODO(ethan): hero screenshot — a phone chat (Telegram or WhatsApp) showing a short real exchange:
+   you ask the agent for something concrete (e.g. "remind me every Friday to send the invoice"), it confirms.
+   Capture from your live install, save to images/hero-chat.png, then embed here:
+   <img src="/images/hero-chat.png" alt="A Telegram chat where the user asks their NanoClaw agent to schedule a weekly reminder and the agent confirms it" />
+*/}
 
 <Info>
   **New here? Four words that show up everywhere:**
@@ -19,6 +26,19 @@ It's self-hosted and yours — clone the repo, run one setup command, connect a 
   - **Sandbox** — the isolated Docker container an agent runs in; it only sees what you explicitly share.
   - **Provider** — the AI model behind an agent (Claude by default; Codex, OpenCode, or Ollama optional).
 </Info>
+
+## What can it do?
+
+Everything below works on a fresh install, from a plain chat message — no configuration first:
+
+- **Research** — agents can search the web and fetch pages out of the box. *"What changed in the new EU battery regulation?"*
+- **Reminders and recurring work** — *"remind me in 20 minutes"* or *"every weekday at 9, summarize my repo's new issues"*. Scheduled tasks fire back into the same chat and survive restarts.
+- **Real code and files** — the agent writes and runs code inside its sandbox, and its working files persist between conversations.
+- **Read what you send** — share a file or photo over a chat app and ask about it; attachments land in the sandbox for the agent to open.
+- **Remember you** — ask it to remember your name, your preferences, your projects. Each agent keeps its own persistent memory.
+- **Grow into a team** — your agent can spawn companion agents, each with its own sandbox and memory, and delegate work to them. See the [multi-agent swarm guide](/guides/multi-agent-swarm).
+
+The [quickstart](/quickstart#things-to-try-first) ends with copy-paste messages that exercise each of these.
 
 <CardGroup cols={2}>
   <Card title="Run it" icon="rocket" href="/quickstart">
@@ -35,35 +55,11 @@ It's self-hosted and yours — clone the repo, run one setup command, connect a 
   </Card>
 </CardGroup>
 
-## How a message flows
+## Under the hood, briefly
 
-One idea drives the whole system: every message is a row in a SQLite queue. A user chat, an inbound webhook, a scheduled job, an agent delegating to another agent — all of them land in an inbox table (`messages_in`), and every response leaves through an outbox (`messages_out`). A scheduled task is just a message with a `process_after` timestamp. There's no separate scheduler, RPC layer, or job system to learn.
+One idea drives the whole system: every message — a chat, a webhook, a scheduled job, one agent delegating to another — is a row in a SQLite queue, and every reply leaves through another one. There's no separate scheduler, RPC layer, or job system to learn. Agents run in Docker containers that see only what you explicitly mount; Bash and file edits execute inside the container, never on your host. Channels aren't bundled features — a skill like `/add-telegram` copies exactly the adapter you asked for into your install. And the whole codebase is ~204k tokens, small enough for a long-context coding agent to hold in context — which is also how you customize it: edit the code, not a config sprawl.
 
-Every channel — Telegram, Discord, a webhook, the built-in CLI — feeds the same pipeline:
-
-```mermaid
-flowchart LR
-    A[Channel adapter] --> B[Router]
-    B --> C[("Inbox<br/>messages_in")]
-    C --> D[Agent container]
-    D --> E[("Outbox<br/>messages_out")]
-    E --> F[Delivery poll]
-    F --> A
-```
-
-The router resolves who sent the message, which agent group should handle it, and which session it belongs to, then writes the row and wakes the container. The container processes its inbox and writes replies to its outbox; the host's delivery polls pick them up and hand them back to the channel adapter. Agent-to-agent messages follow the exact same path — an agent's `send_message` is a row addressed to another agent's inbox.
-
-## Why it's built this way
-
-**Container isolation.** Agents run in Docker containers and see only what you explicitly mount. Bash and file edits execute inside the container, never on your host. Each session gets its own container, so parallel conversations can't interfere with each other.
-
-**Small enough to hold in context.** The codebase is ~204k tokens — compact enough for a long-context agent to hold in context. That's also how you customize it: edit the code, not a config sprawl.
-
-**Channels are skills, not bundled features.** Main ships exactly one channel — the local CLI. Everything else lives on the `channels` branch and gets copied into your fork by a skill: `/add-telegram`, `/add-discord`, `/add-whatsapp`, `/add-slack`, `/add-signal`, `/add-imessage`, and several more. Your install contains the adapters you asked for and nothing else. The same mechanism covers alternative agent providers (`/add-codex`, `/add-opencode`, `/add-ollama-provider`).
-
-## Agents that work together
-
-An agent can spawn long-lived companion agents with `create_agent` — each with its own container, workspace, and persistent memory — and delegate to them over the same message queue. That's enough to build real teams: a worker per task, a manager that tracks what's in flight, a supervisor that pings you for approval. See the [multi-agent swarm guide](/guides/multi-agent-swarm).
+The full picture — routing, sessions, the container lifecycle — lives in [Architecture](/concepts/architecture); the threat model in [Security](/concepts/security).
 
 ## Who this is for
 

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -9,7 +9,7 @@ keywords: ["nanoclaw", "personal ai assistant", "self-hosted", "multi-agent", "c
 
 {/* verified-against: src/index.ts, src/router.ts, src/channels/index.ts, src/container-runtime.ts, src/container-runner.ts, src/session-manager.ts, src/claude-md-compose.ts, src/modules/, container/agent-runner/src/providers/claude.ts, container/agent-runner/src/mcp-tools/{agents,scheduling}.ts, agents.instructions.md, .claude/skills/, .claude/skills/add-telegram/SKILL.md, repo-tokens/badge.svg, package.json @ cb6e3d1 (v2.1.23) */}
 
-NanoClaw is a personal AI assistant you run on your own machine and reach from the messaging apps you already use — Telegram, WhatsApp, Discord, Slack, or just your terminal. Text it like you'd text a coworker: it can search the web, run code, edit files, and follow up on a schedule. Each agent works inside its own locked-down sandbox, so it does real work without touching the rest of your computer.
+NanoClaw is a personal AI assistant you run on your own machine and reach from the messaging apps you already use — Telegram, WhatsApp, Discord, Slack, or just your terminal. Text it like you'd text a coworker. Each agent works inside its own locked-down sandbox, so it does real work without touching the rest of your computer.
 
 It's self-hosted and yours — clone the repo, run one setup command, connect a chat app. Claude powers agents by default, with Codex, OpenCode, and Ollama as alternatives.
 
@@ -57,15 +57,9 @@ The [quickstart](/quickstart#things-to-try-first) ends with copy-paste messages 
 
 ## Under the hood, briefly
 
-One idea drives the whole system: every message — a chat, a webhook, a scheduled job, one agent delegating to another — is a row in a SQLite queue, and every reply leaves through another one. There's no separate scheduler, RPC layer, or job system to learn. Agents run in Docker containers that see only what you explicitly mount; Bash and file edits execute inside the container, never on your host. Channels aren't bundled features — a skill like `/add-telegram` copies exactly the adapter you asked for into your install. And the whole codebase is ~204k tokens, small enough for a long-context coding agent to hold in context — which is also how you customize it: edit the code, not a config sprawl.
+One idea drives the whole system: every message — a chat, a webhook, a scheduled job, one agent delegating to another — is a row in a SQLite queue, and every reply leaves through another one. There's no separate scheduler, RPC layer, or job system to learn. Channels aren't bundled features — a skill like `/add-telegram` copies exactly the adapter you asked for into your install. And the whole codebase is ~204k tokens, small enough for a long-context coding agent to hold in context — which is also how you customize it: edit the code, not a config sprawl.
 
 The full picture — routing, sessions, the container lifecycle — lives in [Architecture](/concepts/architecture); the threat model in [Security](/concepts/security).
-
-## Who this is for
-
-- **Operators** — you want a personal AI assistant on your own machine, reachable from your messaging apps. Start with the [quickstart](/quickstart).
-- **Builders** — you want to extend it: new channels, tools, skills, or agent providers in your own fork. Start with [extending NanoClaw](/extend/overview).
-- **Evaluators and contributors** — you want to judge the design before trusting it. Start with the [architecture](/concepts/architecture) and the [security model](/concepts/security).
 
 ## Source and community
 

--- a/operate/upgrading.mdx
+++ b/operate/upgrading.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Upgrading"
 description: "Update NanoClaw and its skills with /update-nanoclaw and /update-skills — preview, backup, merge, validate, and restart."
-tag: "UPDATED"
 keywords: ["upgrade", "update", "update-nanoclaw", "update-skills", "migrate-nanoclaw", "upstream", "merge", "rollback"]
 ---
 

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -2,10 +2,11 @@
 title: Quick start
 description: Get NanoClaw running in one command with the scripted installer.
 icon: "bolt"
-keywords: ["setup", "install", "getting started", "nanoclaw.sh", "setup wizard", "first agent"]
+tag: "UPDATED"
+keywords: ["setup", "install", "getting started", "nanoclaw.sh", "setup wizard", "first agent", "things to try"]
 ---
 
-{/* verified-against: nanoclaw.sh, setup.sh, setup/auto.ts, setup/probe.sh, setup/install-node.sh, setup/channels/*.ts, setup/providers/registry.ts, scripts/init-first-agent.ts, .claude/skills/setup/SKILL.md, package.json @ cb6e3d1 (v2.1.23) */}
+{/* verified-against: nanoclaw.sh, setup.sh, setup/auto.ts, setup/probe.sh, setup/install-node.sh, setup/channels/*.ts, setup/providers/registry.ts, scripts/init-first-agent.ts, .claude/skills/setup/SKILL.md, package.json, container/agent-runner/src/providers/claude.ts, container/agent-runner/src/mcp-tools/{agents,scheduling}.ts, src/modules/agent-to-agent/create-agent.ts, src/session-manager.ts, src/claude-md-compose.ts, src/channels/cli.ts @ cb6e3d1 (v2.1.23) */}
 
 About 15 minutes from a fresh machine to an assistant you can message — one command, a handful of prompts, and one thing you bring yourself: a credential for your AI provider (a Claude or Codex subscription, or an API key). The script installs everything else.
 
@@ -68,6 +69,21 @@ Everything else — Homebrew on macOS, Node 22, pnpm, Docker, the OneCLI vault �
 You now have a host service (launchd or systemd) running NanoClaw from this checkout. It routes messages between your channels and agents, where each agent runs in its own Docker container sandbox that wakes on incoming messages and sleeps when idle. Your Anthropic credential lives in the OneCLI vault — never inside the container. Agent workspaces live under `groups/`, runtime state under `data/`, and logs under `logs/`. See [Architecture](/concepts/architecture) for the full picture.
 
 Claude is the default agent provider that the wizard connects you to. You can switch a group to Codex, OpenCode, or a local Ollama model afterward — see [Agent providers](/extend/providers).
+
+## Things to try first
+
+Send these to your new assistant as-is — each one exercises a different capability, and all of them work on a fresh install:
+
+1. **"What's the latest on `<a topic you follow>`?"** — agents search the web and fetch pages out of the box.
+2. **"Remind me in 10 minutes to stretch."** — the agent schedules a task that fires back into this same chat. Recurring works too: *"every weekday at 9, give me a weather summary."* See [Scheduled tasks](/guides/scheduled-tasks).
+3. **"Write a script that renames all my screenshots by date, and test it on some sample files."** — code runs inside the sandbox, and the agent's working files persist between conversations.
+4. **Send a file or photo with "what's this?"** — over a chat app, attachments land in the sandbox and the agent reads them from disk. (The terminal chat is text-only.)
+5. **"From now on call me `<name>`, and keep answers short."** — the agent can write its own persistent memory, so preferences survive restarts. See [Customize an agent](/guides/customize-an-agent).
+6. **"Create a helper agent named Scout that watches `<something>` and reports to me."** — your first agent can spawn companion agents, each with its own sandbox and memory. See [Multi-agent swarm](/guides/multi-agent-swarm).
+
+<Note>
+Testing reminders from the **terminal chat**? A reminder that fires after you've disconnected is saved but won't pop up live — the terminal only shows replies while connected. Connect a real channel (Telegram, WhatsApp, …) and reminders arrive as normal notifications.
+</Note>
 
 <Note>
 Coming from NanoClaw v1? Run `bash migrate-v2.sh` before setup — see the [migration guide](/migrate-from-v1).

--- a/reference/skills-catalog.mdx
+++ b/reference/skills-catalog.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Skills catalog"
 description: "Every skill that ships with NanoClaw — host-side workspace skills you invoke in Claude Code, and container skills mounted into every agent container."
-tag: "UPDATED"
 keywords: ["skills", "catalog", "reference", "add-channel", "providers", "tools", "container skills", "workspace skills", "slash commands"]
 ---
 


### PR DESCRIPTION
## Problem

The 06-29 rework fixed the lede, but three beginner blockers survived:

1. The intro's **description/subtitle was architecture jargon** ("…a SQLite queue that carries every message") — first thing a beginner reads.
2. **Half the intro was evaluator content** — the mermaid message-flow + "Why it's built this way" duplicate `concepts/architecture` and sit between the beginner and the quickstart. The router paragraph also used `agent group`/`session`, terms the Key-terms box deliberately excludes.
3. **The journey dead-ended at "say hi"** — nothing staged the aha moment, and the next-steps cards jump straight to channel setup and CLI references.

## Changes

**`introduction`**
- Plain-language description
- New **"What can it do?"** — six concrete capabilities, every one verified against source at `cb6e3d1` (see below)
- Message flow + design rationale compressed to **"Under the hood, briefly"** (links to Architecture/Security, which cover it properly; mermaid removed as duplicate)
- Hero-screenshot placeholder comment (needs a capture from a live install — @glifocat)

**`quickstart`**
- New **"Things to try first"**: six copy-paste messages — web research, reminders (one-shot + recurring), sandboxed code, inbound attachments, persistent memory, companion agents — plus a `<Note>` for the real gotcha: reminders tested over the terminal chat are saved but not pushed live after disconnect (`cli.ts deliver()` no-ops without a client)

**Housekeeping** — `UPDATED` on both pages, stripped from `operate/upgrading` + `reference/skills-catalog` to hold the ~10 cap; docs-updates changelog entry; citations extended with the files backing each new claim.

## Verification (all at `cb6e3d1`, read via `git show`)

| Claim | Source |
|---|---|
| Web search/fetch out of the box | `WebSearch`/`WebFetch` on `TOOL_ALLOWLIST` in `container/agent-runner/src/providers/claude.ts`; egress lockdown off by default (`src/egress-lockdown.ts`) |
| Reminders return to the same chat, survive restarts | `schedule_task` in `mcp-tools/scheduling.ts` carries `platform_id`/`channel_type`/`thread_id`; host `src/modules/scheduling/` |
| Code + persistent files | `Bash`/`Write`/`Edit` allowlisted; `/workspace/agent` mounted RW (`src/container-runner.ts`) |
| Attachments readable | `extractAttachmentFiles()` → session `inbox/`; formatter surfaces the path |
| Memory persists | `CLAUDE.local.md` RW + auto-loaded (`claude-md-compose.ts`, `settingSources: ['project','user','local']`) |
| First agent spawns companions without approval | `init-first-agent.ts` grants `cli_scope: 'global'`; `create-agent.ts` only gates `group`-scope callers |

- `mint validate` ✅ · `mint broken-links` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)