### PR TITLE
docs: fix env-var + mount drift vs code (v2.1.38 / 08a1ac9)

### DIFF
--- a/guides/multi-agent-swarm.mdx
+++ b/guides/multi-agent-swarm.mdx
@@ -5,7 +5,7 @@ tag: "UPDATED"
 keywords: ["multi-agent", "create_agent", "agent-to-agent", "agent destinations", "send_message", "sub-agents", "approval", "ncl destinations"]
 ---
 
-{/* verified-against: src/modules/agent-to-agent/{create-agent,agent-route,write-destinations,index,message-gate}.ts, src/modules/agent-to-agent/db/{agent-destinations,agent-message-policies}.ts, src/modules/approvals/primitive.ts, container/agent-runner/src/mcp-tools/agents.ts + agents.instructions.md, container/agent-runner/src/destinations.ts, src/cli/resources/{destinations,groups,policies,wirings}.ts, src/group-init.ts, src/db/messaging-groups.ts @ cb6e3d1 (v2.1.23) */}
+{/* verified-against: src/modules/agent-to-agent/{create-agent,agent-route,write-destinations,index,message-gate}.ts, src/modules/agent-to-agent/db/{agent-destinations,agent-message-policies}.ts, src/modules/approvals/primitive.ts, container/agent-runner/src/mcp-tools/agents.ts + agents.instructions.md, container/agent-runner/src/destinations.ts, src/cli/resources/{destinations,groups,policies,wirings}.ts, src/group-init.ts, src/db/messaging-groups.ts @ 08a1ac9 (v2.1.38) */}
 
 The [introduction](/introduction) promises real teams: a worker per task, a manager that tracks what's in flight, a supervisor that pings you. This tutorial builds the smallest working version — one agent spawning and delegating to another — then scales the same three primitives into that trio. It continues from [your first agent](/guides/first-agent); you'll reuse Scout to see the approval gate.
 
@@ -151,7 +151,7 @@ Return to free flow with `ncl policies remove --from <source-agent-id> --to <tar
 
 - **No loop protection.** There is no throttle, hop limit, or cycle detection on agent-to-agent messages — two agents told to "always reply" will ping-pong indefinitely, burning API calls. Give every agent's instructions an explicit stop condition ("report back once, then wait"). A [message policy](#gate-a-connection) on the edge also breaks a runaway loop, since every hop then waits for a human tap.
 - **No broadcast.** Each message targets one destination. Fan-out means one `<message>` block (or `send_message` call) per recipient — the parent orchestrates, the queue doesn't.
-- **No concurrency cap.** `MAX_CONCURRENT_CONTAINERS` (default 5) is parsed at startup but [not enforced anywhere as of v2.1.4](/reference/environment-variables) — a wide team really does run one container per active agent, so size the host accordingly.
+- **No concurrency cap.** There's no environment variable that limits simultaneous agent containers — the old `MAX_CONCURRENT_CONTAINERS` was removed from the code entirely, not just left unenforced. A wide team really does run one container per active agent, so size the host accordingly.
 - **Edits to destinations outside `ncl` don't propagate live.** A running container serves a projection of its destinations, refreshed on every wake and by `ncl destinations add`/`remove` — but direct DB writes leave it stale until the next wake.
 
 ## Cleanup

--- a/operate/configuration.mdx
+++ b/operate/configuration.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Configuration"
 description: "Configure a NanoClaw install — environment variables in .env and the service environment, plus per-group container config in the database."
-keywords: ["configuration", "environment variables", ".env", "container config", "ASSISTANT_NAME", "CONTAINER_TIMEOUT", "LOG_LEVEL", "container_configs"]
+keywords: ["configuration", "environment variables", ".env", "container config", "ASSISTANT_NAME", "LOG_LEVEL", "container_configs"]
 ---
 
-{/* verified-against: src/config.ts, src/env.ts, src/log.ts, src/webhook-server.ts, src/egress-lockdown.ts, src/providers/claude.ts, src/container-config.ts, src/db/container-configs.ts, setup/set-env.ts, setup/service.ts @ cb6e3d1 (v2.1.23) */}
+{/* verified-against: src/config.ts, src/env.ts, src/log.ts, src/webhook-server.ts, src/egress-lockdown.ts, src/host-sweep.ts, src/providers/claude.ts, src/container-config.ts, src/db/container-configs.ts, setup/set-env.ts, setup/service.ts @ 08a1ac9 (v2.1.38) */}
 
 NanoClaw has two configuration layers:
 
@@ -27,6 +27,11 @@ Variables come from two sources, and the distinction matters:
 | `ONECLI_URL` | — | URL of the OneCLI Agent Vault. |
 | `ONECLI_API_KEY` | — | API key for the vault. See [Credentials](/operate/credentials). |
 | `TZ` | system timezone, else `UTC` | IANA timezone for scheduled tasks and message timestamps. Invalid values are skipped, not errored. |
+| `CONTAINER_CPU_LIMIT` | _unset_ (unbounded) | Opt-in CPU cap per container, passed to `docker run --cpus` (e.g. `2`). Can be set in `.env` or the process environment. |
+| `CONTAINER_MEMORY_LIMIT` | _unset_ (unbounded) | Opt-in memory cap per container, passed to `docker run --memory` (e.g. `8g`). Hard cap only on a swapless host. Can be set in `.env` or the process environment. |
+| `NANOCLAW_EGRESS_LOCKDOWN` | `false` | Set `true` to force all agent traffic through the OneCLI gateway on an internal Docker network. Fails fast if the gateway isn't running. Can be set in `.env` or the process environment. See [Hardening](/operate/hardening). |
+| `NANOCLAW_EGRESS_NETWORK` | `nanoclaw-egress` | Name of the locked-down Docker network. Can be set in `.env` or the process environment. |
+| `ONECLI_GATEWAY_CONTAINER` | `onecli` | Name of the gateway container attached as the only egress hop. Can be set in `.env` or the process environment. |
 | `ANTHROPIC_BASE_URL` | — | Custom Anthropic-compatible endpoint for the Claude provider. Only active when setup has configured a custom endpoint; the real auth token stays on the host and is injected by the OneCLI proxy. |
 
 Some channels run in containers and can't see the host's `.env`. For those, setup mirrors `.env` to `data/env/env`, which is mounted into the channel container. Keep the two in sync — the `set-env` setup step handles both:
@@ -45,15 +50,12 @@ These are read from `process.env` at startup. Set them in the service definition
 
 | Variable | Default | What it does |
 |---|---|---|
-| `CONTAINER_TIMEOUT` | `1800000` (30 min) | Max runtime for an agent container, in milliseconds. |
-| `IDLE_TIMEOUT` | `1800000` (30 min) | How long a container stays alive after its last result, waiting for follow-ups. |
-| `MAX_CONCURRENT_CONTAINERS` | `5` | Intended cap on simultaneously running agent containers. Parsed at startup but not enforced anywhere as of v2.1.4 — setting it has no effect. |
-| `CONTAINER_MAX_OUTPUT_SIZE` | `10485760` (10 MB) | Max output captured from a container. |
-| `CONTAINER_CPU_LIMIT` | _unset_ (unbounded) | Opt-in CPU cap per container, passed to `docker run --cpus` (e.g. `2`). |
-| `CONTAINER_MEMORY_LIMIT` | _unset_ (unbounded) | Opt-in memory cap per container, passed to `docker run --memory` (e.g. `8g`). Hard cap only on a swapless host. |
-| `MAX_MESSAGES_PER_PROMPT` | `10` | How many queued messages are batched into a single agent prompt. |
 | `CONTAINER_IMAGE` | per-install tag | Full agent image override (name and tag). |
 | `CONTAINER_IMAGE_BASE` | per-install name | Base image name override. The default includes an install slug so two checkouts on one host don't clobber each other's `nanoclaw-agent` image. |
+
+<Note>
+`CONTAINER_TIMEOUT`, `IDLE_TIMEOUT`, `MAX_CONCURRENT_CONTAINERS`, `CONTAINER_MAX_OUTPUT_SIZE`, and `MAX_MESSAGES_PER_PROMPT` were removed from the code and are no longer read — setting any of them has no effect. Container idle/stuck detection is now handled by the periodic host-sweep loop (`src/host-sweep.ts`), not a per-container timeout env var.
+</Note>
 
 **Network and logging**
 
@@ -61,14 +63,6 @@ These are read from `process.env` at startup. Set them in the service definition
 |---|---|---|
 | `WEBHOOK_PORT` | `3000` | Port for the local webhook server. |
 | `LOG_LEVEL` | `info` | One of `debug`, `info`, `warn`, `error`, `fatal`. |
-
-**Security**
-
-| Variable | Default | What it does |
-|---|---|---|
-| `NANOCLAW_EGRESS_LOCKDOWN` | `false` | Set `true` to force all agent traffic through the OneCLI gateway on an internal Docker network. Fails fast if the gateway isn't running. |
-| `NANOCLAW_EGRESS_NETWORK` | `nanoclaw-egress` | Name of the locked-down Docker network. |
-| `ONECLI_GATEWAY_CONTAINER` | `onecli` | Name of the gateway container attached as the only egress hop. |
 
 See [Hardening](/operate/hardening) for the full egress lockdown and sandboxing story.
 

--- a/operate/hardening.mdx
+++ b/operate/hardening.mdx
@@ -4,7 +4,7 @@ description: "Lock down a NanoClaw install — egress lockdown, the mount allowl
 keywords: ["hardening", "security", "egress lockdown", "NANOCLAW_EGRESS_LOCKDOWN", "mount allowlist", "unknown_sender_policy", "command gate", "container limits"]
 ---
 
-{/* verified-against: src/egress-lockdown.ts, src/modules/mount-security/index.ts, src/modules/permissions/{index.ts,access.ts,sender-approval.ts}, src/command-gate.ts, src/router.ts, src/db/schema.ts, src/config.ts, config-examples/mount-allowlist.json, .claude/skills/manage-mounts/SKILL.md, setup/mounts.ts @ cb6e3d1 (v2.1.23) */}
+{/* verified-against: src/egress-lockdown.ts, src/modules/mount-security/index.ts, src/modules/permissions/{index.ts,access.ts,sender-approval.ts}, src/command-gate.ts, src/router.ts, src/db/schema.ts, src/config.ts, src/host-sweep.ts, config-examples/mount-allowlist.json, .claude/skills/manage-mounts/SKILL.md, setup/mounts.ts @ 08a1ac9 (v2.1.38) */}
 
 NanoClaw's isolation boundary is the Docker container: each agent runs in its own container with a scoped workspace mount (see [Container lifecycle](/concepts/container-lifecycle)). There is no micro-VM or alternative sandbox runtime — hardening means tightening what those containers can reach. This page walks the defense-in-depth controls from network to filesystem to people.
 
@@ -18,7 +18,7 @@ By default, agent containers have normal outbound internet access. Set `NANOCLAW
 
 The setup is idempotent and self-healing — NanoClaw creates the network and re-attaches the gateway on every spawn if needed. It also **fails fast**: if lockdown is enabled but the network can't be created or the gateway container can't be attached, NanoClaw throws an `EgressLockdownError` and refuses to spawn the agent rather than silently running it with open egress. If you see that error, start the gateway container (or set `NANOCLAW_EGRESS_LOCKDOWN=false` to opt out).
 
-All three variables are read from `process.env` only — putting them in `.env` has no effect. Set them in the service definition (launchd plist or systemd unit) as described in [Configuration](/operate/configuration#applying-changes):
+All three variables can be set in `.env` or the process environment (`src/config.ts:56-65`) — `.env` is the simpler path for a plain "edit and restart" flow; the service definition (launchd plist or systemd unit) still works too, as described in [Configuration](/operate/configuration#applying-changes):
 
 ```bash
 # Linux (systemd unit)
@@ -56,7 +56,7 @@ pnpm exec tsx setup/index.ts --step mounts --force -- --json '{"allowedRoots":[{
 ```
 
 <Note>
-The key the validator reads is `allowReadWrite`. A `readOnly` key (shown in some upstream examples) is silently ignored, leaving the mount read-only. Likewise, a top-level `nonMainReadOnly` field may appear in configs written by setup, but the mount validator doesn't read it.
+The validator accepts either key: `allowReadWrite` (native) or `readOnly` (written by the `/manage-mounts` skill and setup). If both are absent it defaults to read-only. `readOnly: true` means read-only, `readOnly: false` means read-write — the validator translates it to `allowReadWrite = !readOnly` and logs a warning when it does (`src/modules/mount-security/index.ts`, `normalizeRoot`). Likewise, a top-level `nonMainReadOnly` field may appear in configs written by setup, but the mount validator doesn't read it.
 </Note>
 
 The allowlist is cached in memory, so restart the service after changes.
@@ -91,16 +91,16 @@ If the permissions module isn't installed (no `user_roles` table), admin command
 
 ## Cap container resources
 
-These limits bound what a runaway agent can consume. All are read from `process.env` only — set them in the service definition, not `.env` (see [Configuration](/operate/configuration#process-environment-only)):
+These limits bound what a runaway agent can consume. Both can be set in `.env` or the process environment (see [Configuration](/operate/configuration#read-from-env)):
 
 | Variable | Default | Limits |
 |---|---|---|
-| `CONTAINER_TIMEOUT` | 30 min | Max runtime for an agent container. |
-| `IDLE_TIMEOUT` | 30 min | How long an idle container survives after its last result. |
 | `CONTAINER_CPU_LIMIT` | _unset_ | CPU cap per container, passed to `docker run --cpus` (e.g. `2`). Opt-in; unset leaves containers unbounded. |
 | `CONTAINER_MEMORY_LIMIT` | _unset_ | Memory cap per container, passed to `docker run --memory` (e.g. `8g`). A hard cap only on a swapless host — there a runaway is OOM-killed; with swap it can spill past the limit. |
-| `CONTAINER_MAX_OUTPUT_SIZE` | 10 MB | Output captured from a container. |
-| `MAX_CONCURRENT_CONTAINERS` | `5` | Intended cap on simultaneous containers — [parsed but not enforced](/reference/environment-variables), so setting it currently has no effect. |
+
+<Note>
+There is no env var for a container-count or output-size cap, and no concurrency-cap env var — `CONTAINER_TIMEOUT`, `IDLE_TIMEOUT`, `CONTAINER_MAX_OUTPUT_SIZE`, and `MAX_CONCURRENT_CONTAINERS` were removed from the code. Idle/stuck containers are now caught by the periodic host-sweep loop (`src/host-sweep.ts`) — see [Container killed mid-task](/operate/troubleshooting#container-killed-mid-task).
+</Note>
 
 ## Credentials
 

--- a/operate/troubleshooting.mdx
+++ b/operate/troubleshooting.mdx
@@ -4,7 +4,7 @@ description: "Diagnose NanoClaw v2 failures: host startup stops, container spawn
 keywords: ["troubleshooting", "debugging", "dropped messages", "container spawn", "upgrade tripwire", "host sweep", "LOG_LEVEL"]
 ---
 
-{/* verified-against: .claude/skills/debug/SKILL.md, src/container-runtime.ts, src/container-runner.ts, src/host-sweep.ts, src/upgrade-state.ts, src/log.ts, src/cli/resources/dropped-messages.ts, src/cli/resources/sessions.ts, src/egress-lockdown.ts, src/modules/mount-security/index.ts, src/webhook-server.ts, src/circuit-breaker.ts, setup/service.ts @ cb6e3d1 (v2.1.23) */}
+{/* verified-against: .claude/skills/debug/SKILL.md, src/container-runtime.ts, src/container-runner.ts, src/host-sweep.ts, src/upgrade-state.ts, src/log.ts, src/cli/resources/dropped-messages.ts, src/cli/resources/sessions.ts, src/egress-lockdown.ts, src/modules/mount-security/index.ts, src/webhook-server.ts, src/circuit-breaker.ts, setup/service.ts @ 08a1ac9 (v2.1.38) */}
 
 ## Start here
 
@@ -113,7 +113,7 @@ grep 'Webhook server started' logs/nanoclaw.log   # shows port + registered adap
 curl -i http://localhost:3000/webhook/slack       # 404 "Unknown adapter" = not registered
 ```
 
-The server listens on `WEBHOOK_PORT` (default `3000`). If another process already holds that port, the listen fails and the host crashes with `FATAL Uncaught exception` — change `WEBHOOK_PORT` in `.env`. Channel-specific failures (tokens, tunnel/public URL, platform-side config) are covered on each channel page: [Slack](/channels/slack), [Teams](/channels/teams), [Channels overview](/channels/overview).
+The server listens on `WEBHOOK_PORT` (default `3000`). If another process already holds that port, the listen fails and the host crashes with `FATAL Uncaught exception` — `WEBHOOK_PORT` is read from the process environment only (`src/webhook-server.ts:113`), so set it in the service definition or your shell, not `.env`, then restart. Channel-specific failures (tokens, tunnel/public URL, platform-side config) are covered on each channel page: [Slack](/channels/slack), [Teams](/channels/teams), [Channels overview](/channels/overview).
 
 ## Credential request stuck
 

--- a/reference/environment-variables.mdx
+++ b/reference/environment-variables.mdx
@@ -2,10 +2,10 @@
 title: "Environment variables"
 description: "Every environment variable NanoClaw reads — .env keys, host process environment, setup-time variables, and container-side overrides — with defaults and source locations."
 tag: "UPDATED"
-keywords: ["environment variables", ".env", "configuration", "ASSISTANT_NAME", "CONTAINER_TIMEOUT", "LOG_LEVEL", "NANOCLAW_SKIP", "NANOCLAW_EGRESS_LOCKDOWN", "setup", "reference"]
+keywords: ["environment variables", ".env", "configuration", "ASSISTANT_NAME", "LOG_LEVEL", "NANOCLAW_SKIP", "NANOCLAW_EGRESS_LOCKDOWN", "setup", "reference"]
 ---
 
-{/* verified-against: src/config.ts, src/env.ts, src/log.ts, src/webhook-server.ts, src/egress-lockdown.ts, src/container-runner.ts, src/providers/claude.ts, setup/auto.ts, setup/onecli.ts, setup/lib/setup-config.ts, setup/lib/claude-assist.ts, setup/lib/diagnostics.ts, setup/signal-auth.ts, setup/container.ts, setup/migrate-v2/select-channels.ts, migrate-v2.sh, container/agent-runner/src/{timezone.ts,providers/claude.ts} @ cb6e3d1 (v2.1.23) */}
+{/* verified-against: src/config.ts, src/env.ts, src/log.ts, src/webhook-server.ts, src/egress-lockdown.ts, src/host-sweep.ts, src/container-runner.ts, src/providers/claude.ts, setup/auto.ts, setup/onecli.ts, setup/lib/setup-config.ts, setup/lib/claude-assist.ts, setup/lib/diagnostics.ts, setup/signal-auth.ts, setup/container.ts, setup/migrate-v2/select-channels.ts, migrate-v2.sh, container/agent-runner/src/{timezone.ts,providers/claude.ts} @ 08a1ac9 (v2.1.38) */}
 
 Exhaustive list of every environment variable the NanoClaw host, setup wizard, and agent runner read. For how to actually set these — `.env` editing, service definitions, restart commands — see [Configuration](/operate/configuration).
 
@@ -13,37 +13,36 @@ Channel adapters (Telegram bot tokens, Slack app credentials, and so on) have th
 
 ## Read from .env
 
-NanoClaw's own parser ([`src/env.ts`](https://github.com/nanocoai/nanoclaw/blob/main/src/env.ts)) reads exactly these keys from `.env` at the project root. Values are never loaded into `process.env`, so they don't leak to child processes. For the first five, a value already in the process environment takes precedence over `.env`; `ANTHROPIC_BASE_URL` is read from `.env` only.
+NanoClaw's own parser ([`src/env.ts`](https://github.com/nanocoai/nanoclaw/blob/main/src/env.ts)) reads exactly these keys from `.env` at the project root. Values are never loaded into `process.env`, so they don't leak to child processes. For the first ten, a value already in the process environment takes precedence over `.env`; `ANTHROPIC_BASE_URL` is read from `.env` only.
 
 | Variable | Default | Read in | Effect |
 |---|---|---|---|
-| `ASSISTANT_NAME` | `Andy` | `src/config.ts:11` | Assistant name. Also sets the default trigger, `@<name>`. |
-| `ASSISTANT_HAS_OWN_NUMBER` | `false` | `src/config.ts:13` | Set `true` when the assistant runs on its own WhatsApp number instead of yours. |
-| `ONECLI_URL` | — | `src/config.ts:36` | URL of the OneCLI Agent Vault. |
-| `ONECLI_API_KEY` | — | `src/config.ts:37` | API key for the vault. See [Credentials](/operate/credentials). |
-| `TZ` | system timezone, else `UTC` | `src/config.ts:62` | IANA timezone for scheduled tasks and timestamps. Invalid values are skipped, not errored. Injected into every agent container at spawn. |
+| `ASSISTANT_NAME` | `Andy` | `src/config.ts:22` | Assistant name. Also sets the default trigger, `@<name>`. |
+| `ASSISTANT_HAS_OWN_NUMBER` | `false` | `src/config.ts:23` | Set `true` when the assistant runs on its own WhatsApp number instead of yours. |
+| `ONECLI_URL` | — | `src/config.ts:51` | URL of the OneCLI Agent Vault. |
+| `ONECLI_API_KEY` | — | `src/config.ts:52` | API key for the vault. See [Credentials](/operate/credentials). |
+| `TZ` | system timezone, else `UTC` | `src/config.ts:70` | IANA timezone for scheduled tasks and timestamps. Invalid values are skipped, not errored. Injected into every agent container at spawn. |
+| `CONTAINER_CPU_LIMIT` | _unset_ (unbounded) | `src/config.ts:56` | Opt-in CPU cap per agent container, passed through to `docker run --cpus` (e.g. `2`). Empty leaves containers unbounded — the current default. Can be set in `.env` or the process environment. |
+| `CONTAINER_MEMORY_LIMIT` | _unset_ (unbounded) | `src/config.ts:57` | Opt-in memory cap per agent container, passed through to `docker run --memory` (e.g. `8g`). A hard cap only on a swapless host — there the runaway is OOM-killed; with swap present the container can spill past it. NanoClaw doesn't manage swap. Can be set in `.env` or the process environment. |
+| `NANOCLAW_EGRESS_LOCKDOWN` | `false` | `src/config.ts:61` | Set `true` to force all agent traffic through the OneCLI gateway on an internal Docker network. Spawns fail fast if the gateway isn't running. Can be set in `.env` or the process environment. See [Hardening](/operate/hardening). |
+| `NANOCLAW_EGRESS_NETWORK` | `nanoclaw-egress` | `src/config.ts:62` | Name of the locked-down Docker network. Can be set in `.env` or the process environment. |
+| `ONECLI_GATEWAY_CONTAINER` | `onecli` | `src/config.ts:64` | Name of the gateway container attached as the only egress hop. Can be set in `.env` or the process environment. |
 | `ANTHROPIC_BASE_URL` | — | `src/providers/claude.ts:21` | Custom Anthropic-compatible endpoint, passed into agent containers with a placeholder auth token. Only active when setup has registered the custom-endpoint provider config; the real token stays in the vault. |
 
 ## Host process environment only
 
-Read from `process.env` at host startup. Putting these in `.env` has no effect — the generated launchd plist, systemd unit, and nohup wrapper don't source it. Set them in the service definition or export them before `pnpm run dev`.
+Read from `process.env` at host startup, with no `.env` fallback. Putting these in `.env` has no effect — the generated launchd plist, systemd unit, and nohup wrapper don't source it. Set them in the service definition or export them before `pnpm run dev`.
 
 | Variable | Default | Read in | Effect |
 |---|---|---|---|
-| `CONTAINER_TIMEOUT` | `1800000` (30 min) | `src/config.ts:34` | Max runtime for an agent container, in milliseconds. |
-| `CONTAINER_MAX_OUTPUT_SIZE` | `10485760` (10 MB) | `src/config.ts:35` | Max output captured from a container, in bytes. |
-| `CONTAINER_CPU_LIMIT` | _unset_ (unbounded) | `src/config.ts:44` | Opt-in CPU cap per agent container, passed through to `docker run --cpus` (e.g. `2`). Empty leaves containers unbounded — the current default. |
-| `CONTAINER_MEMORY_LIMIT` | _unset_ (unbounded) | `src/config.ts:45` | Opt-in memory cap per agent container, passed through to `docker run --memory` (e.g. `8g`). A hard cap only on a swapless host — there the runaway is OOM-killed; with swap present the container can spill past it. NanoClaw doesn't manage swap. |
-| `MAX_MESSAGES_PER_PROMPT` | `10` | `src/config.ts:38` | How many queued messages are batched into one agent prompt. Per-group override exists in container config. |
-| `IDLE_TIMEOUT` | `1800000` (30 min) | `src/config.ts:39` | How long a container stays alive after its last result, waiting for follow-ups. |
-| `MAX_CONCURRENT_CONTAINERS` | `5` | `src/config.ts:40` | Intended cap on simultaneous agent containers. Parsed but not enforced anywhere as of v2.1.4 — setting it has no effect. |
-| `CONTAINER_IMAGE` | per-install tag | `src/config.ts:29` | Full agent image override (name and tag). |
-| `CONTAINER_IMAGE_BASE` | per-install name | `src/config.ts:28` | Base image name override. The default embeds an install slug so two checkouts on one host don't clobber each other's image. |
-| `WEBHOOK_PORT` | `3000` | `src/webhook-server.ts:82` | Port for the local webhook server. |
+| `CONTAINER_IMAGE` | per-install tag | `src/config.ts:46` | Full agent image override (name and tag). |
+| `CONTAINER_IMAGE_BASE` | per-install name | `src/config.ts:45` | Base image name override. The default embeds an install slug so two checkouts on one host don't clobber each other's image. |
+| `WEBHOOK_PORT` | `3000` | `src/webhook-server.ts:113` | Port for the local webhook server. |
 | `LOG_LEVEL` | `info` | `src/log.ts:16` | One of `debug`, `info`, `warn`, `error`, `fatal`. |
-| `NANOCLAW_EGRESS_LOCKDOWN` | `false` | `src/egress-lockdown.ts:20` | Set `true` to force all agent traffic through the OneCLI gateway on an internal Docker network. Spawns fail fast if the gateway isn't running. See [Hardening](/operate/hardening). |
-| `NANOCLAW_EGRESS_NETWORK` | `nanoclaw-egress` | `src/egress-lockdown.ts:16` | Name of the locked-down Docker network. |
-| `ONECLI_GATEWAY_CONTAINER` | `onecli` | `src/egress-lockdown.ts:18` | Name of the gateway container attached as the only egress hop. |
+
+<Note>
+`CONTAINER_TIMEOUT`, `IDLE_TIMEOUT`, `MAX_CONCURRENT_CONTAINERS`, `CONTAINER_MAX_OUTPUT_SIZE`, and `MAX_MESSAGES_PER_PROMPT` were removed from the code and are no longer read anywhere (host or container). Container idle/stuck detection is now handled by the periodic host-sweep loop (`src/host-sweep.ts`), not a per-container timeout env var. Setting any of these five in `.env` or the process environment has no effect.
+</Note>
 
 ## Setup-time variables
 

--- a/reference/skills-catalog.mdx
+++ b/reference/skills-catalog.mdx
@@ -4,11 +4,11 @@ description: "Every skill that ships with NanoClaw — host-side workspace skill
 keywords: ["skills", "catalog", "reference", "add-channel", "providers", "tools", "container skills", "workspace skills", "slash commands"]
 ---
 
-{/* verified-against: .claude/skills/ and container/skills/ listings + each skill's SKILL.md frontmatter @ cb6e3d1 (v2.1.23) */}
+{/* verified-against: .claude/skills/ and container/skills/ listings + each skill's SKILL.md frontmatter @ 08a1ac9 (v2.1.38) */}
 
 NanoClaw ships two kinds of skills:
 
-- **Host-side workspace skills** (`.claude/skills/`) — invoked as slash commands in Claude Code from your NanoClaw checkout. They install channels, providers, and tools, or operate and maintain your install. 47 skills total: 17 channel installs, 3 provider installs, 10 tool installs, and 17 operational skills.
+- **Host-side workspace skills** (`.claude/skills/`) — invoked as slash commands in Claude Code from your NanoClaw checkout. They install channels, providers, and tools, or operate and maintain your install. 48 skills total: 17 channel installs, 3 provider installs, 11 tool installs, and 17 operational skills.
 - **Container skills** (`container/skills/`) — 8 skills mounted into every agent container at `/app/skills`. The agent loads them at runtime; you don't invoke them yourself.
 
 For how skills work and how to write your own, see [Extending NanoClaw](/extend/overview).
@@ -54,6 +54,7 @@ Each skill adds a capability or MCP tool to your agents. See [Tools](/extend/too
 | Skill | What it does |
 | --- | --- |
 | `/add-atomic-chat-tool` | Adds the Atomic Chat MCP server so agents can call local models served by the Atomic Chat desktop app via its OpenAI-compatible API |
+| `/add-clidash` | Adds clidash — a zero-dependency, read-only web dashboard that derives its tabs and tables at runtime from any CLI that lists resources as JSON, pre-wired for NanoClaw's `ncl` CLI |
 | `/add-dashboard` | Adds a monitoring dashboard — installs `@nanoco/nanoclaw-dashboard` and a pusher that sends periodic JSON snapshots |
 | `/add-gcal-tool` | Adds Google Calendar as an MCP tool (list calendars, list/search/create events, free/busy) using OneCLI-managed OAuth — no raw credentials reach the container |
 | `/add-gmail-tool` | Adds Gmail as an MCP tool (read, search, send, label, draft) using OneCLI-managed OAuth — tokens injected at request time |


### PR DESCRIPTION
Code-grounded staleness sweep of the portal against nanocoai/nanoclaw upstream/main @ 08a1ac9 (v2.1.38; docs were stamped v2.1.23, ~15 releases behind). Six pages fixed, two systemic root causes:

**Root cause A — `.env` support added upstream.** `config.ts` now falls back to `.env` (envConfig) for `CONTAINER_CPU_LIMIT`, `CONTAINER_MEMORY_LIMIT`, and the 3 egress vars; docs still said these were process.env-only. Fixed in environment-variables, configuration, hardening, troubleshooting. (`WEBHOOK_PORT` remains process.env-only — kept as documented.)

**Root cause B — 5 env vars removed upstream** (host-sweep replaced the old timeout machinery): `CONTAINER_TIMEOUT`, `IDLE_TIMEOUT`, `MAX_CONCURRENT_CONTAINERS`, `CONTAINER_MAX_OUTPUT_SIZE`, `MAX_MESSAGES_PER_PROMPT`. Removed from environment-variables, configuration, hardening, multi-agent-swarm.

**Standalone fixes:**
- `operate/hardening.mdx:59` — security-inverting: doc said the `readOnly` mount key is silently ignored (mount stays read-only); code now honors it (`mount-security/index.ts`, `allowReadWrite = !readOnly`), so `{readOnly: false}` grants RW. Doc understated permissiveness.
- skills-catalog: 47 → 48 (`/add-clidash` added).

`verified-against` bumped to 08a1ac9. Re-verified against fresh upstream HEAD on 2026-07-04 immediately before this PR — HEAD still 08a1ac9, all claims hold.

Also adds the **v2.1.38 drift sweep** entry to `changelog/docs-updates.mdx`, following the sweep-changelog convention.

Known leftover (not fixed here): `environment-variables.mdx` closing note still references v2.1.4 line numbers.

_Assisted by Claude; reviewed and verified by a human before submission._
